### PR TITLE
Skill tabanlı geliştirme: Cursor skills ve kritik düzeltmeler

### DIFF
--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -1,0 +1,56 @@
+# RustHound Cursor Skills
+
+Skills teach the Cursor agent *how* to work on this repo. They load from `.cursor/skills/` automatically.
+
+## Project-specific (maintained here)
+
+| Skill | Use when |
+|-------|----------|
+| [rusthound-architecture](rusthound-architecture/SKILL.md) | Changing modules, follow mode, `ScanState`, data flow |
+| [rusthound-rules-toml](rusthound-rules-toml/SKILL.md) | Editing `rules.toml` or correlation config |
+| [rusthound-dev-workflow](rusthound-dev-workflow/SKILL.md) | Before commit: build, test, clippy, smoke tests |
+| [rusthound-cargo-tail](rusthound-cargo-tail/SKILL.md) | Watching `cargo build` / `cargo test` / `rusthound --follow` output |
+
+## Rust language (from [ZhangHanDong/rust-skills](https://github.com/ZhangHanDong/rust-skills))
+
+| Skill | Use when |
+|-------|----------|
+| rust-m01-ownership | Borrowing, lifetimes, ownership errors |
+| rust-m06-error-handling | `anyhow`, `Result`, error design |
+| rust-m07-concurrency | Tokio, async, `Send`/`Sync` |
+| rust-domain-cli | Clap, exit codes, CLI UX |
+| rust-router | Routing to the right Rust sub-skill |
+
+## Rust rules bundle
+
+| Skill | Source |
+|-------|--------|
+| rust-skills-leonardomso | [leonardomso/rust-skills](https://github.com/leonardomso/rust-skills) |
+
+## Agent workflow (from [bluriesophos/cursorskills](https://github.com/bluriesophos/cursorskills))
+
+| Skill | Use when |
+|-------|----------|
+| prove-it | Task complete — run tests and verify output |
+| debug-to-fix | Structured debugging |
+| trace-it | Before changing shared modules |
+| loose-ends | Before PR — TODOs, missing tests |
+| safe-refactor | Refactors without behavior change |
+
+## DevOps / monitoring (from [awesome-cursor-skills](https://github.com/spencerpauly/awesome-cursor-skills))
+
+| Skill | Use when |
+|-------|----------|
+| monitoring-terminal-errors | Process crashes, stack traces in terminals |
+| tailing-build-output | Stream build output (see also rusthound-cargo-tail) |
+| setting-up-ci | GitHub Actions for Rust |
+| parallel-ci-triage | Multiple failing CI jobs |
+| incident-response | Production incident workflow |
+
+## Refresh third-party skills
+
+```bash
+./scripts/install-cursor-skills.sh
+```
+
+Each vendored skill includes `UPSTREAM.md` with the exact commit. Cache clones live in `.cursor/skills-cache/` (gitignored).

--- a/.cursor/skills/SOURCES.md
+++ b/.cursor/skills/SOURCES.md
@@ -1,0 +1,12 @@
+# Third-party skill sources
+
+Installed via `scripts/install-cursor-skills.sh`. Each folder contains `UPSTREAM.md` with the pinned commit.
+
+| Source | License | Skills |
+|--------|---------|--------|
+| [ZhangHanDong/rust-skills](https://github.com/ZhangHanDong/rust-skills) | See upstream | `rust-m01-ownership`, `rust-m06-error-handling`, `rust-m07-concurrency`, `rust-domain-cli`, `rust-router` |
+| [leonardomso/rust-skills](https://github.com/leonardomso/rust-skills) | MIT | `rust-skills-leonardomso` |
+| [bluriesophos/cursorskills](https://github.com/bluriesophos/cursorskills) | MIT | `prove-it`, `debug-to-fix`, `trace-it`, `loose-ends`, `safe-refactor` |
+| [spencerpauly/awesome-cursor-skills](https://github.com/spencerpauly/awesome-cursor-skills) | See upstream | `monitoring-terminal-errors`, `tailing-build-output`, `setting-up-ci`, `parallel-ci-triage`, `incident-response` |
+
+Project-authored: `rusthound-*`, `rusthound-cargo-tail`.

--- a/.cursor/skills/debug-to-fix/SKILL.md
+++ b/.cursor/skills/debug-to-fix/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: debug-to-fix
+description: When debugging frustration appears ("why isn't this working?", "it should work", "I don't understand"), orchestrate the full debug cycle - clarify, investigate, fix, verify. Prevents jumping to fixes before understanding the problem. Use when the user is stuck on a bug or expressing debugging frustration.
+---
+
+# Debug to Fix
+
+## Purpose
+
+An elixir for debugging. The #1 debugging mistake: jumping to fixes before
+understanding the problem. This chains clarification, investigation, fix, and
+verification, with gates that prevent skipping steps. Uses rubber-duck to clarify,
+built-in investigation phase, and prove-it to verify.
+
+## Prerequisites
+
+This skill works best with these skills installed:
+
+| Skill | Purpose | If Missing |
+|-------|---------|------------|
+| rubber-duck | Structured problem clarification | Falls back to built-in questions |
+| prove-it | Verification enforcement | Falls back to built-in verification |
+| retrospective | Document learnings | Skipped (optional phase) |
+
+The skill degrades gracefully - it will use built-in fallbacks for missing skills.
+
+## When To Activate
+
+- "Why isn't this working?"
+- "It should work but..."
+- "I don't understand why..."
+- "This doesn't make sense"
+- User expresses debugging frustration
+- Bug that persists after initial fix attempts
+- User has been stuck on same issue for multiple messages
+
+## Instructions
+
+### Phase 1: Clarify
+
+**If rubber-duck skill installed:** Invoke it now.
+
+**If not installed, ask:**
+
+Before we debug, let me understand the problem:
+
+1. **Expected:** What should happen?
+2. **Actual:** What actually happens?
+3. **Tried:** What have you already attempted?
+4. **Changed:** What changed before this broke?
+
+**GATE:** Do not proceed until you can state the problem in one sentence:
+"When I [action], I expect [expected], but instead [actual]."
+
+Write this sentence before continuing.
+
+### Phase 2: Investigate
+
+**Objective:** Find the root cause, not just symptoms.
+
+**Investigation checklist:**
+
+1. **Reproduce:** Can you trigger the bug reliably?
+   - [ ] Yes, every time
+   - [ ] Sometimes (note conditions)
+   - [ ] Haven't tried yet - Try now
+
+2. **Isolate:** Where does the bug live?
+   - [ ] Identified the file(s)
+   - [ ] Identified the function(s)
+   - [ ] Narrowed to specific lines
+
+3. **Understand:** Why does it fail?
+   - [ ] Read the actual error (not just the message)
+   - [ ] Checked the data/state at failure point
+   - [ ] Understood the expected flow vs actual flow
+
+**Investigation techniques (try in order):**
+
+```
+1. Read the error message completely - what does it actually say?
+2. Add logging/print at the failure point - what are the actual values?
+3. Trace backwards - where do the bad values come from?
+4. Check recent changes - git diff, git log
+5. Rubber duck the code flow aloud
+```
+
+**GATE:** Do not proceed until you can answer:
+- "The bug happens because [specific cause]"
+- "I know this because [evidence]"
+
+Write both sentences before continuing.
+
+### Phase 3: Fix
+
+**Now** implement the fix.
+
+Before writing code, state:
+1. **What** you're changing
+2. **Why** this fixes the root cause (not just symptoms)
+3. **Risk** of this change breaking something else
+
+Implement the minimal fix. Resist the urge to refactor nearby code.
+
+### Phase 4: Verify
+
+**If prove-it skill installed:** Invoke it now.
+
+**If not installed:**
+
+Verification checklist:
+- [ ] Original bug no longer reproduces
+- [ ] Tested the exact scenario from Phase 1
+- [ ] Checked for regressions in related functionality
+- [ ] Tests pass (if applicable)
+
+**GATE:** Do not declare victory until verification complete.
+
+Show the evidence:
+```
+VERIFIED:
+- [What you tested]
+- [What you observed]
+- [Why this confirms the fix]
+```
+
+### Phase 5: Document (Optional)
+
+**If retrospective skill installed:** Invoke it for significant bugs.
+
+**If not installed or bug was minor:** Skip this phase.
+
+For significant debugging sessions (>15 min), capture:
+- What the bug was
+- Why it was hard to find
+- What you'd do differently
+
+## Output Format
+
+```markdown
+## Debug Session: [Brief description]
+
+### Problem Statement
+When I [action], I expect [expected], but instead [actual].
+
+### Root Cause
+The bug happens because [cause].
+Evidence: [how you know]
+
+### Fix
+[What you changed and why]
+
+### Verification
+- [x] Original bug fixed
+- [x] [Other checks performed]
+
+### Learnings (if significant)
+[What you'd do differently]
+```
+
+## NEVER
+
+- Jump to fixes before completing Phase 1 (clarify)
+- Guess at root cause without evidence (Phase 2)
+- Declare "fixed" without verification (Phase 4)
+- Skip gates because "I already know the answer"
+- Refactor unrelated code while fixing a bug
+
+## ALWAYS
+
+- Write the problem statement sentence before investigating
+- State root cause with evidence before fixing
+- Verify the exact original scenario after fixing
+- Keep fixes minimal and focused
+
+## Example
+
+**User:** "The login is broken, I don't know why"
+
+**Phase 1 - Clarify:**
+> Before we debug, help me understand:
+> 1. What should happen when you log in?
+> 2. What actually happens?
+> 3. What have you tried?
+> 4. Did anything change recently?
+>
+> *[User answers]*
+>
+> Problem statement: "When I submit the login form, I expect to be redirected to /dashboard, but instead I see a blank page with no errors."
+
+**Phase 2 - Investigate:**
+> Let me investigate...
+> - Checked network tab: POST /api/login returns 200
+> - Checked console: No errors
+> - Checked redirect logic: `router.push('/dashboard')` is called
+> - Added logging: redirect fires but page doesn't change
+> - Checked recent commits: Found change to middleware yesterday
+>
+> Root cause: "The bug happens because new auth middleware redirects /dashboard back to /login for users without 'verified' flag, creating a loop that results in blank page."
+> Evidence: "Middleware logs show redirect loop, user object missing 'verified' field."
+
+**Phase 3 - Fix:**
+> Fixing: Add 'verified: true' to user object after successful login
+> Why: Root cause is missing field, not redirect logic
+> Risk: Low - only affects login success path
+
+**Phase 4 - Verify:**
+> VERIFIED:
+> - Logged in with test user, redirected to /dashboard
+> - No redirect loop in network tab
+> - Middleware logs show single redirect
+> - Existing tests pass

--- a/.cursor/skills/debug-to-fix/UPSTREAM.md
+++ b/.cursor/skills/debug-to-fix/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/bluriesophos/cursorskills
+- Path: `debug-to-fix`
+- Commit: `0ebd86c11e02f32d7fc90a4b3b0f5609b0262069`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/incident-response/SKILL.md
+++ b/.cursor/skills/incident-response/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: incident-response
+description: Handle production incidents — triage, mitigate, communicate, and write postmortems.
+user-invocable: true
+---
+
+# Incident Response
+
+Handle production incidents systematically.
+
+## Severity Levels
+
+| Level | Definition | Response Time | Examples |
+|-------|-----------|---------------|----------|
+| SEV1 | Service down, all users affected | Immediate | Database crash, DNS failure, auth broken |
+| SEV2 | Major feature broken, many users affected | < 30 min | Payments failing, search not working |
+| SEV3 | Minor feature broken, workaround exists | < 4 hours | Export button broken, slow dashboard |
+| SEV4 | Cosmetic or low-impact issue | Next business day | Typo in UI, minor styling bug |
+
+## Incident Workflow
+
+### 1. Detect & Triage (first 5 minutes)
+
+- Acknowledge the incident — "I'm looking into this"
+- Determine severity level
+- Check monitoring dashboards (error rates, latency, status page)
+- Check recent deployments: `git log --oneline -10` — was anything deployed recently?
+
+### 2. Mitigate (next 15-30 minutes)
+
+**The goal is to stop the bleeding, not find the root cause.**
+
+Quick mitigations:
+- **Rollback**: `git revert <commit> && deploy` — fastest option if a deploy caused it
+- **Feature flag**: Disable the broken feature
+- **Scale up**: Add more instances if it's a capacity issue
+- **Failover**: Switch to backup/secondary if primary is down
+- **Block traffic**: Rate-limit or block specific abusive traffic
+
+### 3. Communicate
+
+**Internal:**
+- Open an incident channel (`#incident-2026-04-10`)
+- Post status updates every 15-30 minutes
+- Assign roles: Incident Commander, Communicator, Engineers
+
+**External:**
+- Update status page
+- Send email/notification to affected users if the outage is extended
+- Be honest: "We're experiencing issues with X. We've identified the cause and are working on a fix."
+
+### 4. Resolve
+
+- Deploy the fix
+- Verify the fix works in production (check metrics, not just absence of errors)
+- Close the incident channel with a summary
+
+### 5. Postmortem (within 48 hours)
+
+Write a blameless postmortem:
+
+```markdown
+# Incident: Payments failing for Stripe webhook
+**Date:** 2026-04-10
+**Duration:** 45 minutes (14:30 — 15:15 UTC)
+**Severity:** SEV2
+**Impact:** ~200 users unable to complete purchases
+
+## Timeline
+- 14:30 — Alert fires: payment success rate drops to 20%
+- 14:35 — On-call engineer acknowledges, begins investigation
+- 14:40 — Identified: Stripe webhook endpoint returning 500
+- 14:45 — Root cause: migration added NOT NULL column without default
+- 14:50 — Fix deployed: added default value to migration
+- 15:00 — Payment success rate recovering
+- 15:15 — Metrics back to normal, incident closed
+
+## Root Cause
+Database migration #47 added a `currency` column with NOT NULL 
+but no DEFAULT value. Existing rows were fine (backfilled), but 
+new webhook events failed because the insert didn't include `currency`.
+
+## What Went Well
+- Alert fired within 5 minutes of the issue starting
+- Rollback was considered but the fix was faster
+
+## What Went Wrong
+- Migration wasn't tested with live webhook payloads
+- No staging test for the webhook flow
+
+## Action Items
+- [ ] Add webhook integration test to CI (@alice, due 2026-04-17)
+- [ ] Require DEFAULT for all new NOT NULL columns in migration review (@bob)
+- [ ] Add runbook for payment failures (@charlie, due 2026-04-14)
+```
+
+## Tips
+
+- Rollback first, investigate later — speed matters more than elegance
+- The most recent deploy is the most likely cause
+- Don't assign blame in postmortems — focus on process improvements
+- Maintain a runbook for common failure modes
+- Practice incident response with game days before real incidents happen

--- a/.cursor/skills/incident-response/UPSTREAM.md
+++ b/.cursor/skills/incident-response/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/spencerpauly/awesome-cursor-skills
+- Path: `resources/incident-response`
+- Commit: `773b571db3693d2edc1cf656903c292d037e25b8`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/loose-ends/SKILL.md
+++ b/.cursor/skills/loose-ends/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: loose-ends
+description: Before declaring work complete, checks for loose ends - unused imports, TODO comments created, missing tests, stale references, incomplete error handling. Use when finishing features, fixing bugs, or before committing changes. The cleanup that always gets skipped.
+---
+
+# Loose Ends
+
+## Purpose
+
+Implementation feels done, but loose ends remain. The import you added but didn't
+use. The TODO you wrote and forgot. The test you meant to add. The console.log
+you left in. This skill forces a sweep before declaring victory.
+
+## When To Activate
+
+- About to say "done" or "complete"
+- Finishing a feature implementation
+- After fixing a bug
+- Before committing changes
+- After any multi-file change
+- User asks "is it ready?"
+
+## Instructions
+
+### The Loose Ends Checklist
+
+Before declaring complete, run through:
+
+## Loose Ends Sweep
+
+### Code Hygiene
+- [ ] No unused imports
+- [ ] No unused variables
+- [ ] No commented-out code (unless intentional)
+- [ ] No console.log/print statements left in
+- [ ] No debugger statements
+
+### TODOs and FIXMEs
+- [ ] No new TODOs created and forgotten
+- [ ] Any existing TODOs in touched files addressed or noted
+
+### Tests
+- [ ] New code has tests (or explicit reason why not)
+- [ ] Existing tests still pass
+- [ ] Edge cases considered
+
+### Types (if applicable)
+- [ ] No `any` types added
+- [ ] No type assertions without reason
+- [ ] Interfaces/types defined for new structures
+
+### References
+- [ ] Old references updated if things were renamed
+- [ ] No broken imports
+- [ ] No stale comments referring to old code
+
+### Error Handling
+- [ ] Errors handled or explicitly bubbled up
+- [ ] User-facing errors have good messages
+- [ ] No silent failures
+
+### Automated Sweep
+
+Run the sweep script to find common cruft:
+
+```bash
+python scripts/sweep.py
+```
+
+Scans for:
+- `console.log`, `print()`, `debugger` statements
+- `TODO`, `FIXME`, `XXX`, `HACK` comments
+- `dd()`, `var_dump()`, `binding.pry` (PHP/Ruby)
+
+### Quick Scan Commands
+
+```bash
+# Find TODOs in changed files
+git diff --name-only | xargs grep -n "TODO\|FIXME"
+
+# Find console.log in changed files
+git diff --name-only | xargs grep -n "console.log"
+
+# Find unused imports (TypeScript)
+npx tsc --noEmit 2>&1 | grep "declared but"
+
+# Find any types added
+git diff | grep ": any"
+```
+
+### Prioritize by Impact
+
+Not all loose ends are equal:
+
+| Priority | Type | Action |
+|----------|------|--------|
+| **Fix now** | Broken imports, missing exports | Blocks functionality |
+| **Fix now** | console.log in production code | Leaks info |
+| **Should fix** | Unused imports/variables | Code smell |
+| **Should fix** | Missing tests for new logic | Technical debt |
+| **Note for later** | Old TODOs in touched files | Existing debt |
+| **Ignore** | Style inconsistencies | Not your scope |
+
+## Output Format
+
+```markdown
+## Loose Ends Check
+
+**Files changed:** [count]
+
+**Fixed:**
+- [x] Removed unused import in `file.ts`
+- [x] Removed console.log in `handler.ts`
+
+**Noted:**
+- [ ] `utils.ts:45` has existing TODO (not from this change)
+
+**Clean:** No loose ends found / All addressed
+```
+
+## NEVER
+
+- Declare "done" without scanning for loose ends
+- Leave console.log in production code
+- Create TODOs and forget about them
+- Leave unused imports from experimentation
+- Skip the checklist because "it's a small change"
+
+## ALWAYS
+
+- Scan changed files before committing
+- Remove debugging artifacts
+- Address or document any TODOs you create
+- Verify imports are used
+- Check that tests pass after changes
+
+## Example
+
+**After implementing a new API endpoint:**
+
+```markdown
+## Loose Ends Check
+
+**Files changed:** 4
+
+**Scanning...**
+
+`api/users.ts`:
+- Line 3: unused import `lodash` - Removed
+- Line 45: console.log for debugging - Removed
+
+`types/user.ts`:
+- Clean
+
+`tests/users.test.ts`:
+- New endpoint has test - Good
+- Edge case (empty input) not tested - Added
+
+`services/user.ts`:
+- Line 23: TODO I wrote: "validate email format" - Addressed now
+
+**Result:** 4 loose ends found and fixed. Ready to commit.
+```

--- a/.cursor/skills/loose-ends/UPSTREAM.md
+++ b/.cursor/skills/loose-ends/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/bluriesophos/cursorskills
+- Path: `loose-ends`
+- Commit: `0ebd86c11e02f32d7fc90a4b3b0f5609b0262069`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/loose-ends/scripts/sweep.py
+++ b/.cursor/skills/loose-ends/scripts/sweep.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Sweep script for loose-ends skill.
+Scans codebase for common cruft that should be cleaned up before declaring done.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_grep(pattern: str, file_types: list[str], label: str) -> list[str]:
+    """Run ripgrep and return matches."""
+    results = []
+
+    for ft in file_types:
+        try:
+            cmd = ["rg", "-n", "--type", ft, pattern, "."]
+            output = subprocess.run(cmd, capture_output=True, text=True, cwd=Path.cwd())
+            if output.stdout.strip():
+                results.extend(output.stdout.strip().split("\n"))
+        except FileNotFoundError:
+            # Fall back to grep if rg not available
+            pass
+
+    return results
+
+
+def main():
+    findings = {}
+
+    # Debug statements
+    debug_patterns = [
+        ("console\\.log\\(", ["js", "ts", "tsx"], "console.log"),
+        ("print\\(", ["py"], "print()"),
+        ("debugger", ["js", "ts", "tsx"], "debugger"),
+        ("binding\\.pry", ["ruby"], "binding.pry"),
+        ("dd\\(", ["php"], "dd()"),
+        ("var_dump\\(", ["php"], "var_dump()"),
+    ]
+
+    for pattern, types, label in debug_patterns:
+        matches = run_grep(pattern, types, label)
+        if matches:
+            findings[f"Debug: {label}"] = matches[:10]  # Limit to 10
+
+    # TODO/FIXME comments
+    todo_matches = run_grep("(TODO|FIXME|XXX|HACK):", ["js", "ts", "py", "tsx", "jsx", "rb", "go", "rs"], "TODOs")
+    if todo_matches:
+        findings["TODO/FIXME comments"] = todo_matches[:10]
+
+    # Commented-out code (rough heuristic: // followed by code-like patterns)
+    # This is imprecise but catches obvious cases
+
+    # Output results
+    if not findings:
+        print("✓ No loose ends found - looking clean!")
+        return 0
+
+    print("⚠ Loose ends found:\n")
+
+    for category, matches in findings.items():
+        print(f"### {category}")
+        for match in matches:
+            print(f"  {match}")
+        if len(matches) == 10:
+            print("  ... (showing first 10)")
+        print()
+
+    total = sum(len(m) for m in findings.values())
+    print(f"Total: {total} items to review")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.cursor/skills/monitoring-terminal-errors/SKILL.md
+++ b/.cursor/skills/monitoring-terminal-errors/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: monitoring-terminal-errors
+description: Watch running terminal processes for crashes and stack traces. When an error appears, navigate to the failing file and line, diagnose, and fix it automatically.
+user-invocable: true
+---
+
+# Monitoring Terminal Errors
+
+Continuously watch a running process (dev server, test runner, build) for errors and fix them as they appear.
+
+## Workflow
+
+### 1. Identify the Terminal
+
+List terminal files and find the one running the target process:
+
+```bash
+head -n 10 <terminals_folder>/*.txt
+```
+
+Look for terminals running dev servers (`npm run dev`, `pnpm dev`, `python manage.py runserver`, etc.).
+
+### 2. Read Terminal Output
+
+Read the full terminal file content. Search for error patterns:
+
+- **Stack traces**: `at <function> (<file>:<line>:<col>)`
+- **Node.js**: `Error:`, `TypeError:`, `ReferenceError:`, `ENOENT`, `ECONNREFUSED`
+- **Python**: `Traceback (most recent call last):` followed by `File "<path>", line <n>`
+- **React/Next.js**: `Unhandled Runtime Error`, `Error: ...`, `Module not found`
+- **Build errors**: `ERROR in`, `Failed to compile`, `SyntaxError`
+- **Vite**: `[vite] Internal server error:`
+- **TypeScript**: `error TS\d+:`
+
+### 3. Extract the Source Location
+
+From the stack trace, extract:
+- File path
+- Line number
+- Error message
+
+For Node.js: `at functionName (/path/to/file.ts:42:10)`
+For Python: `File "/path/to/file.py", line 42, in function_name`
+
+### 4. Navigate and Fix
+
+1. Read the identified file around the error line
+2. Understand the error (missing import, type mismatch, undefined variable, etc.)
+3. Apply the fix
+4. Re-read the terminal file to confirm the server recovered (hot reload should pick it up)
+
+### 5. Loop
+
+If the server is still showing errors after the fix, repeat from step 2. Stop when:
+- The terminal shows a clean "compiled successfully" or equivalent
+- No new errors appear in the output
+- You've made 5 attempts without resolution (report to user)
+
+## Tips
+
+- Check for `exit_code` in the terminal file footer — if present, the process has crashed entirely and needs a restart
+- Some errors cascade — fix the first/root error and the rest often disappear
+- For HMR errors, the fix might just be saving the file again to trigger a rebuild

--- a/.cursor/skills/monitoring-terminal-errors/UPSTREAM.md
+++ b/.cursor/skills/monitoring-terminal-errors/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/spencerpauly/awesome-cursor-skills
+- Path: `resources/monitoring-terminal-errors`
+- Commit: `773b571db3693d2edc1cf656903c292d037e25b8`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/parallel-ci-triage/SKILL.md
+++ b/.cursor/skills/parallel-ci-triage/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: parallel-ci-triage
+description: When GitHub Actions fails, fetch failing job logs and assign each failing job to a separate subagent that fixes its slice of the problem in parallel. Use for multi-job CI failures where jobs are independent.
+user-invocable: true
+---
+
+# Parallel CI Triage
+
+Speed up fixing broken CI by splitting failing **jobs** (or independent failure clusters) across parallel subagents. Each subagent owns one vertical slice: logs, root cause, code fix, and local verification for that slice.
+
+## Prerequisites
+
+- **GitHub CLI** (`gh`) installed and authenticated (`gh auth login`), or use the GitHub web UI / API to copy logs manually.
+- Push access to the repo so fixes can be pushed and CI re-run.
+
+## Workflow
+
+### 1. Identify the failing run
+
+From the repo root:
+
+```bash
+gh run list --limit 5
+gh run view <RUN_ID> --log-failed
+```
+
+Or open the Actions tab, open the failed workflow run, and note which **jobs** failed (not just which step — group by job name).
+
+If `gh` is unavailable, download logs from the GitHub UI and paste them into the conversation.
+
+### 2. Split by job (or by failure cluster)
+
+- **One subagent per failed job** when jobs test different things (e.g. `lint`, `test-node-18`, `e2e`).
+- **One subagent per independent failure cluster** when a single job logs multiple unrelated errors — but prefer one job per agent to avoid conflicting edits in the same files.
+
+If two failures share the same root cause in the same file, assign **one** subagent to fix both.
+
+### 3. Launch parallel subagents
+
+For each failing job, launch a `generalPurpose` subagent in a **single message** so they run concurrently:
+
+```
+Task: Fix CI failure for job "<JOB_NAME>"
+
+Context:
+- Workflow run: <RUN_URL or RUN_ID>
+- Branch: <branch>
+- Relevant log excerpt (failed steps only):
+<paste gh run view --job <JOB_ID> --log or the failed section>
+
+Instructions:
+1. Infer the root cause from the log (command, stack trace, file:line).
+2. Open and edit only what this job requires.
+3. Run the same commands locally that failed in CI (or the narrowest equivalent, e.g. `npm run lint`, `pytest tests/foo`, `pnpm test --filter pkg`).
+4. Report: what failed, what you changed, and confirmation that the local command passes.
+```
+
+Include the **exact** failing command and error lines so the subagent does not guess.
+
+### 4. Merge and verify
+
+- Collect each subagent’s changed files. Resolve overlaps manually if two agents touched the same file.
+- Run the full CI-equivalent locally when possible:
+
+  ```bash
+  # Example: match your repo
+  npm run lint && npm test
+  ```
+
+- Commit with a conventional message, push, and re-check the workflow:
+
+  ```bash
+  gh run watch
+  ```
+
+## When to use
+
+- Multiple GitHub Actions jobs failed and the failures look independent.
+- A long workflow log is easier to split by job than to fix sequentially.
+
+## When not to use
+
+- A single job with one clear error — fix it in the main agent.
+- Failures that are purely flaky infrastructure — retry or fix workflow config first.
+
+## Notes
+
+- Redact secrets if pasting logs into chat.
+- If agents conflict on shared files, merge sequentially after the parallel pass.

--- a/.cursor/skills/parallel-ci-triage/UPSTREAM.md
+++ b/.cursor/skills/parallel-ci-triage/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/spencerpauly/awesome-cursor-skills
+- Path: `resources/parallel-ci-triage`
+- Commit: `773b571db3693d2edc1cf656903c292d037e25b8`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/prove-it/SKILL.md
+++ b/.cursor/skills/prove-it/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: prove-it
+description: Before declaring any task complete, actually verify the outcome. Run the code. Test the fix. Check the output. AI-generated code optimizes for plausible-looking output, not verified-correct output. Use when completing code changes, bug fixes, or any task where correctness matters.
+---
+
+# Prove It
+
+## Purpose
+
+AI-generated code comes from pattern-matching on training data. Something can look
+syntactically perfect, follow best practices, and still be wrong. The model
+optimizes for "looks right" not "works right." Verification is a separate
+cognitive step that must be explicitly triggered. This skill closes the loop
+between implementation and proof.
+
+## Why This Matters (Technical Reality)
+
+Limitations this skill addresses:
+
+**1. Generation vs Execution**
+Code is generated but not run during generation. Confidence comes from "this
+looks like working code" not from "this was executed and the result observed."
+
+**2. Pattern-Matching Blindness**
+Code that matches common patterns feels correct. But subtle bugs hide in the
+gaps between patterns. Off-by-one errors. Wrong variable names. Missing edge
+cases. These "look right" but aren't.
+
+**3. Confidence-Correctness Gap**
+High confidence in output doesn't correlate with actual correctness.
+The agent is often most confident when most wrong, because the wrong answer
+pattern-matched strongly.
+
+**4. No Feedback Loop**
+Code is generated sequentially. There's no natural "go back and check" step.
+Without explicit verification, errors compound silently.
+
+## When To Verify
+
+ALWAYS verify before declaring complete:
+
+**Code Changes:**
+- New functions or modules
+- Bug fixes
+- Refactoring
+- Configuration changes
+- Build/deploy scripts
+
+**Fixes:**
+- "Fixed the bug" - did you reproduce and confirm it's gone?
+- "Resolved the error" - did you trigger the error path again?
+- "Updated the config" - did you restart and test?
+
+**Claims:**
+- Factual statements that matter to the decision
+- "This will work because..." - did you prove it?
+- "The file contains..." - did you actually read it?
+
+## Instructions
+
+### Step 1: Catch The Victory Lap
+
+Before saying any of these:
+- "Done!"
+- "That should work"
+- "I've implemented..."
+- "The fix is..."
+- "Complete"
+
+STOP. You haven't verified yet.
+
+### Step 2: Determine Verification Method
+
+| Change Type | Verification |
+|-------------|--------------|
+| New code | Run it with test input |
+| Bug fix | Reproduce original bug, confirm fixed |
+| Function change | Call the function, check output |
+| Config change | Restart service, test affected feature |
+| Build script | Run the build |
+| API endpoint | Make a request |
+| UI change | Describe what user should see, or screenshot |
+
+### Step 3: Actually Verify
+
+```bash
+# Don't just write the test - run it
+python -m pytest tests/test_new_feature.py
+
+# Don't just fix the code - prove the fix
+python -c "from module import func; print(func(edge_case))"
+
+# Don't just update config - verify it loads
+node -e "console.log(require('./config.js'))"
+```
+
+### Step 4: Report With Evidence
+
+```
+Verified:
+
+What I changed:
+  - Added input validation to user_signup()
+
+How I verified:
+  - Ran: python -c "from auth import user_signup; user_signup('')"
+  - Expected: ValidationError
+  - Got: ValidationError("Email required")
+
+Proof that it works. Done.
+```
+
+## Verification Patterns
+
+### Pattern 1: The Smoke Test
+
+Minimal test that proves basic functionality:
+
+```bash
+# After writing a new function
+python -c "from new_module import new_func; print(new_func('test'))"
+```
+
+If this crashes, you're not done.
+
+### Pattern 2: The Regression Check
+
+After fixing a bug, trigger the original failure:
+
+```bash
+# Bug was: crash on empty input
+python -c "from module import func; func('')"
+# Should not crash anymore
+```
+
+### Pattern 3: The Build Gate
+
+Before claiming code is complete:
+
+```bash
+# Does it at least compile/parse?
+python -m py_compile new_file.py
+npm run build
+cargo check
+```
+
+### Pattern 4: The Integration Smell Test
+
+After changes that affect multiple components:
+
+```bash
+# Start the service
+npm run dev &
+
+# Hit the affected endpoint
+curl http://localhost:3000/affected-route
+
+# Check for expected response
+```
+
+## The Verification Checklist
+
+Before declaring done:
+
+```
+[ ] Code runs without syntax errors
+[ ] Function produces expected output on happy path
+[ ] Edge case handled (empty, null, boundary)
+[ ] Original bug/issue no longer reproduces
+[ ] No new errors introduced (check logs)
+[ ] Build passes (if applicable)
+```
+
+## NEVER
+
+- Say "done" without running the code
+- Assume it works because it looks right
+- Skip verification because you're confident
+- Claim a bug is fixed without reproducing it first
+- Trust that generated code is correct
+- Let pattern-matching substitute for proof
+
+## ALWAYS
+
+- Run new code at least once
+- Test the specific thing that was broken
+- Show verification output in your response
+- Admit when you can't verify (and say why)
+- Treat verification as required, not optional
+
+## Examples
+
+### Example 1: Bad (No Verification)
+
+```
+User: "Fix the divide by zero error"
+
+*edits code to add check*
+
+Done! Added a check for zero before dividing. The function now returns
+None if the divisor is zero.
+```
+
+This is unverified. The code was never run.
+
+### Example 1: Good (With Verification)
+
+```
+User: "Fix the divide by zero error"
+
+*edits code to add check*
+
+Let me verify the fix:
+
+$ python -c "from math_utils import safe_divide; print(safe_divide(10, 0))"
+None
+
+$ python -c "from math_utils import safe_divide; print(safe_divide(10, 2))"
+5.0
+
+Verified:
+- Division by zero returns None (was: crashed)
+- Normal division still works
+- Fix confirmed.
+```
+
+### Example 2: Admitting Inability To Verify
+
+```
+User: "Update the production config"
+
+I've updated config/production.json with the new API endpoint.
+
+Verification status: UNABLE TO VERIFY
+- This is production config
+- I can't safely test against production
+- Recommend: Test in staging first, or have ops verify after deploy
+
+Change is made but unverified. Proceed with caution.
+```
+
+## The Hard Truth
+
+When "Done!" is said without verifying, it's not reporting a fact. It's making a
+prediction based on pattern-matching. Sometimes that prediction is wrong.
+
+Verification converts prediction into observation. It's the difference between
+"this should work" and "this works."
+
+One is a guess. One is proof.
+
+Prove it.

--- a/.cursor/skills/prove-it/UPSTREAM.md
+++ b/.cursor/skills/prove-it/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/bluriesophos/cursorskills
+- Path: `prove-it`
+- Commit: `0ebd86c11e02f32d7fc90a4b3b0f5609b0262069`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-domain-cli/SKILL.md
+++ b/.cursor/skills/rust-domain-cli/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: domain-cli
+description: "Use when building CLI tools. Keywords: CLI, command line, terminal, clap, structopt, argument parsing, subcommand, interactive, TUI, ratatui, crossterm, indicatif, progress bar, colored output, shell completion, config file, environment variable, 命令行, 终端应用, 参数解析"
+globs: ["**/Cargo.toml"]
+user-invocable: false
+---
+
+# CLI Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| User ergonomics | Clear help, errors | clap derive macros |
+| Config precedence | CLI > env > file | Layered config loading |
+| Exit codes | Non-zero on error | Proper Result handling |
+| Stdout/stderr | Data vs errors | eprintln! for errors |
+| Interruptible | Handle Ctrl+C | Signal handling |
+
+---
+
+## Critical Constraints
+
+### User Communication
+
+```
+RULE: Errors to stderr, data to stdout
+WHY: Pipeable output, scriptability
+RUST: eprintln! for errors, println! for data
+```
+
+### Configuration Priority
+
+```
+RULE: CLI args > env vars > config file > defaults
+WHY: User expectation, override capability
+RUST: Layered config with clap + figment/config
+```
+
+### Exit Codes
+
+```
+RULE: Return non-zero on any error
+WHY: Script integration, automation
+RUST: main() -> Result<(), Error> or explicit exit()
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need argument parsing"
+    ↓ m05-type-driven: Derive structs for args
+    ↓ clap: #[derive(Parser)]
+
+"Need config layering"
+    ↓ m09-domain: Config as domain object
+    ↓ figment/config: Layer sources
+
+"Need progress display"
+    ↓ m12-lifecycle: Progress bar as RAII
+    ↓ indicatif: ProgressBar
+```
+
+---
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Argument parsing | clap |
+| Interactive prompts | dialoguer |
+| Progress bars | indicatif |
+| Colored output | colored |
+| Terminal UI | ratatui |
+| Terminal control | crossterm |
+| Console utilities | console |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Args struct | Type-safe args | `#[derive(Parser)]` |
+| Subcommands | Command hierarchy | `#[derive(Subcommand)]` |
+| Config layers | Override precedence | CLI > env > file |
+| Progress | User feedback | `ProgressBar::new(len)` |
+
+## Code Pattern: CLI Structure
+
+```rust
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "myapp", about = "My CLI tool")]
+struct Cli {
+    /// Enable verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new project
+    Init { name: String },
+    /// Run the application
+    Run {
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Init { name } => init_project(&name)?,
+        Commands::Run { port } => run_server(port.unwrap_or(8080))?,
+    }
+    Ok(())
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Errors to stdout | Breaks piping | eprintln! |
+| No help text | Poor UX | #[arg(help = "...")] |
+| Panic on error | Bad exit code | Result + proper handling |
+| No progress for long ops | User uncertainty | indicatif |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Type-safe args | Derive macros | clap Parser |
+| Error handling | Result propagation | anyhow + exit codes |
+| User feedback | Progress RAII | indicatif ProgressBar |
+| Config precedence | Builder pattern | Layered sources |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Error handling | m06-error-handling |
+| Type-driven args | m05-type-driven |
+| Progress lifecycle | m12-lifecycle |
+| Async CLI | m07-concurrency |

--- a/.cursor/skills/rust-domain-cli/UPSTREAM.md
+++ b/.cursor/skills/rust-domain-cli/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/ZhangHanDong/rust-skills
+- Path: `skills/domain-cli`
+- Commit: `37e050f490a731445eb17d339f7e95878be71d70`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-m01-ownership/SKILL.md
+++ b/.cursor/skills/rust-m01-ownership/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: m01-ownership
+description: "CRITICAL: Use for ownership/borrow/lifetime issues. Triggers: E0382, E0597, E0506, E0507, E0515, E0716, E0106, value moved, borrowed value does not live long enough, cannot move out of, use of moved value, ownership, borrow, lifetime, 'a, 'static, move, clone, Copy, 所有权, 借用, 生命周期"
+user-invocable: false
+---
+
+# Ownership & Lifetimes
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Who should own this data, and for how long?**
+
+Before fixing ownership errors, understand the data's role:
+- Is it shared or exclusive?
+- Is it short-lived or long-lived?
+- Is it transformed or just read?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0382 | "Clone it" | Who should own this data? |
+| E0597 | "Extend lifetime" | Is the scope boundary correct? |
+| E0506 | "End borrow first" | Should mutation happen elsewhere? |
+| E0507 | "Clone before move" | Why are we moving from a reference? |
+| E0515 | "Return owned" | Should caller own the data? |
+| E0716 | "Bind to variable" | Why is this temporary? |
+| E0106 | "Add 'a" | What is the actual lifetime relationship? |
+
+---
+
+## Thinking Prompt
+
+Before fixing an ownership error, ask:
+
+1. **What is this data's domain role?**
+   - Entity (unique identity) → owned
+   - Value Object (interchangeable) → clone/copy OK
+   - Temporary (computation result) → maybe restructure
+
+2. **Is the ownership design intentional?**
+   - By design → work within constraints
+   - Accidental → consider redesign
+
+3. **Fix symptom or redesign?**
+   - If Strike 3 (3rd attempt) → escalate to Layer 2
+
+---
+
+## Trace Up ↑
+
+When errors persist, trace to design layer:
+
+```
+E0382 (moved value)
+    ↑ Ask: What design choice led to this ownership pattern?
+    ↑ Check: m09-domain (is this Entity or Value Object?)
+    ↑ Check: domain-* (what constraints apply?)
+```
+
+| Persistent Error | Trace To | Question |
+|-----------------|----------|----------|
+| E0382 repeated | m02-resource | Should use Arc/Rc for sharing? |
+| E0597 repeated | m09-domain | Is scope boundary at right place? |
+| E0506/E0507 | m03-mutability | Should use interior mutability? |
+
+---
+
+## Trace Down ↓
+
+From design decisions to implementation:
+
+```
+"Data needs to be shared immutably"
+    ↓ Use: Arc<T> (multi-thread) or Rc<T> (single-thread)
+
+"Data needs exclusive ownership"
+    ↓ Use: move semantics, take ownership
+
+"Data is read-only view"
+    ↓ Use: &T (immutable borrow)
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Ownership | Cost | Use When |
+|---------|-----------|------|----------|
+| Move | Transfer | Zero | Caller doesn't need data |
+| `&T` | Borrow | Zero | Read-only access |
+| `&mut T` | Exclusive borrow | Zero | Need to modify |
+| `clone()` | Duplicate | Alloc + copy | Actually need a copy |
+| `Rc<T>` | Shared (single) | Ref count | Single-thread sharing |
+| `Arc<T>` | Shared (multi) | Atomic ref count | Multi-thread sharing |
+| `Cow<T>` | Clone-on-write | Alloc if mutated | Might modify |
+
+## Error Code Reference
+
+| Error | Cause | Quick Fix |
+|-------|-------|-----------|
+| E0382 | Value moved | Clone, reference, or redesign ownership |
+| E0597 | Reference outlives owner | Extend owner scope or restructure |
+| E0506 | Assign while borrowed | End borrow before mutation |
+| E0507 | Move out of borrowed | Clone or use reference |
+| E0515 | Return local reference | Return owned value |
+| E0716 | Temporary dropped | Bind to variable |
+| E0106 | Missing lifetime | Add `'a` annotation |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.clone()` everywhere | Hides design issues | Design ownership properly |
+| Fight borrow checker | Increases complexity | Work with the compiler |
+| `'static` for everything | Restricts flexibility | Use appropriate lifetimes |
+| Leak with `Box::leak` | Memory leak | Proper lifetime design |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Need smart pointers | m02-resource |
+| Need interior mutability | m03-mutability |
+| Data is domain entity | m09-domain |
+| Learning ownership concepts | m14-mental-model |

--- a/.cursor/skills/rust-m01-ownership/UPSTREAM.md
+++ b/.cursor/skills/rust-m01-ownership/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/ZhangHanDong/rust-skills
+- Path: `skills/m01-ownership`
+- Commit: `37e050f490a731445eb17d339f7e95878be71d70`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-m01-ownership/comparison.md
+++ b/.cursor/skills/rust-m01-ownership/comparison.md
@@ -1,0 +1,222 @@
+# Ownership: Comparison with Other Languages
+
+## Rust vs C++
+
+### Memory Management
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Default | Move semantics | Copy semantics (pre-C++11) |
+| Move | `let b = a;` (a invalidated) | `auto b = std::move(a);` (a valid but unspecified) |
+| Copy | `let b = a.clone();` | `auto b = a;` |
+| Safety | Compile-time enforcement | Runtime responsibility |
+
+### Rust Move vs C++ Move
+
+```rust
+// Rust: after move, 'a' is INVALID
+let a = String::from("hello");
+let b = a;  // a moved
+// println!("{}", a);  // COMPILE ERROR
+
+// Equivalent in C++:
+// std::string a = "hello";
+// std::string b = std::move(a);
+// std::cout << a;  // UNDEFINED (compiles but buggy)
+```
+
+### Smart Pointers
+
+| Rust | C++ | Purpose |
+|------|-----|---------|
+| `Box<T>` | `std::unique_ptr<T>` | Unique ownership |
+| `Rc<T>` | `std::shared_ptr<T>` | Shared ownership |
+| `Arc<T>` | `std::shared_ptr<T>` + atomic | Thread-safe shared |
+| `RefCell<T>` | (manual runtime checks) | Interior mutability |
+
+---
+
+## Rust vs Go
+
+### Memory Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Memory | Stack + heap, explicit | GC manages all |
+| Ownership | Enforced at compile-time | None (GC handles) |
+| Null | `Option<T>` | `nil` for pointers |
+| Concurrency | `Send`/`Sync` traits | Channels (less strict) |
+
+### Sharing Data
+
+```rust
+// Rust: explicit about sharing
+use std::sync::Arc;
+let data = Arc::new(vec![1, 2, 3]);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{:?}", data_clone);
+});
+
+// Go: implicit sharing
+// data := []int{1, 2, 3}
+// go func() {
+//     fmt.Println(data)  // potential race condition
+// }()
+```
+
+### Why No GC in Rust
+
+1. **Deterministic destruction**: Resources freed exactly when scope ends
+2. **Zero-cost**: No GC pauses or overhead
+3. **Embeddable**: Works in OS kernels, embedded systems
+4. **Predictable latency**: Critical for real-time systems
+
+---
+
+## Rust vs Java/C#
+
+### Reference Semantics
+
+| Aspect | Rust | Java/C# |
+|--------|------|---------|
+| Objects | Owned by default | Reference by default |
+| Null | `Option<T>` | `null` (nullable) |
+| Immutability | Default | Must use `final`/`readonly` |
+| Copy | Explicit `.clone()` | Reference copy (shallow) |
+
+### Comparison
+
+```rust
+// Rust: clear ownership
+fn process(data: Vec<i32>) {  // takes ownership
+    // data is ours, will be freed at end
+}
+
+let numbers = vec![1, 2, 3];
+process(numbers);
+// numbers is invalid here
+
+// Java: ambiguous ownership
+// void process(List<Integer> data) {
+//     // Who owns data? Caller? Callee? Both?
+//     // Can caller still use it?
+// }
+```
+
+---
+
+## Rust vs Python
+
+### Memory Model
+
+| Aspect | Rust | Python |
+|--------|------|--------|
+| Typing | Static, compile-time | Dynamic, runtime |
+| Memory | Ownership-based | Reference counting + GC |
+| Mutability | Default immutable | Default mutable |
+| Performance | Native, zero-cost | Interpreted, higher overhead |
+
+### Common Pattern Translation
+
+```rust
+// Rust: borrowing iteration
+let items = vec!["a", "b", "c"];
+for item in &items {
+    println!("{}", item);
+}
+// items still usable
+
+// Python: iteration doesn't consume
+// items = ["a", "b", "c"]
+// for item in items:
+//     print(item)
+// items still usable (different reason - ref counting)
+```
+
+---
+
+## Unique Rust Concepts
+
+### Concepts Other Languages Lack
+
+1. **Borrow Checker**: No other mainstream language has compile-time borrow checking
+2. **Lifetimes**: Explicit annotation of reference validity
+3. **Move by Default**: Values move, not copy
+4. **No Null**: `Option<T>` instead of null pointers
+5. **Affine Types**: Values can be used at most once
+
+### Learning Curve Areas
+
+| Concept | Coming From | Key Insight |
+|---------|-------------|-------------|
+| Ownership | GC languages | Think about who "owns" data |
+| Borrowing | C/C++ | Like references but checked |
+| Lifetimes | Any | Explicit scope of validity |
+| Move | C++ | Move is default, not copy |
+
+---
+
+## Mental Model Shifts
+
+### From GC Languages (Java, Go, Python)
+
+```
+Before: "Memory just works, GC handles it"
+After:  "I explicitly decide who owns data and when it's freed"
+```
+
+Key shifts:
+- Think about ownership at design time
+- Returning references requires lifetime thinking
+- No more `null` - use `Option<T>`
+
+### From C/C++
+
+```
+Before: "I manually manage memory and hope I get it right"
+After:  "Compiler enforces correctness, I fight the borrow checker"
+```
+
+Key shifts:
+- Trust the compiler's errors
+- Move is the default (unlike C++ copy)
+- Smart pointers are idiomatic, not overhead
+
+### From Functional Languages (Haskell, ML)
+
+```
+Before: "Everything is immutable, copying is fine"
+After:  "Mutability is explicit, ownership prevents aliasing"
+```
+
+Key shifts:
+- Mutability is safe because of ownership rules
+- No persistent data structures needed (usually)
+- Performance characteristics are explicit
+
+---
+
+## Performance Trade-offs
+
+| Language | Memory Overhead | Latency | Throughput |
+|----------|-----------------|---------|------------|
+| Rust | Minimal (no GC) | Predictable | Excellent |
+| C++ | Minimal | Predictable | Excellent |
+| Go | GC overhead | GC pauses | Good |
+| Java | GC overhead | GC pauses | Good |
+| Python | High (ref counting + GC) | Variable | Lower |
+
+### When Rust Ownership Wins
+
+1. **Real-time systems**: No GC pauses
+2. **Embedded**: No runtime overhead
+3. **High-performance**: Zero-cost abstractions
+4. **Concurrent**: Data races prevented at compile time
+
+### When GC Might Be Preferable
+
+1. **Rapid prototyping**: Less mental overhead
+2. **Complex object graphs**: Cycles are tricky in Rust
+3. **GUI applications**: Object lifetimes are dynamic
+4. **Small programs**: Overhead doesn't matter

--- a/.cursor/skills/rust-m01-ownership/examples/best-practices.md
+++ b/.cursor/skills/rust-m01-ownership/examples/best-practices.md
@@ -1,0 +1,339 @@
+# Ownership Best Practices
+
+## API Design Patterns
+
+### 1. Prefer Borrowing Over Ownership
+
+```rust
+// BAD: takes ownership unnecessarily
+fn print_name(name: String) {
+    println!("Name: {}", name);
+}
+
+// GOOD: borrows instead
+fn print_name(name: &str) {
+    println!("Name: {}", name);
+}
+
+// Caller benefits:
+let name = String::from("Alice");
+print_name(&name);  // can reuse name
+print_name(&name);  // still valid
+```
+
+### 2. Return Owned Values from Constructors
+
+```rust
+// GOOD: return owned value
+impl User {
+    fn new(name: &str) -> Self {
+        User {
+            name: name.to_string(),
+        }
+    }
+}
+
+// GOOD: accept Into<String> for flexibility
+impl User {
+    fn new(name: impl Into<String>) -> Self {
+        User {
+            name: name.into(),
+        }
+    }
+}
+
+// Usage:
+let u1 = User::new("Alice");        // &str
+let u2 = User::new(String::from("Bob"));  // String
+```
+
+### 3. Use AsRef for Generic Borrowing
+
+```rust
+// GOOD: accepts both &str and String
+fn process<S: AsRef<str>>(input: S) {
+    let s = input.as_ref();
+    println!("{}", s);
+}
+
+process("literal");           // &str
+process(String::from("owned")); // String
+process(&String::from("ref")); // &String
+```
+
+### 4. Cow for Clone-on-Write
+
+```rust
+use std::borrow::Cow;
+
+// Return borrowed when possible, owned when needed
+fn maybe_modify(s: &str, uppercase: bool) -> Cow<'_, str> {
+    if uppercase {
+        Cow::Owned(s.to_uppercase())  // allocates
+    } else {
+        Cow::Borrowed(s)  // zero-cost
+    }
+}
+
+let input = "hello";
+let result = maybe_modify(input, false);
+// result is borrowed, no allocation
+```
+
+---
+
+## Struct Design Patterns
+
+### 1. Owned Fields vs References
+
+```rust
+// Use owned fields for most cases
+struct User {
+    name: String,
+    email: String,
+}
+
+// Use references only when lifetime is clear
+struct UserView<'a> {
+    name: &'a str,
+    email: &'a str,
+}
+
+// Pattern: owned data + view for efficiency
+impl User {
+    fn view(&self) -> UserView<'_> {
+        UserView {
+            name: &self.name,
+            email: &self.email,
+        }
+    }
+}
+```
+
+### 2. Builder Pattern with Ownership
+
+```rust
+#[derive(Default)]
+struct RequestBuilder {
+    url: Option<String>,
+    method: Option<String>,
+    body: Option<Vec<u8>>,
+}
+
+impl RequestBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    // Take self by value for chaining
+    fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    fn method(mut self, method: impl Into<String>) -> Self {
+        self.method = Some(method.into());
+        self
+    }
+
+    fn build(self) -> Result<Request, Error> {
+        Ok(Request {
+            url: self.url.ok_or(Error::MissingUrl)?,
+            method: self.method.unwrap_or_else(|| "GET".to_string()),
+            body: self.body.unwrap_or_default(),
+        })
+    }
+}
+
+// Usage:
+let req = RequestBuilder::new()
+    .url("https://example.com")
+    .method("POST")
+    .build()?;
+```
+
+### 3. Interior Mutability When Needed
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Shared mutable state in single-threaded context
+struct Counter {
+    value: Rc<RefCell<u32>>,
+}
+
+impl Counter {
+    fn new() -> Self {
+        Counter {
+            value: Rc::new(RefCell::new(0)),
+        }
+    }
+
+    fn increment(&self) {
+        *self.value.borrow_mut() += 1;
+    }
+
+    fn get(&self) -> u32 {
+        *self.value.borrow()
+    }
+
+    fn clone_handle(&self) -> Self {
+        Counter {
+            value: Rc::clone(&self.value),
+        }
+    }
+}
+```
+
+---
+
+## Collection Patterns
+
+### 1. Efficient Iteration
+
+```rust
+let items = vec![1, 2, 3, 4, 5];
+
+// Iterate by reference (no move)
+for item in &items {
+    println!("{}", item);
+}
+
+// Iterate by mutable reference
+for item in &mut items.clone() {
+    *item *= 2;
+}
+
+// Consume with into_iter when done
+let sum: i32 = items.into_iter().sum();
+```
+
+### 2. Collecting Results
+
+```rust
+// Collect into owned collection
+let strings: Vec<String> = (0..5)
+    .map(|i| format!("item_{}", i))
+    .collect();
+
+// Collect references
+let refs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
+
+// Collect with transformation
+let result: Result<Vec<i32>, _> = ["1", "2", "3"]
+    .iter()
+    .map(|s| s.parse::<i32>())
+    .collect();
+```
+
+### 3. Entry API for Maps
+
+```rust
+use std::collections::HashMap;
+
+let mut map: HashMap<String, Vec<i32>> = HashMap::new();
+
+// Efficient: don't search twice
+map.entry("key".to_string())
+   .or_insert_with(Vec::new)
+   .push(42);
+
+// With entry modification
+map.entry("key".to_string())
+   .and_modify(|v| v.push(43))
+   .or_insert_with(|| vec![43]);
+```
+
+---
+
+## Error Handling with Ownership
+
+### 1. Preserve Context in Errors
+
+```rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct ParseError {
+    input: String,  // owns the problematic input
+    message: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to parse '{}': {}", self.input, self.message)
+    }
+}
+
+fn parse(input: &str) -> Result<i32, ParseError> {
+    input.parse().map_err(|_| ParseError {
+        input: input.to_string(),  // clone for error context
+        message: "not a valid integer".to_string(),
+    })
+}
+```
+
+### 2. Ownership in Result Chains
+
+```rust
+fn process_data(path: &str) -> Result<ProcessedData, Error> {
+    let content = std::fs::read_to_string(path)?;  // owned String
+    let parsed = parse_content(&content)?;          // borrow
+    let processed = transform(parsed)?;             // ownership moves
+    Ok(processed)                                   // return owned
+}
+```
+
+---
+
+## Performance Considerations
+
+### 1. Avoid Unnecessary Clones
+
+```rust
+// BAD: cloning just to compare
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s.clone() == target)  // unnecessary clone
+}
+
+// GOOD: compare references
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s == target)  // String implements PartialEq<str>
+}
+```
+
+### 2. Use Slices for Flexibility
+
+```rust
+// BAD: requires Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// GOOD: accepts any slice
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// Now works with:
+sum(&vec![1, 2, 3]);     // Vec
+sum(&[1, 2, 3]);         // array
+sum(&array[1..3]);       // slice
+```
+
+### 3. In-Place Mutation
+
+```rust
+// BAD: allocates new String
+fn make_uppercase(s: &str) -> String {
+    s.to_uppercase()
+}
+
+// GOOD when you own the data: mutate in place
+fn make_uppercase(mut s: String) -> String {
+    s.make_ascii_uppercase();  // in-place for ASCII
+    s
+}
+```

--- a/.cursor/skills/rust-m01-ownership/patterns/common-errors.md
+++ b/.cursor/skills/rust-m01-ownership/patterns/common-errors.md
@@ -1,0 +1,265 @@
+# Common Ownership Errors & Fixes
+
+## E0382: Use of Moved Value
+
+### Error Pattern
+```rust
+let s = String::from("hello");
+let s2 = s;          // s moved here
+println!("{}", s);   // ERROR: value borrowed after move
+```
+
+### Fix Options
+
+**Option 1: Clone (if ownership not needed)**
+```rust
+let s = String::from("hello");
+let s2 = s.clone();  // s is cloned
+println!("{}", s);   // OK: s still valid
+```
+
+**Option 2: Borrow (if modification not needed)**
+```rust
+let s = String::from("hello");
+let s2 = &s;         // borrow, not move
+println!("{}", s);   // OK
+println!("{}", s2);  // OK
+```
+
+**Option 3: Use Rc/Arc (for shared ownership)**
+```rust
+use std::rc::Rc;
+let s = Rc::new(String::from("hello"));
+let s2 = Rc::clone(&s);  // shared ownership
+println!("{}", s);       // OK
+println!("{}", s2);      // OK
+```
+
+---
+
+## E0597: Borrowed Value Does Not Live Long Enough
+
+### Error Pattern
+```rust
+fn get_str() -> &str {
+    let s = String::from("hello");
+    &s  // ERROR: s dropped here, but reference returned
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn get_str() -> String {
+    String::from("hello")  // return owned value
+}
+```
+
+**Option 2: Use 'static lifetime**
+```rust
+fn get_str() -> &'static str {
+    "hello"  // string literal has 'static lifetime
+}
+```
+
+**Option 3: Accept reference parameter**
+```rust
+fn get_str<'a>(s: &'a str) -> &'a str {
+    s  // return reference with same lifetime as input
+}
+```
+
+---
+
+## E0499: Cannot Borrow as Mutable More Than Once
+
+### Error Pattern
+```rust
+let mut s = String::from("hello");
+let r1 = &mut s;
+let r2 = &mut s;  // ERROR: second mutable borrow
+println!("{}, {}", r1, r2);
+```
+
+### Fix Options
+
+**Option 1: Sequential borrows**
+```rust
+let mut s = String::from("hello");
+{
+    let r1 = &mut s;
+    r1.push_str(" world");
+}  // r1 goes out of scope
+let r2 = &mut s;  // OK: r1 no longer exists
+```
+
+**Option 2: Use RefCell for interior mutability**
+```rust
+use std::cell::RefCell;
+let s = RefCell::new(String::from("hello"));
+let mut r1 = s.borrow_mut();
+// drop r1 before borrowing again
+drop(r1);
+let mut r2 = s.borrow_mut();
+```
+
+---
+
+## E0502: Cannot Borrow as Mutable While Immutable Borrow Exists
+
+### Error Pattern
+```rust
+let mut v = vec![1, 2, 3];
+let first = &v[0];      // immutable borrow
+v.push(4);              // ERROR: mutable borrow while immutable exists
+println!("{}", first);
+```
+
+### Fix Options
+
+**Option 1: Finish using immutable borrow first**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0];       // copy value, not borrow
+v.push(4);              // OK
+println!("{}", first);  // OK: using copied value
+```
+
+**Option 2: Clone before mutating**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0].clone();  // if T: Clone
+v.push(4);
+println!("{}", first);
+```
+
+---
+
+## E0507: Cannot Move Out of Borrowed Content
+
+### Error Pattern
+```rust
+fn take_string(s: &String) {
+    let moved = *s;  // ERROR: cannot move out of borrowed content
+}
+```
+
+### Fix Options
+
+**Option 1: Clone**
+```rust
+fn take_string(s: &String) {
+    let cloned = s.clone();
+}
+```
+
+**Option 2: Take ownership in function signature**
+```rust
+fn take_string(s: String) {  // take ownership
+    let moved = s;
+}
+```
+
+**Option 3: Use mem::take for Option/Default types**
+```rust
+fn take_from_option(opt: &mut Option<String>) -> Option<String> {
+    std::mem::take(opt)  // replaces with None, returns owned value
+}
+```
+
+---
+
+## E0515: Return Local Reference
+
+### Error Pattern
+```rust
+fn create_string() -> &String {
+    let s = String::from("hello");
+    &s  // ERROR: cannot return reference to local variable
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn create_string() -> String {
+    String::from("hello")
+}
+```
+
+**Option 2: Use static/const**
+```rust
+fn get_static_str() -> &'static str {
+    "hello"
+}
+```
+
+---
+
+## E0716: Temporary Value Dropped While Borrowed
+
+### Error Pattern
+```rust
+let r: &str = &String::from("hello");  // ERROR: temporary dropped
+println!("{}", r);
+```
+
+### Fix Options
+
+**Option 1: Bind to variable first**
+```rust
+let s = String::from("hello");
+let r: &str = &s;
+println!("{}", r);
+```
+
+**Option 2: Use let binding with reference**
+```rust
+let r: &str = {
+    let s = String::from("hello");
+    // s.as_str()  // ERROR: still temporary
+    Box::leak(s.into_boxed_str())  // extreme: leak for 'static
+};
+```
+
+---
+
+## Pattern: Loop Ownership Issues
+
+### Error Pattern
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in strings {
+    println!("{}", s);
+}
+// ERROR: strings moved into loop
+println!("{:?}", strings);
+```
+
+### Fix Options
+
+**Option 1: Iterate by reference**
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in &strings {
+    println!("{}", s);
+}
+println!("{:?}", strings);  // OK
+```
+
+**Option 2: Use iter()**
+```rust
+for s in strings.iter() {
+    println!("{}", s);
+}
+```
+
+**Option 3: Clone if needed**
+```rust
+for s in strings.clone() {
+    // consumes cloned vec
+}
+println!("{:?}", strings);  // original still available
+```

--- a/.cursor/skills/rust-m01-ownership/patterns/lifetime-patterns.md
+++ b/.cursor/skills/rust-m01-ownership/patterns/lifetime-patterns.md
@@ -1,0 +1,229 @@
+# Lifetime Patterns
+
+## Basic Lifetime Annotation
+
+### When Required
+```rust
+// ERROR: missing lifetime specifier
+fn longest(x: &str, y: &str) -> &str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// FIX: explicit lifetime
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+```
+
+### Lifetime Elision Rules
+1. Each input reference gets its own lifetime
+2. If one input lifetime, output uses same
+3. If `&self` or `&mut self`, output uses self's lifetime
+
+```rust
+// These are equivalent (elision applies):
+fn first_word(s: &str) -> &str { ... }
+fn first_word<'a>(s: &'a str) -> &'a str { ... }
+
+// Method with self (elision applies):
+impl MyStruct {
+    fn get_ref(&self) -> &str { ... }
+    // Equivalent to:
+    fn get_ref<'a>(&'a self) -> &'a str { ... }
+}
+```
+
+---
+
+## Struct Lifetimes
+
+### Struct Holding References
+```rust
+// Struct must declare lifetime for references
+struct Excerpt<'a> {
+    part: &'a str,
+}
+
+impl<'a> Excerpt<'a> {
+    fn level(&self) -> i32 { 3 }
+
+    // Return reference tied to self's lifetime
+    fn get_part(&self) -> &str {
+        self.part
+    }
+}
+```
+
+### Multiple Lifetimes in Struct
+```rust
+struct Multi<'a, 'b> {
+    x: &'a str,
+    y: &'b str,
+}
+
+// Use when references may have different lifetimes
+fn make_multi<'a, 'b>(x: &'a str, y: &'b str) -> Multi<'a, 'b> {
+    Multi { x, y }
+}
+```
+
+---
+
+## 'static Lifetime
+
+### When to Use
+```rust
+// String literals are 'static
+let s: &'static str = "hello";
+
+// Owned data can be leaked to 'static
+let leaked: &'static str = Box::leak(String::from("hello").into_boxed_str());
+
+// Thread spawn requires 'static or move
+std::thread::spawn(move || {
+    // closure owns data, satisfies 'static
+});
+```
+
+### Avoid Overusing 'static
+```rust
+// BAD: requires 'static unnecessarily
+fn process(s: &'static str) { ... }
+
+// GOOD: use generic lifetime
+fn process<'a>(s: &'a str) { ... }
+// or
+fn process(s: &str) { ... }  // lifetime elision
+```
+
+---
+
+## Higher-Ranked Trait Bounds (HRTB)
+
+### for<'a> Syntax
+```rust
+// Function that works with any lifetime
+fn apply_to_ref<F>(f: F)
+where
+    F: for<'a> Fn(&'a str) -> &'a str,
+{
+    let s = String::from("hello");
+    let result = f(&s);
+    println!("{}", result);
+}
+```
+
+### Common Use: Closure Bounds
+```rust
+// Closure that borrows any lifetime
+fn filter_refs<F>(items: &[&str], pred: F) -> Vec<&str>
+where
+    F: for<'a> Fn(&'a str) -> bool,
+{
+    items.iter().copied().filter(|s| pred(s)).collect()
+}
+```
+
+---
+
+## Lifetime Bounds
+
+### 'a: 'b (Outlives)
+```rust
+// 'a must live at least as long as 'b
+fn coerce<'a, 'b>(x: &'a str) -> &'b str
+where
+    'a: 'b,
+{
+    x
+}
+```
+
+### T: 'a (Type Outlives Lifetime)
+```rust
+// T must live at least as long as 'a
+struct Wrapper<'a, T: 'a> {
+    value: &'a T,
+}
+
+// Common pattern with trait objects
+fn use_trait<'a, T: MyTrait + 'a>(t: &'a T) { ... }
+```
+
+---
+
+## Common Lifetime Mistakes
+
+### Mistake 1: Returning Reference to Local
+```rust
+// WRONG
+fn dangle() -> &String {
+    let s = String::from("hello");
+    &s  // s dropped, reference invalid
+}
+
+// RIGHT
+fn no_dangle() -> String {
+    String::from("hello")
+}
+```
+
+### Mistake 2: Conflicting Lifetimes
+```rust
+// WRONG: might return reference to y which has shorter lifetime
+fn wrong<'a, 'b>(x: &'a str, y: &'b str) -> &'a str {
+    y  // ERROR: 'b might not live as long as 'a
+}
+
+// RIGHT: use same lifetime or add bound
+fn right<'a>(x: &'a str, y: &'a str) -> &'a str {
+    y  // OK: both have lifetime 'a
+}
+```
+
+### Mistake 3: Struct Outlives Reference
+```rust
+// WRONG: s might outlive the string it references
+let r;
+{
+    let s = String::from("hello");
+    r = Excerpt { part: &s };  // ERROR
+}
+println!("{}", r.part);  // s already dropped
+
+// RIGHT: ensure source outlives struct
+let s = String::from("hello");
+let r = Excerpt { part: &s };
+println!("{}", r.part);  // OK: s still in scope
+```
+
+---
+
+## Subtyping and Variance
+
+### Covariance
+```rust
+// &'a T is covariant in 'a
+// Can use &'long where &'short expected
+fn example<'short, 'long: 'short>(long_ref: &'long str) {
+    let short_ref: &'short str = long_ref;  // OK: covariance
+}
+```
+
+### Invariance
+```rust
+// &'a mut T is invariant in 'a
+fn example<'a, 'b>(x: &'a mut &'b str, y: &'b str) {
+    *x = y;  // ERROR if 'a and 'b are different
+}
+```
+
+### Practical Impact
+```rust
+// This works due to covariance
+fn accept_any<'a>(s: &'a str) { ... }
+
+let s = String::from("hello");
+let long_lived: &str = &s;
+accept_any(long_lived);  // 'long coerces to 'short
+```

--- a/.cursor/skills/rust-m06-error-handling/SKILL.md
+++ b/.cursor/skills/rust-m06-error-handling/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: m06-error-handling
+description: "CRITICAL: Use for error handling. Triggers: Result, Option, Error, ?, unwrap, expect, panic, anyhow, thiserror, when to panic vs return Result, custom error, error propagation, 错误处理, Result 用法, 什么时候用 panic"
+user-invocable: false
+---
+
+# Error Handling
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this failure expected or a bug?**
+
+Before choosing error handling strategy:
+- Can this fail in normal operation?
+- Who should handle this failure?
+- What context does the caller need?
+
+---
+
+## Error → Design Question
+
+| Pattern | Don't Just Say | Ask Instead |
+|---------|----------------|-------------|
+| unwrap panics | "Use ?" | Is None/Err actually possible here? |
+| Type mismatch on ? | "Use anyhow" | Are error types designed correctly? |
+| Lost error context | "Add .context()" | What does the caller need to know? |
+| Too many error variants | "Use Box<dyn Error>" | Is error granularity right? |
+
+---
+
+## Thinking Prompt
+
+Before handling an error:
+
+1. **What kind of failure is this?**
+   - Expected → Result<T, E>
+   - Absence normal → Option<T>
+   - Bug/invariant → panic!
+   - Unrecoverable → panic!
+
+2. **Who handles this?**
+   - Caller → propagate with ?
+   - Current function → match/if-let
+   - User → friendly error message
+   - Programmer → panic with message
+
+3. **What context is needed?**
+   - Type of error → thiserror variants
+   - Call chain → anyhow::Context
+   - Debug info → anyhow or tracing
+
+---
+
+## Trace Up ↑
+
+When error strategy is unclear:
+
+```
+"Should I return Result or Option?"
+    ↑ Ask: Is absence/failure normal or exceptional?
+    ↑ Check: m09-domain (what does domain say?)
+    ↑ Check: domain-* (error handling requirements)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Too many unwraps | m09-domain | Is the data model right? |
+| Error context design | m13-domain-error | What recovery is needed? |
+| Library vs app errors | m11-ecosystem | Who are the consumers? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Expected failure, library code"
+    ↓ Use: thiserror for typed errors
+
+"Expected failure, application code"
+    ↓ Use: anyhow for ergonomic errors
+
+"Absence is normal (find, get, lookup)"
+    ↓ Use: Option<T>
+
+"Bug or invariant violation"
+    ↓ Use: panic!, assert!, unreachable!
+
+"Need to propagate with context"
+    ↓ Use: .context("what was happening")
+```
+
+---
+
+## Quick Reference
+
+| Pattern | When | Example |
+|---------|------|---------|
+| `Result<T, E>` | Recoverable error | `fn read() -> Result<String, io::Error>` |
+| `Option<T>` | Absence is normal | `fn find() -> Option<&Item>` |
+| `?` | Propagate error | `let data = file.read()?;` |
+| `unwrap()` | Dev/test only | `config.get("key").unwrap()` |
+| `expect()` | Invariant holds | `env.get("HOME").expect("HOME set")` |
+| `panic!` | Unrecoverable | `panic!("critical failure")` |
+
+## Library vs Application
+
+| Context | Error Crate | Why |
+|---------|-------------|-----|
+| Library | `thiserror` | Typed errors for consumers |
+| Application | `anyhow` | Ergonomic error handling |
+| Mixed | Both | thiserror at boundaries, anyhow internally |
+
+## Decision Flowchart
+
+```
+Is failure expected?
+├─ Yes → Is absence the only "failure"?
+│        ├─ Yes → Option<T>
+│        └─ No → Result<T, E>
+│                 ├─ Library → thiserror
+│                 └─ Application → anyhow
+└─ No → Is it a bug?
+        ├─ Yes → panic!, assert!
+        └─ No → Consider if really unrecoverable
+
+Use ? → Need context?
+├─ Yes → .context("message")
+└─ No → Plain ?
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `unwrap()` panic | Unhandled None/Err | Use `?` or match |
+| Type mismatch | Different error types | Use `anyhow` or `From` |
+| Lost context | `?` without context | Add `.context()` |
+| `cannot use ?` | Missing Result return | Return `Result<(), E>` |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.unwrap()` everywhere | Panics in production | `.expect("reason")` or `?` |
+| Ignore errors silently | Bugs hidden | Handle or propagate |
+| `panic!` for expected errors | Bad UX, no recovery | Result |
+| Box<dyn Error> everywhere | Lost type info | thiserror |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Domain error strategy | m13-domain-error |
+| Crate boundaries | m11-ecosystem |
+| Type-safe errors | m05-type-driven |
+| Mental models | m14-mental-model |

--- a/.cursor/skills/rust-m06-error-handling/UPSTREAM.md
+++ b/.cursor/skills/rust-m06-error-handling/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/ZhangHanDong/rust-skills
+- Path: `skills/m06-error-handling`
+- Commit: `37e050f490a731445eb17d339f7e95878be71d70`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-m06-error-handling/examples/library-vs-app.md
+++ b/.cursor/skills/rust-m06-error-handling/examples/library-vs-app.md
@@ -1,0 +1,332 @@
+# Error Handling: Library vs Application
+
+## Library Error Design
+
+### Principles
+1. **Define specific error types** - Don't use `anyhow` in libraries
+2. **Implement std::error::Error** - For compatibility
+3. **Provide error variants** - Let users match on errors
+4. **Include source errors** - Enable error chains
+5. **Be `Send + Sync`** - For async compatibility
+
+### Example: Library Error Type
+```rust
+// lib.rs
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("connection failed: {host}:{port}")]
+    ConnectionFailed {
+        host: String,
+        port: u16,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("query failed: {query}")]
+    QueryFailed {
+        query: String,
+        #[source]
+        source: SqlError,
+    },
+
+    #[error("record not found: {table}.{id}")]
+    NotFound { table: String, id: String },
+
+    #[error("constraint violation: {0}")]
+    ConstraintViolation(String),
+}
+
+// Public Result alias
+pub type Result<T> = std::result::Result<T, DatabaseError>;
+
+// Library functions
+pub fn connect(host: &str, port: u16) -> Result<Connection> {
+    // ...
+}
+
+pub fn query(conn: &Connection, sql: &str) -> Result<Rows> {
+    // ...
+}
+```
+
+### Library Usage of Errors
+```rust
+impl Database {
+    pub fn get_user(&self, id: &str) -> Result<User> {
+        let rows = self.query(&format!("SELECT * FROM users WHERE id = '{}'", id))?;
+
+        rows.first()
+            .cloned()
+            .ok_or_else(|| DatabaseError::NotFound {
+                table: "users".to_string(),
+                id: id.to_string(),
+            })
+    }
+}
+```
+
+---
+
+## Application Error Design
+
+### Principles
+1. **Use anyhow for convenience** - Or custom unified error
+2. **Add context liberally** - Help debugging
+3. **Log at boundaries** - Don't log in libraries
+4. **Convert to user-friendly messages** - For display
+
+### Example: Application Error Handling
+```rust
+// main.rs
+use anyhow::{Context, Result};
+use tracing::{error, info};
+
+async fn run_server() -> Result<()> {
+    let config = load_config()
+        .context("failed to load configuration")?;
+
+    let db = Database::connect(&config.db_url)
+        .await
+        .context("failed to connect to database")?;
+
+    let server = Server::new(config.port)
+        .context("failed to create server")?;
+
+    info!("Server starting on port {}", config.port);
+
+    server.run(db).await
+        .context("server error")?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::init();
+
+    if let Err(e) = run_server().await {
+        error!("Application error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+```
+
+### Converting Library Errors
+```rust
+use mylib::DatabaseError;
+
+async fn get_user_handler(id: &str) -> Result<Response> {
+    match db.get_user(id).await {
+        Ok(user) => Ok(Response::json(user)),
+
+        Err(DatabaseError::NotFound { .. }) => {
+            Ok(Response::not_found("User not found"))
+        }
+
+        Err(DatabaseError::ConnectionFailed { .. }) => {
+            error!("Database connection failed");
+            Ok(Response::internal_error("Service unavailable"))
+        }
+
+        Err(e) => {
+            error!("Database error: {}", e);
+            Err(e.into())  // Convert to anyhow::Error
+        }
+    }
+}
+```
+
+---
+
+## Error Handling Layers
+
+```
+┌─────────────────────────────────────┐
+│           Application Layer          │
+│  - Use anyhow or unified error       │
+│  - Add context at boundaries         │
+│  - Log errors                        │
+│  - Convert to user messages          │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Service Layer              │
+│  - Map between error types           │
+│  - Add business context              │
+│  - Handle recoverable errors         │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Library Layer              │
+│  - Define specific error types       │
+│  - Use thiserror                     │
+│  - Include source errors             │
+│  - No logging                        │
+└─────────────────────────────────────┘
+```
+
+---
+
+## Practical Examples
+
+### HTTP API Error Response
+```rust
+use axum::{response::IntoResponse, http::StatusCode};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    code: String,
+}
+
+enum AppError {
+    NotFound(String),
+    BadRequest(String),
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, error, code) = match self {
+            AppError::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, msg, "NOT_FOUND")
+            }
+            AppError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, msg, "BAD_REQUEST")
+            }
+            AppError::Internal(e) => {
+                tracing::error!("Internal error: {:#}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                    "INTERNAL_ERROR",
+                )
+            }
+        };
+
+        let body = ErrorResponse {
+            error,
+            code: code.to_string(),
+        };
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+```
+
+### CLI Error Handling
+```rust
+use anyhow::{Context, Result};
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long)]
+    config: String,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+
+    let config = std::fs::read_to_string(&args.config)
+        .context(format!("Failed to read config file: {}", args.config))?;
+
+    let parsed: Config = toml::from_str(&config)
+        .context("Failed to parse config file")?;
+
+    process(parsed)?;
+
+    println!("Done!");
+    Ok(())
+}
+```
+
+---
+
+## Testing Error Handling
+
+### Testing Error Cases
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_found_error() {
+        let result = db.get_user("nonexistent");
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::NotFound { table, id })
+            if table == "users" && id == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn test_error_message() {
+        let err = DatabaseError::NotFound {
+            table: "users".to_string(),
+            id: "123".to_string(),
+        };
+
+        assert_eq!(err.to_string(), "record not found: users.123");
+    }
+
+    #[test]
+    fn test_error_chain() {
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused"
+        );
+
+        let err = DatabaseError::ConnectionFailed {
+            host: "localhost".to_string(),
+            port: 5432,
+            source: io_err,
+        };
+
+        // Check source is preserved
+        assert!(err.source().is_some());
+    }
+}
+```
+
+### Testing with anyhow
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_context() -> anyhow::Result<()> {
+        let result = process("valid input")?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_error_context() {
+        let err = process("invalid")
+            .context("processing failed")
+            .unwrap_err();
+
+        // Check error chain contains expected text
+        let chain = format!("{:#}", err);
+        assert!(chain.contains("processing failed"));
+    }
+}
+```

--- a/.cursor/skills/rust-m06-error-handling/patterns/error-patterns.md
+++ b/.cursor/skills/rust-m06-error-handling/patterns/error-patterns.md
@@ -1,0 +1,404 @@
+# Error Handling Patterns
+
+## The ? Operator
+
+### Basic Usage
+```rust
+fn read_config() -> Result<Config, io::Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    let config: Config = toml::from_str(&content)?;  // needs From impl
+    Ok(config)
+}
+```
+
+### With Different Error Types
+```rust
+use std::error::Error;
+
+// Box<dyn Error> for quick prototyping
+fn process() -> Result<(), Box<dyn Error>> {
+    let file = std::fs::read_to_string("data.txt")?;
+    let num: i32 = file.trim().parse()?;  // different error type
+    Ok(())
+}
+```
+
+### Custom Conversion with From
+```rust
+#[derive(Debug)]
+enum MyError {
+    Io(std::io::Error),
+    Parse(std::num::ParseIntError),
+}
+
+impl From<std::io::Error> for MyError {
+    fn from(err: std::io::Error) -> Self {
+        MyError::Io(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for MyError {
+    fn from(err: std::num::ParseIntError) -> Self {
+        MyError::Parse(err)
+    }
+}
+
+fn process() -> Result<i32, MyError> {
+    let content = std::fs::read_to_string("num.txt")?;  // auto-converts
+    let num: i32 = content.trim().parse()?;  // auto-converts
+    Ok(num)
+}
+```
+
+---
+
+## Error Type Design
+
+### Simple Enum Error
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigError {
+    NotFound,
+    InvalidFormat,
+    MissingField(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::NotFound => write!(f, "configuration file not found"),
+            ConfigError::InvalidFormat => write!(f, "invalid configuration format"),
+            ConfigError::MissingField(field) => write!(f, "missing field: {}", field),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+```
+
+### Error with Source (Wrapping)
+```rust
+#[derive(Debug)]
+pub struct AppError {
+    kind: AppErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AppErrorKind {
+    Config,
+    Database,
+    Network,
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            AppErrorKind::Config => write!(f, "configuration error"),
+            AppErrorKind::Database => write!(f, "database error"),
+            AppErrorKind::Network => write!(f, "network error"),
+        }
+    }
+}
+
+impl std::error::Error for AppError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as _)
+    }
+}
+```
+
+---
+
+## Using thiserror
+
+### Basic Usage
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DataError {
+    #[error("file not found: {path}")]
+    NotFound { path: String },
+
+    #[error("invalid data format")]
+    InvalidFormat,
+
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+
+    #[error("parse error: {0}")]
+    Parse(#[from] std::num::ParseIntError),
+}
+
+// Usage
+fn load_data(path: &str) -> Result<Data, DataError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|_| DataError::NotFound { path: path.to_string() })?;
+    let num: i32 = content.trim().parse()?;  // auto-converts with #[from]
+    Ok(Data { value: num })
+}
+```
+
+### Transparent Wrapper
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct MyError(#[from] InnerError);
+
+// Useful for newtype error wrappers
+```
+
+---
+
+## Using anyhow
+
+### For Applications
+```rust
+use anyhow::{Context, Result, bail, ensure};
+
+fn process_file(path: &str) -> Result<Data> {
+    let content = std::fs::read_to_string(path)
+        .context("failed to read config file")?;
+
+    ensure!(!content.is_empty(), "config file is empty");
+
+    let data: Data = serde_json::from_str(&content)
+        .context("failed to parse JSON")?;
+
+    if data.version < 1 {
+        bail!("unsupported config version: {}", data.version);
+    }
+
+    Ok(data)
+}
+
+fn main() -> Result<()> {
+    let data = process_file("config.json")
+        .context("failed to load configuration")?;
+    Ok(())
+}
+```
+
+### Error Chain
+```rust
+use anyhow::{Context, Result};
+
+fn deep_function() -> Result<()> {
+    std::fs::read_to_string("missing.txt")
+        .context("failed to read file")?;
+    Ok(())
+}
+
+fn middle_function() -> Result<()> {
+    deep_function()
+        .context("failed in deep function")?;
+    Ok(())
+}
+
+fn top_function() -> Result<()> {
+    middle_function()
+        .context("failed in middle function")?;
+    Ok(())
+}
+
+// Error output shows full chain:
+// Error: failed in middle function
+// Caused by:
+//     0: failed in deep function
+//     1: failed to read file
+//     2: No such file or directory (os error 2)
+```
+
+---
+
+## Option Handling
+
+### Converting Option to Result
+```rust
+fn find_user(id: u32) -> Option<User> { ... }
+
+// Using ok_or for static error
+fn get_user(id: u32) -> Result<User, &'static str> {
+    find_user(id).ok_or("user not found")
+}
+
+// Using ok_or_else for dynamic error
+fn get_user(id: u32) -> Result<User, String> {
+    find_user(id).ok_or_else(|| format!("user {} not found", id))
+}
+```
+
+### Chaining Options
+```rust
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()?
+        .nested
+        .as_ref()?
+        .value
+        .as_deref()
+}
+
+// Equivalent with and_then
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()
+        .and_then(|c| c.nested.as_ref())
+        .and_then(|n| n.value.as_deref())
+}
+```
+
+---
+
+## Pattern: Result Combinators
+
+### map and map_err
+```rust
+fn parse_port(s: &str) -> Result<u16, ParseError> {
+    s.parse::<u16>()
+        .map_err(|e| ParseError::InvalidPort(e))
+}
+
+fn get_url(config: &Config) -> Result<String, Error> {
+    config.url()
+        .map(|u| format!("https://{}", u))
+}
+```
+
+### and_then (flatMap)
+```rust
+fn validate_and_save(input: &str) -> Result<(), Error> {
+    validate(input)
+        .and_then(|valid| save(valid))
+        .and_then(|saved| notify(saved))
+}
+```
+
+### unwrap_or and unwrap_or_else
+```rust
+// Default value
+let port = config.port().unwrap_or(8080);
+
+// Computed default
+let port = config.port().unwrap_or_else(|| find_free_port());
+
+// Default for Result
+let data = load_data().unwrap_or_default();
+```
+
+---
+
+## Pattern: Early Return vs Combinators
+
+### Early Return Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    let step1 = validate(input)?;
+    if !step1.is_valid {
+        return Err(Error::Invalid);
+    }
+
+    let step2 = transform(step1)?;
+    let step3 = save(step2)?;
+
+    Ok(step3)
+}
+```
+
+### Combinator Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    validate(input)
+        .and_then(|s| {
+            if s.is_valid {
+                Ok(s)
+            } else {
+                Err(Error::Invalid)
+            }
+        })
+        .and_then(transform)
+        .and_then(save)
+}
+```
+
+### When to Use Which
+
+| Style | Best For |
+|-------|----------|
+| Early return (`?`) | Most cases, clearer flow |
+| Combinators | Functional pipelines, one-liners |
+| Match | Complex branching on errors |
+
+---
+
+## Panic vs Result
+
+### When to Panic
+```rust
+// 1. Unrecoverable programmer error
+fn get_config() -> &'static Config {
+    CONFIG.get().expect("config must be initialized")
+}
+
+// 2. In tests
+#[test]
+fn test_parsing() {
+    let result = parse("valid").unwrap();  // OK in tests
+    assert_eq!(result, expected);
+}
+
+// 3. Prototype/examples
+fn main() {
+    let data = load().unwrap();  // OK for quick examples
+}
+```
+
+### When to Return Result
+```rust
+// 1. Any I/O operation
+fn read_file(path: &str) -> Result<String, io::Error>
+
+// 2. User input validation
+fn parse_port(s: &str) -> Result<u16, ParseError>
+
+// 3. Network operations
+async fn fetch(url: &str) -> Result<Response, Error>
+
+// 4. Anything that can fail at runtime
+fn connect(addr: &str) -> Result<Connection, Error>
+```
+
+---
+
+## Error Context Best Practices
+
+### Add Context at Boundaries
+```rust
+fn load_user_config(user_id: u64) -> Result<Config, Error> {
+    let path = format!("/home/{}/config.toml", user_id);
+
+    std::fs::read_to_string(&path)
+        .context(format!("failed to read config for user {}", user_id))?
+        // NOT: .context("failed to read file")  // too generic
+
+    // ...
+}
+```
+
+### Include Relevant Data
+```rust
+// Good: includes the problematic value
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context(format!("invalid age value: '{}'", s))
+}
+
+// Bad: no context about what failed
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context("parse error")
+}
+```

--- a/.cursor/skills/rust-m07-concurrency/SKILL.md
+++ b/.cursor/skills/rust-m07-concurrency/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: m07-concurrency
+description: "CRITICAL: Use for concurrency/async. Triggers: E0277 Send Sync, cannot be sent between threads, thread, spawn, channel, mpsc, Mutex, RwLock, Atomic, async, await, Future, tokio, deadlock, race condition, 并发, 线程, 异步, 死锁"
+user-invocable: false
+---
+
+# Concurrency
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this CPU-bound or I/O-bound, and what's the sharing model?**
+
+Before choosing concurrency primitives:
+- What's the workload type?
+- What data needs to be shared?
+- What's the thread safety requirement?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0277 Send | "Add Send bound" | Should this type cross threads? |
+| E0277 Sync | "Wrap in Mutex" | Is shared access really needed? |
+| Future not Send | "Use spawn_local" | Is async the right choice? |
+| Deadlock | "Reorder locks" | Is the locking design correct? |
+
+---
+
+## Thinking Prompt
+
+Before adding concurrency:
+
+1. **What's the workload?**
+   - CPU-bound → threads (std::thread, rayon)
+   - I/O-bound → async (tokio, async-std)
+   - Mixed → hybrid approach
+
+2. **What's the sharing model?**
+   - No sharing → message passing (channels)
+   - Immutable sharing → Arc<T>
+   - Mutable sharing → Arc<Mutex<T>> or Arc<RwLock<T>>
+
+3. **What are the Send/Sync requirements?**
+   - Cross-thread ownership → Send
+   - Cross-thread references → Sync
+   - Single-thread async → spawn_local
+
+---
+
+## Trace Up ↑ (MANDATORY)
+
+**CRITICAL**: Don't just fix the error. Trace UP to find domain constraints.
+
+### Domain Detection Table
+
+| Context Keywords | Load Domain Skill | Key Constraint |
+|-----------------|-------------------|----------------|
+| Web API, HTTP, axum, actix, handler | **domain-web** | Handlers run on any thread |
+| 交易, 支付, trading, payment | **domain-fintech** | Audit + thread safety |
+| gRPC, kubernetes, microservice | **domain-cloud-native** | Distributed tracing |
+| CLI, terminal, clap | **domain-cli** | Usually single-thread OK |
+
+### Example: Web API + Rc Error
+
+```
+"Rc cannot be sent between threads" in Web API context
+    ↑ DETECT: "Web API" → Load domain-web
+    ↑ FIND: domain-web says "Shared state must be thread-safe"
+    ↑ FIND: domain-web says "Rc in state" is Common Mistake
+    ↓ DESIGN: Use Arc<T> with State extractor
+    ↓ IMPL: axum::extract::State<Arc<AppConfig>>
+```
+
+### Generic Trace
+
+```
+"Send not satisfied for my type"
+    ↑ Ask: What domain is this? Load domain-* skill
+    ↑ Ask: Does this type need to cross thread boundaries?
+    ↑ Check: m09-domain (is the data model correct?)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Send/Sync in Web | **domain-web** | What's the state management pattern? |
+| Send/Sync in CLI | **domain-cli** | Is multi-thread really needed? |
+| Mutex vs channels | m09-domain | Shared state or message passing? |
+| Async vs threads | m10-performance | What's the workload profile? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need parallelism for CPU work"
+    ↓ Use: std::thread or rayon
+
+"Need concurrency for I/O"
+    ↓ Use: async/await with tokio
+
+"Need to share immutable data across threads"
+    ↓ Use: Arc<T>
+
+"Need to share mutable data across threads"
+    ↓ Use: Arc<Mutex<T>> or Arc<RwLock<T>>
+    ↓ Or: channels for message passing
+
+"Need simple atomic operations"
+    ↓ Use: AtomicBool, AtomicUsize, etc.
+```
+
+---
+
+## Send/Sync Markers
+
+| Marker | Meaning | Example |
+|--------|---------|---------|
+| `Send` | Can transfer ownership between threads | Most types |
+| `Sync` | Can share references between threads | `Arc<T>` |
+| `!Send` | Must stay on one thread | `Rc<T>` |
+| `!Sync` | No shared refs across threads | `RefCell<T>` |
+
+## Quick Reference
+
+| Pattern | Thread-Safe | Blocking | Use When |
+|---------|-------------|----------|----------|
+| `std::thread` | Yes | Yes | CPU-bound parallelism |
+| `async/await` | Yes | No | I/O-bound concurrency |
+| `Mutex<T>` | Yes | Yes | Shared mutable state |
+| `RwLock<T>` | Yes | Yes | Read-heavy shared state |
+| `mpsc::channel` | Yes | Optional | Message passing |
+| `Arc<Mutex<T>>` | Yes | Yes | Shared mutable across threads |
+
+## Decision Flowchart
+
+```
+What type of work?
+├─ CPU-bound → std::thread or rayon
+├─ I/O-bound → async/await
+└─ Mixed → hybrid (spawn_blocking)
+
+Need to share data?
+├─ No → message passing (channels)
+├─ Immutable → Arc<T>
+└─ Mutable →
+   ├─ Read-heavy → Arc<RwLock<T>>
+   └─ Write-heavy → Arc<Mutex<T>>
+   └─ Simple counter → AtomicUsize
+
+Async context?
+├─ Type is Send → tokio::spawn
+├─ Type is !Send → spawn_local
+└─ Blocking code → spawn_blocking
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| E0277 `Send` not satisfied | Non-Send in async | Use Arc or spawn_local |
+| E0277 `Sync` not satisfied | Non-Sync shared | Wrap with Mutex |
+| Deadlock | Lock ordering | Consistent lock order |
+| `future is not Send` | Non-Send across await | Drop before await |
+| `MutexGuard` across await | Guard held during suspend | Scope guard properly |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Arc<Mutex<T>> everywhere | Contention, complexity | Message passing |
+| thread::sleep in async | Blocks executor | tokio::time::sleep |
+| Holding locks across await | Blocks other tasks | Scope locks tightly |
+| Ignoring deadlock risk | Hard to debug | Lock ordering, try_lock |
+
+---
+
+## Async-Specific Patterns
+
+### Avoid MutexGuard Across Await
+
+```rust
+// Bad: guard held across await
+let guard = mutex.lock().await;
+do_async().await;  // guard still held!
+
+// Good: scope the lock
+{
+    let guard = mutex.lock().await;
+    // use guard
+}  // guard dropped
+do_async().await;
+```
+
+### Non-Send Types in Async
+
+```rust
+// Rc is !Send, can't cross await in spawned task
+// Option 1: use Arc instead
+// Option 2: use spawn_local (single-thread runtime)
+// Option 3: ensure Rc is dropped before .await
+```
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Smart pointer choice | m02-resource |
+| Interior mutability | m03-mutability |
+| Performance tuning | m10-performance |
+| Domain concurrency needs | domain-* |

--- a/.cursor/skills/rust-m07-concurrency/UPSTREAM.md
+++ b/.cursor/skills/rust-m07-concurrency/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/ZhangHanDong/rust-skills
+- Path: `skills/m07-concurrency`
+- Commit: `37e050f490a731445eb17d339f7e95878be71d70`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-m07-concurrency/comparison.md
+++ b/.cursor/skills/rust-m07-concurrency/comparison.md
@@ -1,0 +1,312 @@
+# Concurrency: Comparison with Other Languages
+
+## Rust vs Go
+
+### Concurrency Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Model | Ownership + Send/Sync | CSP (Communicating Sequential Processes) |
+| Primitives | Arc, Mutex, channels | goroutines, channels |
+| Safety | Compile-time | Runtime (race detector) |
+| Async | async/await + runtime | Built-in scheduler |
+
+### Goroutines vs Rust Tasks
+
+```rust
+// Rust: explicit about thread safety
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+let data = Arc::new(Mutex::new(vec![]));
+let data_clone = Arc::clone(&data);
+
+tokio::spawn(async move {
+    let mut guard = data_clone.lock().await;
+    guard.push(1);  // Safe: Mutex protects access
+});
+
+// Go: implicit sharing (potential race)
+// data := []int{}
+// go func() {
+//     data = append(data, 1)  // RACE CONDITION!
+// }()
+```
+
+### Channel Comparison
+
+```rust
+// Rust: typed channels with ownership
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<String>(100);
+
+tokio::spawn(async move {
+    tx.send("hello".to_string()).await.unwrap();
+    // tx is moved, can't be used elsewhere
+});
+
+// Go: channels are more flexible but less safe
+// ch := make(chan string, 100)
+// go func() {
+//     ch <- "hello"
+//     // ch can still be used anywhere
+// }()
+```
+
+---
+
+## Rust vs Java
+
+### Thread Safety Model
+
+| Aspect | Rust | Java |
+|--------|------|------|
+| Safety | Compile-time (Send/Sync) | Runtime (synchronized, volatile) |
+| Null | No null (Option) | NullPointerException risk |
+| Locks | RAII (drop releases) | try-finally or try-with-resources |
+| Memory | No GC | GC with stop-the-world |
+
+### Synchronization Comparison
+
+```rust
+// Rust: lock is tied to data
+use std::sync::Mutex;
+
+let data = Mutex::new(vec![1, 2, 3]);
+{
+    let mut guard = data.lock().unwrap();
+    guard.push(4);
+}  // lock released automatically
+
+// Java: lock and data are separate
+// List<Integer> data = new ArrayList<>();
+// synchronized(data) {
+//     data.add(4);
+// }  // easy to forget synchronization elsewhere
+```
+
+### Thread Pool Comparison
+
+```rust
+// Rust: rayon for data parallelism
+use rayon::prelude::*;
+
+let sum: i32 = (0..1000)
+    .into_par_iter()
+    .map(|x| x * x)
+    .sum();
+
+// Java: Stream API
+// int sum = IntStream.range(0, 1000)
+//     .parallel()
+//     .map(x -> x * x)
+//     .sum();
+```
+
+---
+
+## Rust vs C++
+
+### Safety Guarantees
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Data races | Prevented at compile-time | Undefined behavior |
+| Deadlocks | Not prevented (same as C++) | Not prevented |
+| Thread safety | Send/Sync traits | Convention only |
+| Memory ordering | Explicit Ordering enum | memory_order enum |
+
+### Atomic Comparison
+
+```rust
+// Rust: clear memory ordering
+use std::sync::atomic::{AtomicI32, Ordering};
+
+let counter = AtomicI32::new(0);
+counter.fetch_add(1, Ordering::SeqCst);
+let value = counter.load(Ordering::Acquire);
+
+// C++: similar but without safety
+// std::atomic<int> counter{0};
+// counter.fetch_add(1, std::memory_order_seq_cst);
+// int value = counter.load(std::memory_order_acquire);
+```
+
+### Mutex Comparison
+
+```rust
+// Rust: data protected by Mutex
+use std::sync::Mutex;
+
+struct SafeCounter {
+    count: Mutex<i32>,  // Mutex contains the data
+}
+
+impl SafeCounter {
+    fn increment(&self) {
+        *self.count.lock().unwrap() += 1;
+    }
+}
+
+// C++: mutex separate from data (error-prone)
+// class Counter {
+//     std::mutex mtx;
+//     int count;  // NOT protected by type system
+// public:
+//     void increment() {
+//         std::lock_guard<std::mutex> lock(mtx);
+//         count++;
+//     }
+//     void unsafe_increment() {
+//         count++;  // Compiles! But wrong.
+//     }
+// };
+```
+
+---
+
+## Async Models Comparison
+
+| Language | Model | Runtime |
+|----------|-------|---------|
+| Rust | async/await, zero-cost | tokio, async-std (bring your own) |
+| Go | goroutines | Built-in scheduler |
+| JavaScript | async/await, Promises | Event loop (single-threaded) |
+| Python | async/await | asyncio (single-threaded) |
+| Java | CompletableFuture, Virtual Threads | ForkJoinPool, Loom |
+
+### Rust vs JavaScript Async
+
+```rust
+// Rust: async requires explicit runtime, can use multiple threads
+#[tokio::main]
+async fn main() {
+    let results = tokio::join!(
+        fetch("url1"),  // runs concurrently
+        fetch("url2"),
+    );
+}
+
+// JavaScript: single-threaded event loop
+// async function main() {
+//     const results = await Promise.all([
+//         fetch("url1"),
+//         fetch("url2"),
+//     ]);
+// }
+```
+
+### Rust vs Python Async
+
+```rust
+// Rust: true parallelism possible
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| tokio::spawn(fetch(url)))  // spawns on thread pool
+        .collect();
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
+// Python: asyncio is single-threaded (use ProcessPoolExecutor for CPU)
+# async def main():
+#     tasks = [asyncio.create_task(fetch(url)) for url in urls]
+#     await asyncio.gather(*tasks)  # all on same thread
+```
+
+---
+
+## Send and Sync: Rust's Unique Feature
+
+No other mainstream language has compile-time thread safety markers:
+
+| Trait | Meaning | Auto-impl |
+|-------|---------|-----------|
+| `Send` | Safe to transfer between threads | Most types |
+| `Sync` | Safe to share `&T` between threads | Types with thread-safe `&` |
+| `!Send` | Must stay on one thread | Rc, raw pointers |
+| `!Sync` | References can't be shared | RefCell, Cell |
+
+### Why This Matters
+
+```rust
+// Rust PREVENTS this at compile time:
+use std::rc::Rc;
+
+let rc = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", rc);  // ERROR: Rc is not Send
+});
+
+// In other languages, this would be a runtime bug:
+// - Go: race detector might catch it
+// - Java: undefined behavior
+// - Python: GIL usually saves you
+// - C++: undefined behavior
+```
+
+---
+
+## Performance Characteristics
+
+| Aspect | Rust | Go | Java | C++ |
+|--------|------|-----|------|-----|
+| Thread overhead | System threads or M:N | M:N (goroutines) | System or virtual | System threads |
+| Context switch | OS-level or cooperative | Cheap (goroutines) | OS-level | OS-level |
+| Memory | Predictable (no GC) | GC pauses | GC pauses | Predictable |
+| Async overhead | Zero-cost futures | Runtime overhead | Boxing overhead | Depends |
+
+### When to Use What
+
+| Scenario | Best Choice |
+|----------|-------------|
+| CPU-bound parallelism | Rust (rayon), C++ |
+| I/O-bound concurrency | Rust (tokio), Go, Node.js |
+| Low latency required | Rust, C++ |
+| Rapid development | Go, Python |
+| Complex concurrent state | Rust (compile-time safety) |
+
+---
+
+## Mental Model Shifts
+
+### From Go
+
+```
+Before: "Just use goroutines and channels"
+After:  "Explicitly declare what can be shared and how"
+```
+
+Key shifts:
+- `Arc<Mutex<T>>` instead of implicit sharing
+- Compiler enforces thread safety
+- Async needs explicit runtime
+
+### From Java
+
+```
+Before: "synchronized everywhere, hope for the best"
+After:  "Types encode thread safety, compiler enforces"
+```
+
+Key shifts:
+- No need for synchronized keyword
+- Mutex contains data, not separate
+- No GC pauses in critical sections
+
+### From C++
+
+```
+Before: "Be careful, read the docs, use sanitizers"
+After:  "Compiler catches data races, trust the type system"
+```
+
+Key shifts:
+- Send/Sync replace convention
+- RAII locks are mandatory, not optional
+- Much harder to write incorrect concurrent code

--- a/.cursor/skills/rust-m07-concurrency/examples/thread-patterns.md
+++ b/.cursor/skills/rust-m07-concurrency/examples/thread-patterns.md
@@ -1,0 +1,396 @@
+# Thread-Based Concurrency Patterns
+
+## Thread Spawning Best Practices
+
+### Basic Thread Spawn
+```rust
+use std::thread;
+
+fn main() {
+    let handle = thread::spawn(|| {
+        println!("Hello from thread!");
+        42  // return value
+    });
+
+    let result = handle.join().unwrap();
+    println!("Thread returned: {}", result);
+}
+```
+
+### Named Threads for Debugging
+```rust
+use std::thread;
+
+let builder = thread::Builder::new()
+    .name("worker-1".to_string())
+    .stack_size(32 * 1024);  // 32KB stack
+
+let handle = builder.spawn(|| {
+    println!("Thread name: {:?}", thread::current().name());
+}).unwrap();
+```
+
+### Scoped Threads (No 'static Required)
+```rust
+use std::thread;
+
+fn process_data(data: &[u32]) -> Vec<u32> {
+    thread::scope(|s| {
+        let handles: Vec<_> = data
+            .chunks(2)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk.iter().map(|x| x * 2).collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect()
+    })
+}
+
+fn main() {
+    let data = vec![1, 2, 3, 4, 5, 6];
+    let result = process_data(&data);  // No 'static needed!
+    println!("{:?}", result);
+}
+```
+
+---
+
+## Shared State Patterns
+
+### Arc + Mutex (Read-Write)
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+fn shared_counter() {
+    let counter = Arc::new(Mutex::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        let handle = thread::spawn(move || {
+            let mut num = counter.lock().unwrap();
+            *num += 1;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", *counter.lock().unwrap());
+}
+```
+
+### Arc + RwLock (Read-Heavy)
+```rust
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+fn read_heavy_cache() {
+    let cache = Arc::new(RwLock::new(vec![1, 2, 3]));
+
+    // Many readers
+    for i in 0..5 {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let data = cache.read().unwrap();
+            println!("Reader {}: {:?}", i, *data);
+        });
+    }
+
+    // Occasional writer
+    {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let mut data = cache.write().unwrap();
+            data.push(4);
+            println!("Writer: added element");
+        });
+    }
+}
+```
+
+### Atomic for Simple Types
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+fn atomic_counter() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            for _ in 0..1000 {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", counter.load(Ordering::SeqCst));
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC Channel
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn producer_consumer() {
+    let (tx, rx) = mpsc::channel();
+
+    // Multiple producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            for j in 0..5 {
+                tx.send(format!("msg {}-{}", i, j)).unwrap();
+            }
+        });
+    }
+    drop(tx);  // Drop original sender
+
+    // Single consumer
+    for received in rx {
+        println!("Got: {}", received);
+    }
+}
+```
+
+### Sync Channel (Bounded)
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn bounded_channel() {
+    let (tx, rx) = mpsc::sync_channel(2);  // buffer size 2
+
+    thread::spawn(move || {
+        for i in 0..5 {
+            println!("Sending {}", i);
+            tx.send(i).unwrap();  // blocks if buffer full
+            println!("Sent {}", i);
+        }
+    });
+
+    thread::sleep(std::time::Duration::from_millis(500));
+    for received in rx {
+        println!("Received: {}", received);
+        thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+```
+
+---
+
+## Thread Pool Patterns
+
+### Using rayon for Parallel Iteration
+```rust
+use rayon::prelude::*;
+
+fn parallel_map() {
+    let numbers: Vec<i32> = (0..1000).collect();
+
+    let squares: Vec<i32> = numbers
+        .par_iter()  // parallel iterator
+        .map(|x| x * x)
+        .collect();
+
+    println!("Processed {} items", squares.len());
+}
+
+fn parallel_filter_map() {
+    let data: Vec<String> = get_data();
+
+    let results: Vec<_> = data
+        .par_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| expensive_process(s))
+        .collect();
+}
+```
+
+### Custom Thread Pool with crossbeam
+```rust
+use crossbeam::channel;
+use std::thread;
+
+fn custom_pool(num_workers: usize) {
+    let (tx, rx) = channel::bounded::<Box<dyn FnOnce() + Send>>(100);
+
+    // Spawn workers
+    let workers: Vec<_> = (0..num_workers)
+        .map(|_| {
+            let rx = rx.clone();
+            thread::spawn(move || {
+                while let Ok(task) = rx.recv() {
+                    task();
+                }
+            })
+        })
+        .collect();
+
+    // Submit tasks
+    for i in 0..100 {
+        tx.send(Box::new(move || {
+            println!("Processing task {}", i);
+        })).unwrap();
+    }
+
+    drop(tx);  // Close channel
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+}
+```
+
+---
+
+## Synchronization Primitives
+
+### Barrier (Wait for All)
+```rust
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn barrier_example() {
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = vec![];
+
+    for i in 0..3 {
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            println!("Thread {} starting", i);
+            thread::sleep(std::time::Duration::from_millis(i as u64 * 100));
+
+            barrier.wait();  // All threads wait here
+
+            println!("Thread {} after barrier", i);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+```
+
+### Condvar (Condition Variable)
+```rust
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+
+fn condvar_example() {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_clone = Arc::clone(&pair);
+
+    // Waiter thread
+    let waiter = thread::spawn(move || {
+        let (lock, cvar) = &*pair_clone;
+        let mut started = lock.lock().unwrap();
+        while !*started {
+            started = cvar.wait(started).unwrap();
+        }
+        println!("Waiter: condition met!");
+    });
+
+    // Notifier
+    thread::sleep(std::time::Duration::from_millis(100));
+    let (lock, cvar) = &*pair;
+    {
+        let mut started = lock.lock().unwrap();
+        *started = true;
+    }
+    cvar.notify_one();
+
+    waiter.join().unwrap();
+}
+```
+
+### Once (One-Time Initialization)
+```rust
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+static mut CONFIG: Option<Config> = None;
+
+fn get_config() -> &'static Config {
+    INIT.call_once(|| {
+        unsafe {
+            CONFIG = Some(load_config());
+        }
+    });
+    unsafe { CONFIG.as_ref().unwrap() }
+}
+
+// Better: use once_cell or lazy_static
+use once_cell::sync::Lazy;
+
+static CONFIG: Lazy<Config> = Lazy::new(|| {
+    load_config()
+});
+```
+
+---
+
+## Error Handling in Threads
+
+### Handling Panics
+```rust
+use std::thread;
+
+fn handle_panic() {
+    let handle = thread::spawn(|| {
+        panic!("Thread panicked!");
+    });
+
+    match handle.join() {
+        Ok(_) => println!("Thread completed successfully"),
+        Err(e) => {
+            if let Some(s) = e.downcast_ref::<&str>() {
+                println!("Thread panicked with: {}", s);
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                println!("Thread panicked with: {}", s);
+            } else {
+                println!("Thread panicked with unknown error");
+            }
+        }
+    }
+}
+```
+
+### Catching Panics
+```rust
+use std::panic;
+
+fn catch_panic() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(value) => println!("Success: {:?}", value),
+        Err(_) => println!("Operation panicked, continuing..."),
+    }
+}
+```

--- a/.cursor/skills/rust-m07-concurrency/patterns/async-patterns.md
+++ b/.cursor/skills/rust-m07-concurrency/patterns/async-patterns.md
@@ -1,0 +1,409 @@
+# Async Patterns in Rust
+
+## Task Spawning
+
+### Basic Spawn
+```rust
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    // Spawn a task that runs concurrently
+    let handle = task::spawn(async {
+        expensive_computation().await
+    });
+
+    // Do other work while task runs
+    other_work().await;
+
+    // Wait for result
+    let result = handle.await.unwrap();
+}
+```
+
+### Spawn with Shared State
+```rust
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+async fn process_with_state() {
+    let state = Arc::new(Mutex::new(vec![]));
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let state = Arc::clone(&state);
+            tokio::spawn(async move {
+                let mut guard = state.lock().await;
+                guard.push(i);
+            })
+        })
+        .collect();
+
+    // Wait for all tasks
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Select Pattern
+
+### Racing Multiple Futures
+```rust
+use tokio::select;
+use tokio::time::{sleep, Duration};
+
+async fn first_response() {
+    select! {
+        result = fetch_from_server_a() => {
+            println!("A responded first: {:?}", result);
+        }
+        result = fetch_from_server_b() => {
+            println!("B responded first: {:?}", result);
+        }
+    }
+}
+```
+
+### Select with Timeout
+```rust
+use tokio::time::timeout;
+
+async fn with_timeout() -> Result<Data, Error> {
+    select! {
+        result = fetch_data() => result,
+        _ = sleep(Duration::from_secs(5)) => {
+            Err(Error::Timeout)
+        }
+    }
+}
+
+// Or use timeout directly
+async fn with_timeout2() -> Result<Data, Error> {
+    timeout(Duration::from_secs(5), fetch_data())
+        .await
+        .map_err(|_| Error::Timeout)?
+}
+```
+
+### Select with Channel
+```rust
+use tokio::sync::mpsc;
+
+async fn process_messages(mut rx: mpsc::Receiver<Message>) {
+    loop {
+        select! {
+            Some(msg) = rx.recv() => {
+                handle_message(msg).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC (Multi-Producer, Single-Consumer)
+```rust
+use tokio::sync::mpsc;
+
+async fn producer_consumer() {
+    let (tx, mut rx) = mpsc::channel(100);
+
+    // Spawn producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            tx.send(format!("Message from {}", i)).await.unwrap();
+        });
+    }
+
+    // Drop original sender so channel closes
+    drop(tx);
+
+    // Consume
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+}
+```
+
+### Oneshot (Single-Shot Response)
+```rust
+use tokio::sync::oneshot;
+
+async fn request_response() {
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let result = compute_something().await;
+        tx.send(result).unwrap();
+    });
+
+    // Wait for response
+    let response = rx.await.unwrap();
+}
+```
+
+### Broadcast (Multi-Consumer)
+```rust
+use tokio::sync::broadcast;
+
+async fn pub_sub() {
+    let (tx, _) = broadcast::channel(16);
+
+    // Subscribe multiple consumers
+    let mut rx1 = tx.subscribe();
+    let mut rx2 = tx.subscribe();
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx1.recv().await {
+            println!("Consumer 1: {}", msg);
+        }
+    });
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx2.recv().await {
+            println!("Consumer 2: {}", msg);
+        }
+    });
+
+    // Publish
+    tx.send("Hello").unwrap();
+}
+```
+
+### Watch (Single Latest Value)
+```rust
+use tokio::sync::watch;
+
+async fn config_updates() {
+    let (tx, mut rx) = watch::channel(Config::default());
+
+    // Consumer watches for changes
+    tokio::spawn(async move {
+        while rx.changed().await.is_ok() {
+            let config = rx.borrow();
+            apply_config(&config);
+        }
+    });
+
+    // Update config
+    tx.send(Config::new()).unwrap();
+}
+```
+
+---
+
+## Structured Concurrency
+
+### JoinSet for Task Groups
+```rust
+use tokio::task::JoinSet;
+
+async fn parallel_fetch(urls: Vec<String>) -> Vec<Result<Response, Error>> {
+    let mut set = JoinSet::new();
+
+    for url in urls {
+        set.spawn(async move {
+            fetch(&url).await
+        });
+    }
+
+    let mut results = vec![];
+    while let Some(res) = set.join_next().await {
+        results.push(res.unwrap());
+    }
+    results
+}
+```
+
+### Scoped Tasks (no 'static)
+```rust
+// Using tokio-scoped or async-scoped crate
+use async_scoped::TokioScope;
+
+async fn scoped_example(data: &[u32]) {
+    let results = TokioScope::scope_and_block(|scope| {
+        for item in data {
+            scope.spawn(async move {
+                process(item).await
+            });
+        }
+    });
+}
+```
+
+---
+
+## Cancellation Patterns
+
+### Using CancellationToken
+```rust
+use tokio_util::sync::CancellationToken;
+
+async fn cancellable_task(token: CancellationToken) {
+    loop {
+        select! {
+            _ = token.cancelled() => {
+                println!("Task cancelled");
+                break;
+            }
+            _ = do_work() => {
+                // Continue working
+            }
+        }
+    }
+}
+
+async fn main_with_cancellation() {
+    let token = CancellationToken::new();
+    let task_token = token.clone();
+
+    let handle = tokio::spawn(cancellable_task(task_token));
+
+    // Cancel after some condition
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    token.cancel();
+
+    handle.await.unwrap();
+}
+```
+
+### Graceful Shutdown
+```rust
+async fn serve_with_shutdown(shutdown: impl Future) {
+    let server = TcpListener::bind("0.0.0.0:8080").await.unwrap();
+
+    loop {
+        select! {
+            Ok((socket, _)) = server.accept() => {
+                tokio::spawn(handle_connection(socket));
+            }
+            _ = &mut shutdown => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await.unwrap();
+    };
+
+    serve_with_shutdown(ctrl_c).await;
+}
+```
+
+---
+
+## Backpressure Patterns
+
+### Bounded Channels
+```rust
+use tokio::sync::mpsc;
+
+async fn with_backpressure() {
+    // Buffer of 10 - producers will wait if full
+    let (tx, mut rx) = mpsc::channel(10);
+
+    let producer = tokio::spawn(async move {
+        for i in 0..1000 {
+            // This will wait if channel is full
+            tx.send(i).await.unwrap();
+        }
+    });
+
+    let consumer = tokio::spawn(async move {
+        while let Some(item) = rx.recv().await {
+            // Slow consumer
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            process(item);
+        }
+    });
+
+    let _ = tokio::join!(producer, consumer);
+}
+```
+
+### Semaphore for Rate Limiting
+```rust
+use tokio::sync::Semaphore;
+use std::sync::Arc;
+
+async fn rate_limited_requests(urls: Vec<String>) {
+    let semaphore = Arc::new(Semaphore::new(10));  // max 10 concurrent
+
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| {
+            let sem = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
+                fetch(&url).await
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Error Handling in Async
+
+### Propagating Errors
+```rust
+async fn fetch_and_parse(url: &str) -> Result<Data, Error> {
+    let response = fetch(url).await?;
+    let data = parse(response).await?;
+    Ok(data)
+}
+```
+
+### Handling Task Panics
+```rust
+async fn robust_spawn() {
+    let handle = tokio::spawn(async {
+        risky_operation().await
+    });
+
+    match handle.await {
+        Ok(result) => println!("Success: {:?}", result),
+        Err(e) if e.is_panic() => {
+            println!("Task panicked: {:?}", e);
+        }
+        Err(e) => {
+            println!("Task cancelled: {:?}", e);
+        }
+    }
+}
+```
+
+### Try-Join for Multiple Results
+```rust
+use tokio::try_join;
+
+async fn fetch_all() -> Result<(A, B, C), Error> {
+    // All must succeed, or first error returned
+    try_join!(
+        fetch_a(),
+        fetch_b(),
+        fetch_c(),
+    )
+}
+```

--- a/.cursor/skills/rust-m07-concurrency/patterns/common-errors.md
+++ b/.cursor/skills/rust-m07-concurrency/patterns/common-errors.md
@@ -1,0 +1,331 @@
+# Common Concurrency Errors & Fixes
+
+## E0277: Cannot Send Between Threads
+
+### Error Pattern
+```rust
+use std::rc::Rc;
+
+let data = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", data);  // ERROR: Rc<i32> cannot be sent between threads
+});
+```
+
+### Fix Options
+
+**Option 1: Use Arc instead**
+```rust
+use std::sync::Arc;
+
+let data = Arc::new(42);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{}", data_clone);  // OK: Arc is Send
+});
+```
+
+**Option 2: Move owned data**
+```rust
+let data = 42;  // i32 is Copy and Send
+std::thread::spawn(move || {
+    println!("{}", data);  // OK
+});
+```
+
+---
+
+## E0277: Cannot Share Between Threads (Not Sync)
+
+### Error Pattern
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+
+let data = Arc::new(RefCell::new(42));
+// ERROR: RefCell is not Sync
+```
+
+### Fix Options
+
+**Option 1: Use Mutex for thread-safe interior mutability**
+```rust
+use std::sync::{Arc, Mutex};
+
+let data = Arc::new(Mutex::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let mut guard = data_clone.lock().unwrap();
+    *guard += 1;
+});
+```
+
+**Option 2: Use RwLock for read-heavy workloads**
+```rust
+use std::sync::{Arc, RwLock};
+
+let data = Arc::new(RwLock::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let guard = data_clone.read().unwrap();
+    println!("{}", *guard);
+});
+```
+
+---
+
+## Deadlock Patterns
+
+### Pattern 1: Lock Ordering Deadlock
+```rust
+// DANGER: potential deadlock
+use std::sync::{Arc, Mutex};
+
+let a = Arc::new(Mutex::new(1));
+let b = Arc::new(Mutex::new(2));
+
+// Thread 1: locks a then b
+let a1 = Arc::clone(&a);
+let b1 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();  // waits for b
+});
+
+// Thread 2: locks b then a (opposite order!)
+let a2 = Arc::clone(&a);
+let b2 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _b = b2.lock().unwrap();
+    let _a = a2.lock().unwrap();  // waits for a - DEADLOCK
+});
+```
+
+### Fix: Consistent Lock Ordering
+```rust
+// SAFE: always lock in same order (a before b)
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();
+});
+
+std::thread::spawn(move || {
+    let _a = a2.lock().unwrap();  // same order
+    let _b = b2.lock().unwrap();
+});
+```
+
+### Pattern 2: Self-Deadlock
+```rust
+// DANGER: locking same mutex twice
+let m = Mutex::new(42);
+let _g1 = m.lock().unwrap();
+let _g2 = m.lock().unwrap();  // DEADLOCK on std::Mutex
+
+// FIX: use parking_lot::ReentrantMutex if needed
+// or restructure code to avoid double locking
+```
+
+---
+
+## Mutex Guard Across Await
+
+### Error Pattern
+```rust
+use std::sync::Mutex;
+use tokio::time::sleep;
+
+async fn bad_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().unwrap();
+    sleep(Duration::from_secs(1)).await;  // WARNING: guard held across await
+    println!("{}", *guard);
+}
+```
+
+### Fix Options
+
+**Option 1: Scope the lock**
+```rust
+async fn good_async() {
+    let m = Mutex::new(42);
+    let value = {
+        let guard = m.lock().unwrap();
+        *guard  // copy value
+    };  // guard dropped here
+    sleep(Duration::from_secs(1)).await;
+    println!("{}", value);
+}
+```
+
+**Option 2: Use tokio::sync::Mutex**
+```rust
+use tokio::sync::Mutex;
+
+async fn good_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().await;  // async lock
+    sleep(Duration::from_secs(1)).await;  // OK with tokio::Mutex
+    println!("{}", *guard);
+}
+```
+
+---
+
+## Data Race Prevention
+
+### Pattern: Missing Synchronization
+```rust
+// This WON'T compile - Rust prevents data races
+use std::sync::Arc;
+
+let data = Arc::new(0);
+let d1 = Arc::clone(&data);
+let d2 = Arc::clone(&data);
+
+std::thread::spawn(move || {
+    // *d1 += 1;  // ERROR: cannot mutate through Arc
+});
+
+std::thread::spawn(move || {
+    // *d2 += 1;  // ERROR: cannot mutate through Arc
+});
+```
+
+### Fix: Add Synchronization
+```rust
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+// Option 1: Mutex
+let data = Arc::new(Mutex::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    *d1.lock().unwrap() += 1;
+});
+
+// Option 2: Atomic (for simple types)
+let data = Arc::new(AtomicI32::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    d1.fetch_add(1, Ordering::SeqCst);
+});
+```
+
+---
+
+## Channel Errors
+
+### Disconnected Channel
+```rust
+use std::sync::mpsc;
+
+let (tx, rx) = mpsc::channel();
+drop(tx);  // sender dropped
+match rx.recv() {
+    Ok(v) => println!("{}", v),
+    Err(_) => println!("channel disconnected"),  // this happens
+}
+```
+
+### Fix: Handle Disconnection
+```rust
+// Use try_recv for non-blocking
+loop {
+    match rx.try_recv() {
+        Ok(msg) => handle(msg),
+        Err(TryRecvError::Empty) => continue,
+        Err(TryRecvError::Disconnected) => break,
+    }
+}
+
+// Or iterate (stops on disconnect)
+for msg in rx {
+    handle(msg);
+}
+```
+
+---
+
+## Async Common Errors
+
+### Forgetting to Spawn
+```rust
+// WRONG: future not polled
+async fn fetch_data() -> Result<Data, Error> { ... }
+
+fn process() {
+    fetch_data();  // does nothing! returns Future that's dropped
+}
+
+// RIGHT: await or spawn
+async fn process() {
+    let data = fetch_data().await;  // awaited
+}
+
+fn process_sync() {
+    tokio::spawn(fetch_data());  // spawned
+}
+```
+
+### Blocking in Async Context
+```rust
+// WRONG: blocks the executor
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocks!
+    std::fs::read_to_string("file.txt").unwrap();  // blocks!
+}
+
+// RIGHT: use async versions
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::fs::read_to_string("file.txt").await.unwrap();
+}
+
+// Or spawn_blocking for CPU-bound work
+async fn compute() {
+    let result = tokio::task::spawn_blocking(|| {
+        heavy_computation()  // OK to block here
+    }).await.unwrap();
+}
+```
+
+---
+
+## Thread Panic Handling
+
+### Unhandled Panic
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+// Main thread continues, might miss the error
+handle.join().unwrap();  // panics here
+```
+
+### Proper Error Handling
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+match handle.join() {
+    Ok(result) => println!("Success: {:?}", result),
+    Err(e) => println!("Thread panicked: {:?}", e),
+}
+
+// For async: use catch_unwind
+use std::panic;
+
+async fn safe_task() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(v) => use_value(v),
+        Err(_) => log_error("task panicked"),
+    }
+}
+```

--- a/.cursor/skills/rust-router/SKILL.md
+++ b/.cursor/skills/rust-router/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: rust-router
+description: "CRITICAL: Use for ALL Rust questions including errors, design, and coding.
+HIGHEST PRIORITY for: 比较, 对比, compare, vs, versus, 区别, difference, 最佳实践, best practice,
+tokio vs, async-std vs, 比较 tokio, 比较 async,
+Triggers on: Rust, cargo, rustc, crate, Cargo.toml,
+意图分析, 问题分析, 语义分析, analyze intent, question analysis,
+compile error, borrow error, lifetime error, ownership error, type error, trait error,
+value moved, cannot borrow, does not live long enough, mismatched types, not satisfied,
+E0382, E0597, E0277, E0308, E0499, E0502, E0596,
+async, await, Send, Sync, tokio, concurrency, error handling,
+编译错误, compile error, 所有权, ownership, 借用, borrow, 生命周期, lifetime, 类型错误, type error,
+异步, async, 并发, concurrency, 错误处理, error handling,
+问题, problem, question, 怎么用, how to use, 如何, how to, 为什么, why,
+什么是, what is, 帮我写, help me write, 实现, implement, 解释, explain"
+globs: ["**/Cargo.toml", "**/*.rs"]
+---
+
+---
+
+# Rust Question Router
+
+> **Version:** 2.0.0 | **Last Updated:** 2025-01-22
+>
+> **v2.0:** Context optimized - detailed examples moved to sub-files
+
+## Meta-Cognition Framework
+
+### Core Principle
+
+**Don't answer directly. Trace through the cognitive layers first.**
+
+```
+Layer 3: Domain Constraints (WHY)
+├── Business rules, regulatory requirements
+├── domain-fintech, domain-web, domain-cli, etc.
+└── "Why is it designed this way?"
+
+Layer 2: Design Choices (WHAT)
+├── Architecture patterns, DDD concepts
+├── m09-m15 skills
+└── "What pattern should I use?"
+
+Layer 1: Language Mechanics (HOW)
+├── Ownership, borrowing, lifetimes, traits
+├── m01-m07 skills
+└── "How do I implement this in Rust?"
+```
+
+### Routing by Entry Point
+
+| User Signal | Entry Layer | Direction | First Skill |
+|-------------|-------------|-----------|-------------|
+| E0xxx error | Layer 1 | Trace UP ↑ | m01-m07 |
+| Compile error | Layer 1 | Trace UP ↑ | Error table below |
+| "How to design..." | Layer 2 | Check L3, then DOWN ↓ | m09-domain |
+| "Building [domain] app" | Layer 3 | Trace DOWN ↓ | domain-* |
+| "Best practice..." | Layer 2 | Both directions | m09-m15 |
+| Performance issue | Layer 1 → 2 | UP then DOWN | m10-performance |
+
+### CRITICAL: Dual-Skill Loading
+
+**When domain keywords are present, you MUST load BOTH skills:**
+
+| Domain Keywords | L1 Skill | L3 Skill |
+|-----------------|----------|----------|
+| Web API, HTTP, axum, handler | m07-concurrency | **domain-web** |
+| 交易, 支付, trading, payment | m01-ownership | **domain-fintech** |
+| CLI, terminal, clap | m07-concurrency | **domain-cli** |
+| kubernetes, grpc, microservice | m07-concurrency | **domain-cloud-native** |
+| embedded, no_std, MCU | m02-resource | **domain-embedded** |
+
+---
+
+## INSTRUCTIONS FOR CLAUDE
+
+### CRITICAL: Negotiation Protocol Trigger
+
+**BEFORE answering, check if negotiation is required:**
+
+| Query Contains | Action |
+|----------------|--------|
+| "比较", "对比", "compare", "vs", "versus" | **MUST use negotiation** |
+| "最佳实践", "best practice" | **MUST use negotiation** |
+| Domain + error (e.g., "交易系统 E0382") | **MUST use negotiation** |
+| Ambiguous scope (e.g., "tokio 性能") | **SHOULD use negotiation** |
+
+**When negotiation is required, include:**
+
+```markdown
+## Negotiation Analysis
+
+**Query Type:** [Comparative | Cross-domain | Synthesis | Ambiguous]
+**Negotiation:** Enabled
+
+### Source: [Agent/Skill Name]
+**Confidence:** HIGH | MEDIUM | LOW | UNCERTAIN
+**Gaps:** [What's missing]
+
+## Synthesized Answer
+[Answer]
+
+**Overall Confidence:** [Level]
+**Disclosed Gaps:** [Gaps user should know]
+```
+
+> **详细协议见:** `patterns/negotiation.md`
+
+---
+
+### Default Project Settings
+
+When creating new Rust projects or Cargo.toml files, ALWAYS use:
+
+```toml
+[package]
+edition = "2024"  # ALWAYS use latest stable edition
+rust-version = "1.85"
+
+[lints.rust]
+unsafe_code = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+```
+
+---
+
+## Layer 1 Skills (Language Mechanics)
+
+| Pattern | Route To |
+|---------|----------|
+| move, borrow, lifetime, E0382, E0597 | m01-ownership |
+| Box, Rc, Arc, RefCell, Cell | m02-resource |
+| mut, interior mutability, E0499, E0502, E0596 | m03-mutability |
+| generic, trait, inline, monomorphization | m04-zero-cost |
+| type state, phantom, newtype | m05-type-driven |
+| Result, Error, panic, ?, anyhow, thiserror | m06-error-handling |
+| Send, Sync, thread, async, channel | m07-concurrency |
+| unsafe, FFI, extern, raw pointer, transmute | **unsafe-checker** |
+
+## Layer 2 Skills (Design Choices)
+
+| Pattern | Route To |
+|---------|----------|
+| domain model, business logic | m09-domain |
+| performance, optimization, benchmark | m10-performance |
+| integration, interop, bindings | m11-ecosystem |
+| resource lifecycle, RAII, Drop | m12-lifecycle |
+| domain error, recovery strategy | m13-domain-error |
+| mental model, how to think | m14-mental-model |
+| anti-pattern, common mistake, pitfall | m15-anti-pattern |
+
+## Layer 3 Skills (Domain Constraints)
+
+| Domain Keywords | Route To |
+|-----------------|----------|
+| fintech, trading, decimal, currency | domain-fintech |
+| ml, tensor, model, inference | domain-ml |
+| kubernetes, docker, grpc, microservice | domain-cloud-native |
+| embedded, sensor, mqtt, iot | domain-iot |
+| web server, HTTP, REST, axum, actix | domain-web |
+| CLI, command line, clap, terminal | domain-cli |
+| no_std, microcontroller, firmware | domain-embedded |
+
+---
+
+## Error Code Routing
+
+| Error Code | Route To | Common Cause |
+|------------|----------|--------------|
+| E0382 | m01-ownership | Use of moved value |
+| E0597 | m01-ownership | Lifetime too short |
+| E0506 | m01-ownership | Cannot assign to borrowed |
+| E0507 | m01-ownership | Cannot move out of borrowed |
+| E0515 | m01-ownership | Return local reference |
+| E0716 | m01-ownership | Temporary value dropped |
+| E0106 | m01-ownership | Missing lifetime specifier |
+| E0596 | m03-mutability | Cannot borrow as mutable |
+| E0499 | m03-mutability | Multiple mutable borrows |
+| E0502 | m03-mutability | Borrow conflict |
+| E0277 | m04/m07 | Trait bound not satisfied |
+| E0308 | m04-zero-cost | Type mismatch |
+| E0599 | m04-zero-cost | No method found |
+| E0038 | m04-zero-cost | Trait not object-safe |
+| E0433 | m11-ecosystem | Cannot find crate/module |
+
+---
+
+## Functional Routing Table
+
+| Pattern | Route To | Action |
+|---------|----------|--------|
+| latest version, what's new | **rust-learner** | Use agents |
+| API, docs, documentation | **docs-researcher** | Use agent |
+| code style, naming, clippy | **coding-guidelines** | Read skill |
+| unsafe code, FFI | **unsafe-checker** | Read skill |
+| code review | **os-checker** | See `integrations/os-checker.md` |
+
+---
+
+## Priority Order
+
+1. **Identify cognitive layer** (L1/L2/L3)
+2. **Load entry skill** (m0x/m1x/domain)
+3. **Trace through layers** (UP or DOWN)
+4. **Cross-reference skills** as indicated in "Trace" sections
+5. **Answer with reasoning chain**
+
+### Keyword Conflict Resolution
+
+| Keyword | Resolution |
+|---------|------------|
+| `unsafe` | **unsafe-checker** (more specific than m11) |
+| `error` | **m06** for general, **m13** for domain-specific |
+| `RAII` | **m12** for design, **m01** for implementation |
+| `crate` | **rust-learner** for version, **m11** for integration |
+| `tokio` | **tokio-*** for API, **m07** for concepts |
+
+**Priority Hierarchy:**
+
+```
+1. Error codes (E0xxx) → Direct lookup, highest priority
+2. Negotiation triggers (compare, vs, best practice) → Enable negotiation
+3. Domain keywords + error → Load BOTH domain + error skills
+4. Specific crate keywords → Route to crate-specific skill if exists
+5. General concept keywords → Route to meta-question skill
+```
+
+---
+
+## Sub-Files Reference
+
+| File | Content |
+|------|---------|
+| `patterns/negotiation.md` | Negotiation protocol details |
+| `examples/workflow.md` | Workflow examples |
+| `integrations/os-checker.md` | OS-Checker integration |

--- a/.cursor/skills/rust-router/UPSTREAM.md
+++ b/.cursor/skills/rust-router/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/ZhangHanDong/rust-skills
+- Path: `skills/rust-router`
+- Commit: `37e050f490a731445eb17d339f7e95878be71d70`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/rust-router/examples/workflow.md
+++ b/.cursor/skills/rust-router/examples/workflow.md
@@ -1,0 +1,85 @@
+# Workflow Examples
+
+> rust-router 的工作流程示例
+
+## Example 1: Error Code with Domain Context
+
+```
+User: "Why am I getting E0382 in my trading system?"
+
+Analysis:
+1. Entry: Layer 1 (E0382 = ownership/move error)
+2. Load: m01-ownership skill
+3. Context: "trading system" → domain-fintech
+
+Trace UP ↑:
+- E0382 in trading context
+- Check domain-fintech: "immutable audit records"
+- Finding: Trading data should be shared, not moved
+
+Response:
+"E0382 indicates a value was moved when still needed.
+In a trading system (domain-fintech), transaction records
+should be immutable and shareable for audit purposes.
+
+Instead of cloning, consider:
+- Arc<TradeRecord> for shared immutable access
+- This aligns with financial audit requirements
+
+See: m01-ownership (Trace Up section),
+     domain-fintech (Audit Requirements)"
+```
+
+## Example 2: Design Question
+
+```
+User: "How should I handle user authentication?"
+
+1. Entry: Layer 2 (design question)
+2. Trace UP to Layer 3: domain-web constraints
+3. Load: domain-web skill (security, stateless HTTP)
+4. Trace DOWN: m06-error-handling, m07-concurrency
+5. Answer: JWT with proper error types, async handlers
+```
+
+## Example 3: Comparative Query
+
+```
+User: "Compare tokio and async-std"
+
+1. Detect: "compare" → Enable negotiation
+2. Load both runtime knowledge sources
+3. Assess confidence for each
+4. Synthesize with disclosed gaps
+5. Answer: Structured comparison table
+```
+
+## Example 4: Multi-Layer Trace
+
+```
+User: "My web API reports Rc cannot be sent between threads"
+
+1. Entry: Layer 1 (Send/Sync error)
+2. Load: m07-concurrency
+3. Detect: "web API" → domain-web
+4. Dual-skill loading:
+   - m07: Explain Send/Sync bounds
+   - domain-web: Web state management patterns
+5. Answer: Use Arc instead of Rc, or move to thread-local
+```
+
+## Example 5: Intent Analysis Request
+
+```
+User: "Analyze this question: How do I share state in actix-web?"
+
+Analysis Steps:
+1. Extract Keywords: share, state, actix-web
+2. Identify Entry Layer: Layer 1 (sharing = concurrency) + Layer 3 (actix-web = web)
+3. Map to Skills: m07-concurrency, domain-web
+4. Report:
+   - Layer 1: Concurrency (state sharing mechanisms)
+   - Layer 3: Web domain (HTTP handler patterns)
+   - Suggested trace: L1 → L3
+5. Invoke: m07-concurrency first, then domain-web
+```

--- a/.cursor/skills/rust-router/integrations/os-checker.md
+++ b/.cursor/skills/rust-router/integrations/os-checker.md
@@ -1,0 +1,56 @@
+# OS-Checker Integration
+
+> 代码审查和安全审计工具集成
+
+## Available Commands
+
+| Use Case | Command | Tools |
+|----------|---------|-------|
+| Daily check | `/rust-review` | clippy |
+| Security audit | `/audit security` | cargo audit, geiger |
+| Unsafe audit | `/audit safety` | miri, rudra |
+| Concurrency audit | `/audit concurrency` | lockbud |
+| Full audit | `/audit full` | all os-checker tools |
+
+## When to Suggest OS-Checker
+
+| User Intent | Suggest |
+|-------------|---------|
+| Code review request | `/rust-review` |
+| Security concerns | `/audit security` |
+| Unsafe code review | `/audit safety` |
+| Deadlock/race concerns | `/audit concurrency` |
+| Pre-release check | `/audit full` |
+
+## Tool Descriptions
+
+### clippy
+Standard Rust linter for code style and common mistakes.
+
+### cargo audit
+Security vulnerability scanner for dependencies.
+
+### geiger
+Counts unsafe code usage in dependencies.
+
+### miri
+Interprets MIR to detect undefined behavior.
+
+### rudra
+Memory safety bug detector.
+
+### lockbud
+Deadlock and concurrency bug detector.
+
+## Integration Flow
+
+```
+User: "Review my unsafe code"
+     │
+     ▼
+Router detects: unsafe + review
+     │
+     ├── Load: unsafe-checker skill (for manual review)
+     │
+     └── Suggest: `/audit safety` (for automated check)
+```

--- a/.cursor/skills/rust-router/patterns/negotiation.md
+++ b/.cursor/skills/rust-router/patterns/negotiation.md
@@ -1,0 +1,154 @@
+# Negotiation Protocol
+
+> 比较查询和跨领域问题的处理协议
+
+## When to Enable Negotiation
+
+For complex queries requiring structured agent responses, enable negotiation mode.
+
+| Query Pattern | Enable Negotiation | Reason |
+|---------------|-------------------|--------|
+| Single error code lookup | No | Direct answer |
+| Single crate version | No | Direct lookup |
+| "Compare X and Y" | **Yes** | Multi-faceted |
+| Domain + error | **Yes** | Cross-layer context |
+| "Best practices for..." | **Yes** | Requires synthesis |
+| Ambiguous scope | **Yes** | Needs clarification |
+| Multi-crate question | **Yes** | Multiple sources |
+
+## Negotiation Decision Flow
+
+```
+Query Received
+     │
+     ▼
+┌─────────────────────────────┐
+│ Is query single-lookup?     │
+│ (version, error code, def)  │
+└─────────────────────────────┘
+     │
+     ├── Yes → Direct dispatch (no negotiation)
+     │
+     ▼ No
+┌─────────────────────────────┐
+│ Does query require:         │
+│ - Comparison?               │
+│ - Cross-domain context?     │
+│ - Synthesis/aggregation?    │
+│ - Multiple sources?         │
+└─────────────────────────────┘
+     │
+     ├── Yes → Dispatch with negotiation: true
+     │
+     ▼ No
+┌─────────────────────────────┐
+│ Is scope ambiguous?         │
+└─────────────────────────────┘
+     │
+     ├── Yes → Dispatch with negotiation: true
+     │
+     ▼ No
+     └── Direct dispatch (no negotiation)
+```
+
+## Negotiation Dispatch
+
+When dispatching with negotiation:
+
+```
+1. Set `negotiation: true`
+2. Include original query context
+3. Expect structured response:
+   - Findings
+   - Confidence (HIGH/MEDIUM/LOW/UNCERTAIN)
+   - Gaps identified
+   - Context questions (if any)
+4. Evaluate response against original intent
+```
+
+## Orchestrator Evaluation
+
+After receiving negotiation response:
+
+| Confidence | Intent Coverage | Action |
+|------------|-----------------|--------|
+| HIGH | Complete | Synthesize answer |
+| HIGH | Partial | May need supplementary query |
+| MEDIUM | Complete | Accept with disclosed gaps |
+| MEDIUM | Partial | Refine with context |
+| LOW | Any | Refine or try alternative |
+| UNCERTAIN | Any | Try alternative or escalate |
+
+## Refinement Loop
+
+If response insufficient:
+
+```
+Round 1: Initial query
+  │
+  ▼ (LOW confidence or gaps block intent)
+Round 2: Refined query with:
+  - Answers to agent's context questions
+  - Narrowed scope
+  │
+  ▼ (still insufficient)
+Round 3: Final attempt with:
+  - Alternative agent/source
+  - Maximum context provided
+  │
+  ▼ (still insufficient)
+Synthesize best-effort answer with disclosed gaps
+```
+
+## Integration with 3-Strike Rule
+
+Negotiation follows the 3-Strike escalation:
+
+```
+Strike 1: Initial query returns LOW confidence
+  → Refine with more context
+
+Strike 2: Refined query still LOW
+  → Try alternative agent/source
+
+Strike 3: Still insufficient
+  → Synthesize best-effort answer
+  → Report gaps to user explicitly
+```
+
+See `_meta/error-protocol.md` for full escalation rules.
+
+## Negotiation Routing Examples
+
+**Example 1: No Negotiation Needed**
+```
+Query: "What is tokio's latest version?"
+Analysis: Single lookup
+Action: Direct dispatch to crate-researcher
+```
+
+**Example 2: Negotiation Required**
+```
+Query: "Compare tokio and async-std for a web server"
+Analysis: Comparative + domain context
+Action: Dispatch with negotiation: true
+Expected: Structured responses from both runtime lookups
+Evaluation: Check if web-server specific data found
+```
+
+**Example 3: Cross-Domain Negotiation**
+```
+Query: "E0382 in my trading system"
+Analysis: Error code + domain context
+Action:
+  - Dispatch m01-ownership (standard - error is defined)
+  - Dispatch domain-fintech (negotiation: true - domain context)
+Synthesis: Combine error explanation with domain-appropriate fix
+```
+
+## Related Documents
+
+- `_meta/negotiation-protocol.md` - Full protocol specification
+- `_meta/negotiation-templates.md` - Response templates
+- `_meta/error-protocol.md` - 3-Strike escalation
+- `agents/_negotiation/response-format.md` - Agent response format

--- a/.cursor/skills/rust-skills-leonardomso/AGENTS.md
+++ b/.cursor/skills/rust-skills-leonardomso/AGENTS.md
@@ -1,0 +1,1 @@
+SKILL.md

--- a/.cursor/skills/rust-skills-leonardomso/CLAUDE.md
+++ b/.cursor/skills/rust-skills-leonardomso/CLAUDE.md
@@ -1,0 +1,1 @@
+SKILL.md

--- a/.cursor/skills/rust-skills-leonardomso/LICENSE
+++ b/.cursor/skills/rust-skills-leonardomso/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Leonardo Maldonado
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.cursor/skills/rust-skills-leonardomso/README.md
+++ b/.cursor/skills/rust-skills-leonardomso/README.md
@@ -1,0 +1,196 @@
+# Rust Skills
+
+179 Rust rules your AI coding agent can use to write better code.
+
+Works with Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, Zed, Amp, Cline, and pretty much any other agent that supports skills.
+
+## Install
+
+```bash
+npx add-skill leonardomso/rust-skills
+```
+
+That's it. The CLI figures out which agents you have and installs the skill to the right place.
+
+## How to use it
+
+After installing, just ask your agent:
+
+```
+/rust-skills review this function
+```
+
+```
+/rust-skills is my error handling idiomatic?
+```
+
+```
+/rust-skills check for memory issues
+```
+
+The agent loads the relevant rules and applies them to your code.
+
+## What's in here
+
+179 rules split into 14 categories:
+
+| Category | Rules | What it covers |
+|----------|-------|----------------|
+| **Ownership & Borrowing** | 12 | When to borrow vs clone, Arc/Rc, lifetimes |
+| **Error Handling** | 12 | thiserror for libs, anyhow for apps, the `?` operator |
+| **Memory** | 15 | SmallVec, arenas, avoiding allocations |
+| **API Design** | 15 | Builder pattern, newtypes, sealed traits |
+| **Async** | 15 | Tokio patterns, channels, spawn_blocking |
+| **Optimization** | 12 | LTO, inlining, PGO, SIMD |
+| **Naming** | 16 | Following Rust API Guidelines |
+| **Type Safety** | 10 | Newtypes, parse don't validate |
+| **Testing** | 13 | Proptest, mockall, criterion |
+| **Docs** | 11 | Doc examples, intra-doc links |
+| **Performance** | 11 | Iterators, entry API, collect patterns |
+| **Project Structure** | 11 | Workspaces, module layout |
+| **Linting** | 11 | Clippy config, CI setup |
+| **Anti-patterns** | 15 | Common mistakes and how to fix them |
+
+Each rule has:
+- Why it matters
+- Bad code example
+- Good code example
+- Links to official docs when relevant
+
+## Manual install
+
+If `add-skill` doesn't work for your setup, here's how to install manually:
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+Global (applies to all projects):
+```bash
+git clone https://github.com/leonardomso/rust-skills.git ~/.claude/skills/rust-skills
+```
+
+Or just for one project:
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .claude/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>OpenCode</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .opencode/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .cursor/skills/rust-skills
+```
+
+Or just grab the skill file:
+```bash
+curl -o .cursorrules https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+```bash
+mkdir -p .windsurf/rules
+curl -o .windsurf/rules/rust-skills.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>OpenAI Codex</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .codex/skills/rust-skills
+```
+
+Or use the AGENTS.md standard:
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>GitHub Copilot</b></summary>
+
+```bash
+mkdir -p .github
+curl -o .github/copilot-instructions.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Aider</b></summary>
+
+Add to `.aider.conf.yml`:
+```yaml
+read: path/to/rust-skills/SKILL.md
+```
+
+Or pass it directly:
+```bash
+aider --read path/to/rust-skills/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Zed</b></summary>
+
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Amp</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .agents/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>Cline / Roo Code</b></summary>
+
+```bash
+mkdir -p .clinerules
+curl -o .clinerules/rust-skills.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Other agents (AGENTS.md)</b></summary>
+
+If your agent supports the [AGENTS.md](https://agents.md) standard:
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+## All rules
+
+See [SKILL.md](./SKILL.md) for the full list with links to each rule file.
+
+## Where these rules come from
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Real code from ripgrep, tokio, serde, polars, axum
+- Clippy docs
+
+## Contributing
+
+PRs welcome. Just follow the format of existing rules.
+
+## License
+
+MIT

--- a/.cursor/skills/rust-skills-leonardomso/SKILL.md
+++ b/.cursor/skills/rust-skills-leonardomso/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: rust-skills
+description: >
+  Comprehensive Rust coding guidelines with 179 rules across 14 categories.
+  Use when writing, reviewing, or refactoring Rust code. Covers ownership,
+  error handling, async patterns, API design, memory optimization, performance,
+  testing, and common anti-patterns. Invoke with /rust-skills.
+license: MIT
+metadata:
+  author: leonardomso
+  version: "1.0.0"
+  sources:
+    - Rust API Guidelines
+    - Rust Performance Book
+    - ripgrep, tokio, serde, polars codebases
+---
+
+# Rust Best Practices
+
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 179 rules across 14 categories, prioritized by impact to guide LLMs in code generation and refactoring.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new Rust functions, structs, or modules
+- Implementing error handling or async code
+- Designing public APIs for libraries
+- Reviewing code for ownership/borrowing issues
+- Optimizing memory usage or reducing allocations
+- Tuning performance for hot paths
+- Refactoring existing Rust code
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix | Rules |
+|----------|----------|--------|--------|-------|
+| 1 | Ownership & Borrowing | CRITICAL | `own-` | 12 |
+| 2 | Error Handling | CRITICAL | `err-` | 12 |
+| 3 | Memory Optimization | CRITICAL | `mem-` | 15 |
+| 4 | API Design | HIGH | `api-` | 15 |
+| 5 | Async/Await | HIGH | `async-` | 15 |
+| 6 | Compiler Optimization | HIGH | `opt-` | 12 |
+| 7 | Naming Conventions | MEDIUM | `name-` | 16 |
+| 8 | Type Safety | MEDIUM | `type-` | 10 |
+| 9 | Testing | MEDIUM | `test-` | 13 |
+| 10 | Documentation | MEDIUM | `doc-` | 11 |
+| 11 | Performance Patterns | MEDIUM | `perf-` | 11 |
+| 12 | Project Structure | LOW | `proj-` | 11 |
+| 13 | Clippy & Linting | LOW | `lint-` | 11 |
+| 14 | Anti-patterns | REFERENCE | `anti-` | 15 |
+
+---
+
+## Quick Reference
+
+### 1. Ownership & Borrowing (CRITICAL)
+
+- [`own-borrow-over-clone`](rules/own-borrow-over-clone.md) - Prefer `&T` borrowing over `.clone()`
+- [`own-slice-over-vec`](rules/own-slice-over-vec.md) - Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+- [`own-cow-conditional`](rules/own-cow-conditional.md) - Use `Cow<'a, T>` for conditional ownership
+- [`own-arc-shared`](rules/own-arc-shared.md) - Use `Arc<T>` for thread-safe shared ownership
+- [`own-rc-single-thread`](rules/own-rc-single-thread.md) - Use `Rc<T>` for single-threaded sharing
+- [`own-refcell-interior`](rules/own-refcell-interior.md) - Use `RefCell<T>` for interior mutability (single-thread)
+- [`own-mutex-interior`](rules/own-mutex-interior.md) - Use `Mutex<T>` for interior mutability (multi-thread)
+- [`own-rwlock-readers`](rules/own-rwlock-readers.md) - Use `RwLock<T>` when reads dominate writes
+- [`own-copy-small`](rules/own-copy-small.md) - Derive `Copy` for small, trivial types
+- [`own-clone-explicit`](rules/own-clone-explicit.md) - Make `Clone` explicit, avoid implicit copies
+- [`own-move-large`](rules/own-move-large.md) - Move large data instead of cloning
+- [`own-lifetime-elision`](rules/own-lifetime-elision.md) - Rely on lifetime elision when possible
+
+### 2. Error Handling (CRITICAL)
+
+- [`err-thiserror-lib`](rules/err-thiserror-lib.md) - Use `thiserror` for library error types
+- [`err-anyhow-app`](rules/err-anyhow-app.md) - Use `anyhow` for application error handling
+- [`err-result-over-panic`](rules/err-result-over-panic.md) - Return `Result`, don't panic on expected errors
+- [`err-context-chain`](rules/err-context-chain.md) - Add context with `.context()` or `.with_context()`
+- [`err-no-unwrap-prod`](rules/err-no-unwrap-prod.md) - Never use `.unwrap()` in production code
+- [`err-expect-bugs-only`](rules/err-expect-bugs-only.md) - Use `.expect()` only for programming errors
+- [`err-question-mark`](rules/err-question-mark.md) - Use `?` operator for clean propagation
+- [`err-from-impl`](rules/err-from-impl.md) - Use `#[from]` for automatic error conversion
+- [`err-source-chain`](rules/err-source-chain.md) - Use `#[source]` to chain underlying errors
+- [`err-lowercase-msg`](rules/err-lowercase-msg.md) - Error messages: lowercase, no trailing punctuation
+- [`err-doc-errors`](rules/err-doc-errors.md) - Document errors with `# Errors` section
+- [`err-custom-type`](rules/err-custom-type.md) - Create custom error types, not `Box<dyn Error>`
+
+### 3. Memory Optimization (CRITICAL)
+
+- [`mem-with-capacity`](rules/mem-with-capacity.md) - Use `with_capacity()` when size is known
+- [`mem-smallvec`](rules/mem-smallvec.md) - Use `SmallVec` for usually-small collections
+- [`mem-arrayvec`](rules/mem-arrayvec.md) - Use `ArrayVec` for bounded-size collections
+- [`mem-box-large-variant`](rules/mem-box-large-variant.md) - Box large enum variants to reduce type size
+- [`mem-boxed-slice`](rules/mem-boxed-slice.md) - Use `Box<[T]>` instead of `Vec<T>` when fixed
+- [`mem-thinvec`](rules/mem-thinvec.md) - Use `ThinVec` for often-empty vectors
+- [`mem-clone-from`](rules/mem-clone-from.md) - Use `clone_from()` to reuse allocations
+- [`mem-reuse-collections`](rules/mem-reuse-collections.md) - Reuse collections with `clear()` in loops
+- [`mem-avoid-format`](rules/mem-avoid-format.md) - Avoid `format!()` when string literals work
+- [`mem-write-over-format`](rules/mem-write-over-format.md) - Use `write!()` instead of `format!()` 
+- [`mem-arena-allocator`](rules/mem-arena-allocator.md) - Use arena allocators for batch allocations
+- [`mem-zero-copy`](rules/mem-zero-copy.md) - Use zero-copy patterns with slices and `Bytes`
+- [`mem-compact-string`](rules/mem-compact-string.md) - Use `CompactString` for small string optimization
+- [`mem-smaller-integers`](rules/mem-smaller-integers.md) - Use smallest integer type that fits
+- [`mem-assert-type-size`](rules/mem-assert-type-size.md) - Assert hot type sizes to prevent regressions
+
+### 4. API Design (HIGH)
+
+- [`api-builder-pattern`](rules/api-builder-pattern.md) - Use Builder pattern for complex construction
+- [`api-builder-must-use`](rules/api-builder-must-use.md) - Add `#[must_use]` to builder types
+- [`api-newtype-safety`](rules/api-newtype-safety.md) - Use newtypes for type-safe distinctions
+- [`api-typestate`](rules/api-typestate.md) - Use typestate for compile-time state machines
+- [`api-sealed-trait`](rules/api-sealed-trait.md) - Seal traits to prevent external implementations
+- [`api-extension-trait`](rules/api-extension-trait.md) - Use extension traits to add methods to foreign types
+- [`api-parse-dont-validate`](rules/api-parse-dont-validate.md) - Parse into validated types at boundaries
+- [`api-impl-into`](rules/api-impl-into.md) - Accept `impl Into<T>` for flexible string inputs
+- [`api-impl-asref`](rules/api-impl-asref.md) - Accept `impl AsRef<T>` for borrowed inputs
+- [`api-must-use`](rules/api-must-use.md) - Add `#[must_use]` to `Result` returning functions
+- [`api-non-exhaustive`](rules/api-non-exhaustive.md) - Use `#[non_exhaustive]` for future-proof enums/structs
+- [`api-from-not-into`](rules/api-from-not-into.md) - Implement `From`, not `Into` (auto-derived)
+- [`api-default-impl`](rules/api-default-impl.md) - Implement `Default` for sensible defaults
+- [`api-common-traits`](rules/api-common-traits.md) - Implement `Debug`, `Clone`, `PartialEq` eagerly
+- [`api-serde-optional`](rules/api-serde-optional.md) - Gate `Serialize`/`Deserialize` behind feature flag
+
+### 5. Async/Await (HIGH)
+
+- [`async-tokio-runtime`](rules/async-tokio-runtime.md) - Use Tokio for production async runtime
+- [`async-no-lock-await`](rules/async-no-lock-await.md) - Never hold `Mutex`/`RwLock` across `.await`
+- [`async-spawn-blocking`](rules/async-spawn-blocking.md) - Use `spawn_blocking` for CPU-intensive work
+- [`async-tokio-fs`](rules/async-tokio-fs.md) - Use `tokio::fs` not `std::fs` in async code
+- [`async-cancellation-token`](rules/async-cancellation-token.md) - Use `CancellationToken` for graceful shutdown
+- [`async-join-parallel`](rules/async-join-parallel.md) - Use `tokio::join!` for parallel operations
+- [`async-try-join`](rules/async-try-join.md) - Use `tokio::try_join!` for fallible parallel ops
+- [`async-select-racing`](rules/async-select-racing.md) - Use `tokio::select!` for racing/timeouts
+- [`async-bounded-channel`](rules/async-bounded-channel.md) - Use bounded channels for backpressure
+- [`async-mpsc-queue`](rules/async-mpsc-queue.md) - Use `mpsc` for work queues
+- [`async-broadcast-pubsub`](rules/async-broadcast-pubsub.md) - Use `broadcast` for pub/sub patterns
+- [`async-watch-latest`](rules/async-watch-latest.md) - Use `watch` for latest-value sharing
+- [`async-oneshot-response`](rules/async-oneshot-response.md) - Use `oneshot` for request/response
+- [`async-joinset-structured`](rules/async-joinset-structured.md) - Use `JoinSet` for dynamic task groups
+- [`async-clone-before-await`](rules/async-clone-before-await.md) - Clone data before await, release locks
+
+### 6. Compiler Optimization (HIGH)
+
+- [`opt-inline-small`](rules/opt-inline-small.md) - Use `#[inline]` for small hot functions
+- [`opt-inline-always-rare`](rules/opt-inline-always-rare.md) - Use `#[inline(always)]` sparingly
+- [`opt-inline-never-cold`](rules/opt-inline-never-cold.md) - Use `#[inline(never)]` for cold paths
+- [`opt-cold-unlikely`](rules/opt-cold-unlikely.md) - Use `#[cold]` for error/unlikely paths
+- [`opt-likely-hint`](rules/opt-likely-hint.md) - Use `likely()`/`unlikely()` for branch hints
+- [`opt-lto-release`](rules/opt-lto-release.md) - Enable LTO in release builds
+- [`opt-codegen-units`](rules/opt-codegen-units.md) - Use `codegen-units = 1` for max optimization
+- [`opt-pgo-profile`](rules/opt-pgo-profile.md) - Use PGO for production builds
+- [`opt-target-cpu`](rules/opt-target-cpu.md) - Set `target-cpu=native` for local builds
+- [`opt-bounds-check`](rules/opt-bounds-check.md) - Use iterators to avoid bounds checks
+- [`opt-simd-portable`](rules/opt-simd-portable.md) - Use portable SIMD for data-parallel ops
+- [`opt-cache-friendly`](rules/opt-cache-friendly.md) - Design cache-friendly data layouts (SoA)
+
+### 7. Naming Conventions (MEDIUM)
+
+- [`name-types-camel`](rules/name-types-camel.md) - Use `UpperCamelCase` for types, traits, enums
+- [`name-variants-camel`](rules/name-variants-camel.md) - Use `UpperCamelCase` for enum variants
+- [`name-funcs-snake`](rules/name-funcs-snake.md) - Use `snake_case` for functions, methods, modules
+- [`name-consts-screaming`](rules/name-consts-screaming.md) - Use `SCREAMING_SNAKE_CASE` for constants/statics
+- [`name-lifetime-short`](rules/name-lifetime-short.md) - Use short lowercase lifetimes: `'a`, `'de`, `'src`
+- [`name-type-param-single`](rules/name-type-param-single.md) - Use single uppercase for type params: `T`, `E`, `K`, `V`
+- [`name-as-free`](rules/name-as-free.md) - `as_` prefix: free reference conversion
+- [`name-to-expensive`](rules/name-to-expensive.md) - `to_` prefix: expensive conversion
+- [`name-into-ownership`](rules/name-into-ownership.md) - `into_` prefix: ownership transfer
+- [`name-no-get-prefix`](rules/name-no-get-prefix.md) - No `get_` prefix for simple getters
+- [`name-is-has-bool`](rules/name-is-has-bool.md) - Use `is_`, `has_`, `can_` for boolean methods
+- [`name-iter-convention`](rules/name-iter-convention.md) - Use `iter`/`iter_mut`/`into_iter` for iterators
+- [`name-iter-method`](rules/name-iter-method.md) - Name iterator methods consistently
+- [`name-iter-type-match`](rules/name-iter-type-match.md) - Iterator type names match method
+- [`name-acronym-word`](rules/name-acronym-word.md) - Treat acronyms as words: `Uuid` not `UUID`
+- [`name-crate-no-rs`](rules/name-crate-no-rs.md) - Crate names: no `-rs` suffix
+
+### 8. Type Safety (MEDIUM)
+
+- [`type-newtype-ids`](rules/type-newtype-ids.md) - Wrap IDs in newtypes: `UserId(u64)`
+- [`type-newtype-validated`](rules/type-newtype-validated.md) - Newtypes for validated data: `Email`, `Url`
+- [`type-enum-states`](rules/type-enum-states.md) - Use enums for mutually exclusive states
+- [`type-option-nullable`](rules/type-option-nullable.md) - Use `Option<T>` for nullable values
+- [`type-result-fallible`](rules/type-result-fallible.md) - Use `Result<T, E>` for fallible operations
+- [`type-phantom-marker`](rules/type-phantom-marker.md) - Use `PhantomData<T>` for type-level markers
+- [`type-never-diverge`](rules/type-never-diverge.md) - Use `!` type for functions that never return
+- [`type-generic-bounds`](rules/type-generic-bounds.md) - Add trait bounds only where needed
+- [`type-no-stringly`](rules/type-no-stringly.md) - Avoid stringly-typed APIs, use enums/newtypes
+- [`type-repr-transparent`](rules/type-repr-transparent.md) - Use `#[repr(transparent)]` for FFI newtypes
+
+### 9. Testing (MEDIUM)
+
+- [`test-cfg-test-module`](rules/test-cfg-test-module.md) - Use `#[cfg(test)] mod tests { }`
+- [`test-use-super`](rules/test-use-super.md) - Use `use super::*;` in test modules
+- [`test-integration-dir`](rules/test-integration-dir.md) - Put integration tests in `tests/` directory
+- [`test-descriptive-names`](rules/test-descriptive-names.md) - Use descriptive test names
+- [`test-arrange-act-assert`](rules/test-arrange-act-assert.md) - Structure tests as arrange/act/assert
+- [`test-proptest-properties`](rules/test-proptest-properties.md) - Use `proptest` for property-based testing
+- [`test-mockall-mocking`](rules/test-mockall-mocking.md) - Use `mockall` for trait mocking
+- [`test-mock-traits`](rules/test-mock-traits.md) - Use traits for dependencies to enable mocking
+- [`test-fixture-raii`](rules/test-fixture-raii.md) - Use RAII pattern (Drop) for test cleanup
+- [`test-tokio-async`](rules/test-tokio-async.md) - Use `#[tokio::test]` for async tests
+- [`test-should-panic`](rules/test-should-panic.md) - Use `#[should_panic]` for panic tests
+- [`test-criterion-bench`](rules/test-criterion-bench.md) - Use `criterion` for benchmarking
+- [`test-doctest-examples`](rules/test-doctest-examples.md) - Keep doc examples as executable tests
+
+### 10. Documentation (MEDIUM)
+
+- [`doc-all-public`](rules/doc-all-public.md) - Document all public items with `///`
+- [`doc-module-inner`](rules/doc-module-inner.md) - Use `//!` for module-level documentation
+- [`doc-examples-section`](rules/doc-examples-section.md) - Include `# Examples` with runnable code
+- [`doc-errors-section`](rules/doc-errors-section.md) - Include `# Errors` for fallible functions
+- [`doc-panics-section`](rules/doc-panics-section.md) - Include `# Panics` for panicking functions
+- [`doc-safety-section`](rules/doc-safety-section.md) - Include `# Safety` for unsafe functions
+- [`doc-question-mark`](rules/doc-question-mark.md) - Use `?` in examples, not `.unwrap()`
+- [`doc-hidden-setup`](rules/doc-hidden-setup.md) - Use `# ` prefix to hide example setup code
+- [`doc-intra-links`](rules/doc-intra-links.md) - Use intra-doc links: `[Vec]`
+- [`doc-link-types`](rules/doc-link-types.md) - Link related types and functions in docs
+- [`doc-cargo-metadata`](rules/doc-cargo-metadata.md) - Fill `Cargo.toml` metadata
+
+### 11. Performance Patterns (MEDIUM)
+
+- [`perf-iter-over-index`](rules/perf-iter-over-index.md) - Prefer iterators over manual indexing
+- [`perf-iter-lazy`](rules/perf-iter-lazy.md) - Keep iterators lazy, collect() only when needed
+- [`perf-collect-once`](rules/perf-collect-once.md) - Don't `collect()` intermediate iterators
+- [`perf-entry-api`](rules/perf-entry-api.md) - Use `entry()` API for map insert-or-update
+- [`perf-drain-reuse`](rules/perf-drain-reuse.md) - Use `drain()` to reuse allocations
+- [`perf-extend-batch`](rules/perf-extend-batch.md) - Use `extend()` for batch insertions
+- [`perf-chain-avoid`](rules/perf-chain-avoid.md) - Avoid `chain()` in hot loops
+- [`perf-collect-into`](rules/perf-collect-into.md) - Use `collect_into()` for reusing containers
+- [`perf-black-box-bench`](rules/perf-black-box-bench.md) - Use `black_box()` in benchmarks
+- [`perf-release-profile`](rules/perf-release-profile.md) - Optimize release profile settings
+- [`perf-profile-first`](rules/perf-profile-first.md) - Profile before optimizing
+
+### 12. Project Structure (LOW)
+
+- [`proj-lib-main-split`](rules/proj-lib-main-split.md) - Keep `main.rs` minimal, logic in `lib.rs`
+- [`proj-mod-by-feature`](rules/proj-mod-by-feature.md) - Organize modules by feature, not type
+- [`proj-flat-small`](rules/proj-flat-small.md) - Keep small projects flat
+- [`proj-mod-rs-dir`](rules/proj-mod-rs-dir.md) - Use `mod.rs` for multi-file modules
+- [`proj-pub-crate-internal`](rules/proj-pub-crate-internal.md) - Use `pub(crate)` for internal APIs
+- [`proj-pub-super-parent`](rules/proj-pub-super-parent.md) - Use `pub(super)` for parent-only visibility
+- [`proj-pub-use-reexport`](rules/proj-pub-use-reexport.md) - Use `pub use` for clean public API
+- [`proj-prelude-module`](rules/proj-prelude-module.md) - Create `prelude` module for common imports
+- [`proj-bin-dir`](rules/proj-bin-dir.md) - Put multiple binaries in `src/bin/`
+- [`proj-workspace-large`](rules/proj-workspace-large.md) - Use workspaces for large projects
+- [`proj-workspace-deps`](rules/proj-workspace-deps.md) - Use workspace dependency inheritance
+
+### 13. Clippy & Linting (LOW)
+
+- [`lint-deny-correctness`](rules/lint-deny-correctness.md) - `#![deny(clippy::correctness)]`
+- [`lint-warn-suspicious`](rules/lint-warn-suspicious.md) - `#![warn(clippy::suspicious)]`
+- [`lint-warn-style`](rules/lint-warn-style.md) - `#![warn(clippy::style)]`
+- [`lint-warn-complexity`](rules/lint-warn-complexity.md) - `#![warn(clippy::complexity)]`
+- [`lint-warn-perf`](rules/lint-warn-perf.md) - `#![warn(clippy::perf)]`
+- [`lint-pedantic-selective`](rules/lint-pedantic-selective.md) - Enable `clippy::pedantic` selectively
+- [`lint-missing-docs`](rules/lint-missing-docs.md) - `#![warn(missing_docs)]`
+- [`lint-unsafe-doc`](rules/lint-unsafe-doc.md) - `#![warn(clippy::undocumented_unsafe_blocks)]`
+- [`lint-cargo-metadata`](rules/lint-cargo-metadata.md) - `#![warn(clippy::cargo)]` for published crates
+- [`lint-rustfmt-check`](rules/lint-rustfmt-check.md) - Run `cargo fmt --check` in CI
+- [`lint-workspace-lints`](rules/lint-workspace-lints.md) - Configure lints at workspace level
+
+### 14. Anti-patterns (REFERENCE)
+
+- [`anti-unwrap-abuse`](rules/anti-unwrap-abuse.md) - Don't use `.unwrap()` in production code
+- [`anti-expect-lazy`](rules/anti-expect-lazy.md) - Don't use `.expect()` for recoverable errors
+- [`anti-clone-excessive`](rules/anti-clone-excessive.md) - Don't clone when borrowing works
+- [`anti-lock-across-await`](rules/anti-lock-across-await.md) - Don't hold locks across `.await`
+- [`anti-string-for-str`](rules/anti-string-for-str.md) - Don't accept `&String` when `&str` works
+- [`anti-vec-for-slice`](rules/anti-vec-for-slice.md) - Don't accept `&Vec<T>` when `&[T]` works
+- [`anti-index-over-iter`](rules/anti-index-over-iter.md) - Don't use indexing when iterators work
+- [`anti-panic-expected`](rules/anti-panic-expected.md) - Don't panic on expected/recoverable errors
+- [`anti-empty-catch`](rules/anti-empty-catch.md) - Don't use empty `if let Err(_) = ...` blocks
+- [`anti-over-abstraction`](rules/anti-over-abstraction.md) - Don't over-abstract with excessive generics
+- [`anti-premature-optimize`](rules/anti-premature-optimize.md) - Don't optimize before profiling
+- [`anti-type-erasure`](rules/anti-type-erasure.md) - Don't use `Box<dyn Trait>` when `impl Trait` works
+- [`anti-format-hot-path`](rules/anti-format-hot-path.md) - Don't use `format!()` in hot paths
+- [`anti-collect-intermediate`](rules/anti-collect-intermediate.md) - Don't `collect()` intermediate iterators
+- [`anti-stringly-typed`](rules/anti-stringly-typed.md) - Don't use strings for structured data
+
+---
+
+## Recommended Cargo.toml Settings
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3  # Optimize dependencies in dev
+```
+
+---
+
+## How to Use
+
+This skill provides rule identifiers for quick reference. When generating or reviewing Rust code:
+
+1. **Check relevant category** based on task type
+2. **Apply rules** with matching prefix
+3. **Prioritize** CRITICAL > HIGH > MEDIUM > LOW
+4. **Read rule files** in `rules/` for detailed examples
+
+### Rule Application by Task
+
+| Task | Primary Categories |
+|------|-------------------|
+| New function | `own-`, `err-`, `name-` |
+| New struct/API | `api-`, `type-`, `doc-` |
+| Async code | `async-`, `own-` |
+| Error handling | `err-`, `api-` |
+| Memory optimization | `mem-`, `own-`, `perf-` |
+| Performance tuning | `opt-`, `mem-`, `perf-` |
+| Code review | `anti-`, `lint-` |
+
+---
+
+## Sources
+
+This skill synthesizes best practices from:
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Production codebases: ripgrep, tokio, serde, polars, axum, deno
+- Clippy lint documentation
+- Community conventions (2024-2025)

--- a/.cursor/skills/rust-skills-leonardomso/UPSTREAM.md
+++ b/.cursor/skills/rust-skills-leonardomso/UPSTREAM.md
@@ -1,0 +1,5 @@
+# Upstream
+
+- Repository: https://github.com/leonardomso/rust-skills
+- Path: `.`
+- Commit: `89910e8585331dabbecd400ae132b4070ecf24af`

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-clone-excessive.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-clone-excessive.md
@@ -1,0 +1,124 @@
+# anti-clone-excessive
+
+> Don't clone when borrowing works
+
+## Why It Matters
+
+`.clone()` allocates memory and copies data. When you only need to read data, borrowing (`&T`) is free. Excessive cloning wastes memory, CPU cycles, and often indicates misunderstanding of ownership.
+
+## Bad
+
+```rust
+// Cloning to pass to a function that only reads
+fn print_name(name: String) {  // Takes ownership
+    println!("{}", name);
+}
+let name = "Alice".to_string();
+print_name(name.clone());  // Unnecessary clone
+print_name(name);          // Could have just done this
+
+// Cloning in a loop
+for item in items.clone() {  // Clones entire Vec
+    process(&item);
+}
+
+// Cloning for comparison
+if input.clone() == expected {  // Pointless clone
+    // ...
+}
+
+// Cloning struct fields
+fn get_name(&self) -> String {
+    self.name.clone()  // Caller might not need ownership
+}
+```
+
+## Good
+
+```rust
+// Accept reference if only reading
+fn print_name(name: &str) {
+    println!("{}", name);
+}
+let name = "Alice".to_string();
+print_name(&name);  // Borrow, no clone
+
+// Iterate by reference
+for item in &items {
+    process(item);
+}
+
+// Compare by reference
+if input == expected {
+    // ...
+}
+
+// Return reference when possible
+fn get_name(&self) -> &str {
+    &self.name
+}
+```
+
+## When to Clone
+
+```rust
+// Need owned data for async move
+let name = name.clone();
+tokio::spawn(async move {
+    process(name).await;
+});
+
+// Storing in a new struct
+struct Cache {
+    data: String,
+}
+impl Cache {
+    fn store(&mut self, data: &str) {
+        self.data = data.to_string();  // Must own
+    }
+}
+
+// Multiple owners (use Arc instead if frequent)
+let shared = data.clone();
+thread::spawn(move || use_data(shared));
+```
+
+## Alternatives to Clone
+
+| Instead of | Use |
+|------------|-----|
+| `s.clone()` for reading | `&s` |
+| `vec.clone()` for iteration | `&vec` or `vec.iter()` |
+| `Clone` for shared ownership | `Arc<T>` |
+| Clone in hot loop | Move outside loop |
+| `s.to_string()` from `&str` | Accept `&str` if possible |
+
+## Pattern: Clone on Write
+
+```rust
+use std::borrow::Cow;
+
+fn process(input: Cow<str>) -> Cow<str> {
+    if needs_modification(&input) {
+        Cow::Owned(modify(&input))  // Clone only if needed
+    } else {
+        input  // No clone
+    }
+}
+```
+
+## Detecting Excessive Clones
+
+```toml
+# Cargo.toml
+[lints.clippy]
+clone_on_copy = "warn"
+clone_on_ref_ptr = "warn"
+redundant_clone = "warn"
+```
+
+## See Also
+
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Borrowing patterns
+- [own-cow-conditional](./own-cow-conditional.md) - Clone on write
+- [own-arc-shared](./own-arc-shared.md) - Shared ownership

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-collect-intermediate.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-collect-intermediate.md
@@ -1,0 +1,131 @@
+# anti-collect-intermediate
+
+> Don't collect intermediate iterators
+
+## Why It Matters
+
+Each `.collect()` allocates a new collection. Collecting intermediate results in a chain creates unnecessary allocations and prevents iterator fusion. Keep the chain lazy; collect only at the end.
+
+## Bad
+
+```rust
+// Three allocations, three passes
+fn process(data: Vec<i32>) -> Vec<i32> {
+    let step1: Vec<_> = data.into_iter()
+        .filter(|x| *x > 0)
+        .collect();
+    
+    let step2: Vec<_> = step1.into_iter()
+        .map(|x| x * 2)
+        .collect();
+    
+    step2.into_iter()
+        .filter(|x| *x < 100)
+        .collect()
+}
+
+// Collecting just to check length
+fn has_valid_items(items: &[Item]) -> bool {
+    let valid: Vec<_> = items.iter()
+        .filter(|i| i.is_valid())
+        .collect();
+    !valid.is_empty()
+}
+
+// Collecting to iterate again
+fn sum_valid(items: &[Item]) -> i64 {
+    let valid: Vec<_> = items.iter()
+        .filter(|i| i.is_valid())
+        .collect();
+    valid.iter().map(|i| i.value).sum()
+}
+```
+
+## Good
+
+```rust
+// Single allocation, single pass
+fn process(data: Vec<i32>) -> Vec<i32> {
+    data.into_iter()
+        .filter(|x| *x > 0)
+        .map(|x| x * 2)
+        .filter(|x| *x < 100)
+        .collect()
+}
+
+// No allocation - iterator short-circuits
+fn has_valid_items(items: &[Item]) -> bool {
+    items.iter().any(|i| i.is_valid())
+}
+
+// No intermediate allocation
+fn sum_valid(items: &[Item]) -> i64 {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .map(|i| i.value)
+        .sum()
+}
+```
+
+## When Collection Is Needed
+
+```rust
+// Need to iterate twice
+let valid: Vec<_> = items.iter()
+    .filter(|i| i.is_valid())
+    .collect();
+let count = valid.len();
+for item in &valid {
+    process(item);
+}
+
+// Need to sort (requires concrete collection)
+let mut sorted: Vec<_> = items.iter()
+    .filter(|i| i.is_active())
+    .collect();
+sorted.sort_by_key(|i| i.priority);
+
+// Need random access
+let indexed: Vec<_> = items.iter().collect();
+let middle = indexed.get(indexed.len() / 2);
+```
+
+## Iterator Methods That Avoid Collection
+
+| Instead of Collecting to... | Use |
+|-----------------------------|-----|
+| Check if empty | `.any(|_| true)` or `.next().is_some()` |
+| Check if any match | `.any(predicate)` |
+| Check if all match | `.all(predicate)` |
+| Count elements | `.count()` |
+| Sum elements | `.sum()` |
+| Find first | `.find(predicate)` |
+| Get first | `.next()` |
+| Get last | `.last()` |
+
+## Pattern: Deferred Collection
+
+```rust
+// Return iterator, let caller collect if needed
+fn valid_items(items: &[Item]) -> impl Iterator<Item = &Item> {
+    items.iter().filter(|i| i.is_valid())
+}
+
+// Caller decides
+let count = valid_items(&items).count();  // No collection
+let vec: Vec<_> = valid_items(&items).collect();  // Collection when needed
+```
+
+## Comparison
+
+| Pattern | Allocations | Passes |
+|---------|-------------|--------|
+| `.collect()` each step | N | N |
+| Single chain, one `.collect()` | 1 | 1 |
+| No collection (streaming) | 0 | 1 |
+
+## See Also
+
+- [perf-collect-once](./perf-collect-once.md) - Single collect
+- [perf-iter-lazy](./perf-iter-lazy.md) - Lazy evaluation
+- [perf-iter-over-index](./perf-iter-over-index.md) - Iterator patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-empty-catch.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-empty-catch.md
@@ -1,0 +1,132 @@
+# anti-empty-catch
+
+> Don't silently ignore errors
+
+## Why It Matters
+
+Empty error handling (`if let Err(_) = ...`, `let _ = result`, `.ok()`) silently discards errors. Failures go unnoticed, bugs hide, and debugging becomes impossible. Every error deserves acknowledgment—even if just logging.
+
+## Bad
+
+```rust
+// Silently ignores errors
+let _ = write_to_file(data);
+
+// Discards error completely
+if let Err(_) = send_notification() {
+    // Nothing - error vanishes
+}
+
+// Converts Result to Option, losing error info
+let value = risky_operation().ok();
+
+// Match with empty arm
+match database.save(record) {
+    Ok(_) => println!("saved"),
+    Err(_) => {}  // Silent failure
+}
+
+// Ignored in loop
+for item in items {
+    let _ = process(item);  // Failures unnoticed
+}
+```
+
+## Good
+
+```rust
+// Log the error
+if let Err(e) = write_to_file(data) {
+    error!("failed to write file: {}", e);
+}
+
+// Propagate if possible
+send_notification()?;
+
+// Or handle explicitly
+match send_notification() {
+    Ok(_) => info!("notification sent"),
+    Err(e) => warn!("notification failed: {}", e),
+}
+
+// Collect errors in batch operations
+let (successes, failures): (Vec<_>, Vec<_>) = items
+    .into_iter()
+    .map(process)
+    .partition(Result::is_ok);
+
+if !failures.is_empty() {
+    warn!("{} items failed to process", failures.len());
+}
+
+// Explicit documentation when ignoring
+// Intentionally ignored: cleanup failure is not critical
+let _ = cleanup_temp_file();  // Add comment explaining why
+```
+
+## Acceptable Ignoring (Documented)
+
+```rust
+// Close errors often ignored, but document it
+// INTENTIONAL: TCP close errors are not actionable
+let _ = stream.shutdown(Shutdown::Both);
+
+// Mutex poisoning recovery
+// INTENTIONAL: We'll reset the state anyway
+let guard = mutex.lock().unwrap_or_else(|e| e.into_inner());
+```
+
+## Pattern: Collect and Report
+
+```rust
+fn process_batch(items: Vec<Item>) -> BatchResult {
+    let mut errors = Vec::new();
+    
+    for item in items {
+        if let Err(e) = process_item(&item) {
+            errors.push((item.id, e));
+        }
+    }
+    
+    if errors.is_empty() {
+        BatchResult::AllSucceeded
+    } else {
+        BatchResult::PartialFailure(errors)
+    }
+}
+```
+
+## Pattern: Best-Effort Operations
+
+```rust
+// Metrics/telemetry can fail without affecting main flow
+fn report_metric(name: &str, value: f64) {
+    if let Err(e) = metrics_client.record(name, value) {
+        // Log but don't propagate - metrics are not critical
+        debug!("failed to record metric {}: {}", name, e);
+    }
+}
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+let_underscore_drop = "warn"
+ignored_unit_patterns = "warn"
+```
+
+## Decision Guide
+
+| Situation | Action |
+|-----------|--------|
+| Critical operation | `?` or handle explicitly |
+| Non-critical, debugging needed | Log the error |
+| Truly ignorable (rare) | `let _ =` with comment |
+| Batch operation | Collect errors, report |
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Proper error handling
+- [err-context-chain](./err-context-chain.md) - Adding context
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap issues

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-expect-lazy.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-expect-lazy.md
@@ -1,0 +1,95 @@
+# anti-expect-lazy
+
+> Don't use expect for recoverable errors
+
+## Why It Matters
+
+`.expect()` panics with a custom message, but it's still a panic. Using it for errors that could reasonably occur in production (network failures, file not found, invalid input) crashes the program instead of handling the error gracefully.
+
+Reserve `.expect()` for programming errors where panic is appropriate.
+
+## Bad
+
+```rust
+// Network failures are expected - don't panic
+let response = client.get(url).await.expect("failed to fetch");
+
+// Files might not exist
+let config = fs::read_to_string("config.toml").expect("config not found");
+
+// User input can be invalid
+let age: u32 = input.parse().expect("invalid age");
+
+// Database queries can fail
+let user = db.find_user(id).await.expect("user not found");
+```
+
+## Good
+
+```rust
+// Handle recoverable errors properly
+let response = client.get(url).await
+    .context("failed to fetch URL")?;
+
+// Return error if file doesn't exist
+let config = fs::read_to_string("config.toml")
+    .context("failed to read config file")?;
+
+// Validate and return error
+let age: u32 = input.parse()
+    .map_err(|_| Error::InvalidInput("age must be a number"))?;
+
+// Handle missing data
+let user = db.find_user(id).await?
+    .ok_or(Error::NotFound("user"))?;
+```
+
+## When expect() Is Appropriate
+
+Use `.expect()` for invariants that indicate bugs:
+
+```rust
+// Mutex poisoning indicates a bug elsewhere
+let guard = mutex.lock().expect("mutex poisoned");
+
+// Regex is known valid at compile time
+let re = Regex::new(r"^\d{4}$").expect("invalid regex");
+
+// Thread spawn failure is unrecoverable
+let handle = thread::spawn(|| work()).expect("failed to spawn thread");
+
+// Static data that must be valid
+let config: Config = toml::from_str(EMBEDDED_CONFIG)
+    .expect("embedded config is invalid");
+```
+
+## Pattern: expect() vs unwrap()
+
+```rust
+// unwrap: no context, hard to debug
+let x = option.unwrap();
+
+// expect: gives context, still panics
+let x = option.expect("value should exist after validation");
+
+// ?: proper error handling
+let x = option.ok_or(Error::MissingValue)?;
+```
+
+## Decision Guide
+
+| Situation | Use |
+|-----------|-----|
+| User input | `?` with error |
+| File/network I/O | `?` with error |
+| Database operations | `?` with error |
+| Parsed constants | `.expect()` |
+| Thread/mutex operations | `.expect()` |
+| After validation check | `.expect()` with explanation |
+| Never expected to fail | `.expect()` documenting invariant |
+
+## See Also
+
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to use expect
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoiding unwrap
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap anti-pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-format-hot-path.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-format-hot-path.md
@@ -1,0 +1,141 @@
+# anti-format-hot-path
+
+> Don't use format! in hot paths
+
+## Why It Matters
+
+`format!()` allocates a new `String` every call. In hot paths (loops, frequently called functions), this creates allocation churn that impacts performance. Pre-allocate, reuse buffers, or use `write!()` to an existing buffer.
+
+## Bad
+
+```rust
+// format! in loop - allocates every iteration
+fn log_events(events: &[Event]) {
+    for event in events {
+        let message = format!("[{}] {}: {}", event.level, event.source, event.message);
+        logger.log(&message);
+    }
+}
+
+// format! for building parts
+fn build_url(base: &str, path: &str, params: &[(&str, &str)]) -> String {
+    let mut url = format!("{}{}", base, path);
+    for (key, value) in params {
+        url = format!("{}{}={}&", url, key, value);  // New allocation each time
+    }
+    url
+}
+
+// format! for simple concatenation
+fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)  // Fine for one-off, bad if called 1M times
+}
+```
+
+## Good
+
+```rust
+use std::fmt::Write;
+
+// Reuse buffer across iterations
+fn log_events(events: &[Event]) {
+    let mut buffer = String::with_capacity(256);
+    for event in events {
+        buffer.clear();
+        write!(buffer, "[{}] {}: {}", event.level, event.source, event.message).unwrap();
+        logger.log(&buffer);
+    }
+}
+
+// Build incrementally in single buffer
+fn build_url(base: &str, path: &str, params: &[(&str, &str)]) -> String {
+    let mut url = String::with_capacity(base.len() + path.len() + params.len() * 20);
+    url.push_str(base);
+    url.push_str(path);
+    for (key, value) in params {
+        write!(url, "{}={}&", key, value).unwrap();
+    }
+    url
+}
+
+// For truly hot paths, avoid allocation entirely
+fn greet_to_buf(name: &str, buffer: &mut String) {
+    buffer.clear();
+    buffer.push_str("Hello, ");
+    buffer.push_str(name);
+    buffer.push('!');
+}
+```
+
+## Comparison
+
+| Approach | Allocations | Performance |
+|----------|-------------|-------------|
+| `format!()` in loop | N | Slow |
+| `write!()` to reused buffer | 1 | Fast |
+| `push_str()` + `push()` | 1 | Fastest |
+| Pre-sized `String::with_capacity()` | 1 (no realloc) | Fast |
+
+## When format! Is Fine
+
+```rust
+// One-time initialization
+let config_path = format!("{}/config.toml", home_dir);
+
+// Error messages (not hot path)
+return Err(format!("invalid input: {}", input));
+
+// Debug output
+println!("Debug: {:?}", value);
+```
+
+## Pattern: Formatter Buffer Pool
+
+```rust
+use std::cell::RefCell;
+
+thread_local! {
+    static BUFFER: RefCell<String> = RefCell::new(String::with_capacity(256));
+}
+
+fn format_event(event: &Event) -> String {
+    BUFFER.with(|buf| {
+        let mut buf = buf.borrow_mut();
+        buf.clear();
+        write!(buf, "[{}] {}", event.level, event.message).unwrap();
+        buf.clone()  // Still one allocation per call, but no parsing
+    })
+}
+```
+
+## Pattern: Display Implementation
+
+```rust
+struct Event {
+    level: Level,
+    message: String,
+}
+
+impl std::fmt::Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.level, self.message)
+    }
+}
+
+// Caller controls allocation
+let mut buf = String::new();
+write!(buf, "{}", event)?;
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+format_in_format_args = "warn"
+```
+
+## See Also
+
+- [mem-avoid-format](./mem-avoid-format.md) - Avoiding format
+- [mem-write-over-format](./mem-write-over-format.md) - Using write!
+- [mem-reuse-collections](./mem-reuse-collections.md) - Buffer reuse

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-index-over-iter.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-index-over-iter.md
@@ -1,0 +1,125 @@
+# anti-index-over-iter
+
+> Don't use indexing when iterators work
+
+## Why It Matters
+
+Manual indexing (`for i in 0..len`) requires bounds checks on every access, prevents SIMD optimization, and introduces off-by-one error risks. Iterators eliminate these issues and are more idiomatic Rust.
+
+## Bad
+
+```rust
+// Manual indexing - bounds checked every access
+fn sum_squares(data: &[i32]) -> i64 {
+    let mut result = 0i64;
+    for i in 0..data.len() {
+        result += (data[i] as i64) * (data[i] as i64);
+    }
+    result
+}
+
+// Index-based with multiple arrays
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len().min(b.len()) {
+        sum += a[i] * b[i];
+    }
+    sum
+}
+
+// Mutation with indices
+fn normalize(data: &mut [f64]) {
+    let max = data.iter().cloned().fold(0.0, f64::max);
+    for i in 0..data.len() {
+        data[i] /= max;
+    }
+}
+```
+
+## Good
+
+```rust
+// Iterator - no bounds checks, SIMD-friendly
+fn sum_squares(data: &[i32]) -> i64 {
+    data.iter()
+        .map(|&x| (x as i64) * (x as i64))
+        .sum()
+}
+
+// Zip - handles length mismatch automatically
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| x * y)
+        .sum()
+}
+
+// Mutable iteration
+fn normalize(data: &mut [f64]) {
+    let max = data.iter().cloned().fold(0.0, f64::max);
+    for x in data.iter_mut() {
+        *x /= max;
+    }
+}
+```
+
+## When Indices Are Needed
+
+Sometimes you genuinely need indices:
+
+```rust
+// Need index in output
+for (i, item) in items.iter().enumerate() {
+    println!("{}: {}", i, item);
+}
+
+// Non-sequential access
+for i in (0..len).step_by(2) {
+    swap(&mut data[i], &mut data[i + 1]);
+}
+
+// Multi-dimensional iteration
+for i in 0..rows {
+    for j in 0..cols {
+        matrix[i][j] = i * cols + j;
+    }
+}
+```
+
+## Comparison
+
+| Pattern | Bounds Checks | SIMD | Safety |
+|---------|---------------|------|--------|
+| `for i in 0..len { data[i] }` | Every access | Limited | Off-by-one risk |
+| `for x in &data` | None | Good | Safe |
+| `for x in data.iter()` | None | Good | Safe |
+| `data.iter().enumerate()` | None | Good | Safe |
+
+## Common Conversions
+
+| Index Pattern | Iterator Pattern |
+|---------------|------------------|
+| `for i in 0..v.len()` | `for x in &v` |
+| `v[0]` | `v.first()` |
+| `v[v.len()-1]` | `v.last()` |
+| `for i in 0..a.len() { a[i] + b[i] }` | `a.iter().zip(&b)` |
+| `for i in 0..v.len() { v[i] *= 2 }` | `for x in &mut v { *x *= 2 }` |
+
+## Performance Note
+
+```rust
+// Iterator version can auto-vectorize
+let sum: i32 = data.iter().sum();
+
+// Manual indexing prevents vectorization
+let mut sum = 0;
+for i in 0..data.len() {
+    sum += data[i];
+}
+```
+
+## See Also
+
+- [perf-iter-over-index](./perf-iter-over-index.md) - Performance details
+- [opt-bounds-check](./opt-bounds-check.md) - Bounds check elimination
+- [perf-iter-lazy](./perf-iter-lazy.md) - Lazy iterators

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-lock-across-await.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-lock-across-await.md
@@ -1,0 +1,127 @@
+# anti-lock-across-await
+
+> Don't hold locks across await points
+
+## Why It Matters
+
+Holding a `Mutex` or `RwLock` guard across an `.await` causes the lock to be held while the task is suspended. Other tasks waiting for the lock block indefinitely. With `std::sync::Mutex`, this is even worse—it can deadlock the entire runtime.
+
+## Bad
+
+```rust
+use std::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+// DEADLOCK RISK: std::sync::Mutex held across await
+async fn bad_std_mutex(data: &Mutex<Vec<i32>>) {
+    let mut guard = data.lock().unwrap();
+    do_async_work().await;  // Lock held during await!
+    guard.push(42);
+}
+
+// BLOCKS OTHER TASKS: tokio Mutex held across await
+async fn bad_async_mutex(data: &AsyncMutex<Vec<i32>>) {
+    let mut guard = data.lock().await;
+    slow_network_call().await;  // Lock held for entire call!
+    guard.push(42);
+}
+```
+
+## Good
+
+```rust
+use std::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+// Release lock before await
+async fn good_approach(data: &Mutex<Vec<i32>>) {
+    let value = {
+        let guard = data.lock().unwrap();
+        guard.last().copied()  // Extract what you need
+    };  // Lock released here
+    
+    let result = do_async_work(value).await;
+    
+    {
+        let mut guard = data.lock().unwrap();
+        guard.push(result);
+    }
+}
+
+// Minimize lock scope with async mutex
+async fn good_async_mutex(data: &AsyncMutex<Vec<i32>>, item: i32) {
+    // Quick lock, quick release
+    data.lock().await.push(item);
+    
+    // Async work without lock
+    let result = slow_network_call().await;
+    
+    // Quick lock again
+    data.lock().await.push(result);
+}
+```
+
+## Pattern: Clone Before Await
+
+```rust
+async fn process(data: &AsyncMutex<Config>) -> Result<()> {
+    // Clone inside lock scope
+    let config = data.lock().await.clone();
+    
+    // Now use config freely across awaits
+    let result = fetch_data(&config.url).await?;
+    process_result(&config, result).await?;
+    
+    Ok(())
+}
+```
+
+## Pattern: Restructure to Avoid Lock
+
+```rust
+// Instead of locking a shared map
+struct Service {
+    data: AsyncMutex<HashMap<String, Data>>,
+}
+
+// Use channels or owned data
+struct BetterService {
+    // Each task owns its data via channels
+    sender: mpsc::Sender<Request>,
+}
+
+impl BetterService {
+    async fn request(&self, key: String) -> Data {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send(Request { key, respond: tx }).await?;
+        rx.await?
+    }
+}
+```
+
+## What Can Cross Await
+
+| Type | Safe Across Await? |
+|------|--------------------|
+| `std::sync::Mutex` guard | **NO** - can deadlock |
+| `std::sync::RwLock` guard | **NO** - can deadlock |
+| `tokio::sync::Mutex` guard | Allowed but blocks tasks |
+| `tokio::sync::RwLock` guard | Allowed but blocks tasks |
+| Owned values | Yes |
+| `Arc<T>` | Yes |
+| References | Depends on lifetime |
+
+## Detection
+
+```toml
+# Cargo.toml
+[lints.clippy]
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+```
+
+## See Also
+
+- [async-no-lock-await](./async-no-lock-await.md) - Async lock patterns
+- [async-clone-before-await](./async-clone-before-await.md) - Clone pattern
+- [own-mutex-interior](./own-mutex-interior.md) - Mutex usage

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-over-abstraction.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-over-abstraction.md
@@ -1,0 +1,120 @@
+# anti-over-abstraction
+
+> Don't over-abstract with excessive generics
+
+## Why It Matters
+
+Generics and traits are powerful but come at a cost: compile times, binary size, and cognitive load. Over-abstraction—making everything generic "for flexibility"—often adds complexity without benefit. Start concrete; generalize when you have real use cases.
+
+## Bad
+
+```rust
+// Overly generic for a simple function
+fn add<T, U, R>(a: T, b: U) -> R
+where
+    T: Into<R>,
+    U: Into<R>,
+    R: std::ops::Add<Output = R>,
+{
+    a.into() + b.into()
+}
+
+// Just call add(1, 2) - why make it this complex?
+
+// Trait explosion
+trait Readable {}
+trait Writable {}
+trait ReadWritable: Readable + Writable {}
+trait AsyncReadable {}
+trait AsyncWritable {}
+trait AsyncReadWritable: AsyncReadable + AsyncWritable {}
+
+// Abstract factory pattern (Java flashback)
+trait Factory<T> {
+    fn create(&self) -> T;
+}
+trait FactoryFactory<F: Factory<T>, T> {
+    fn create_factory(&self) -> F;
+}
+```
+
+## Good
+
+```rust
+// Concrete implementation - clear and simple
+fn add_i32(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+// Generic when actually needed (e.g., library code)
+fn add<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
+    a + b
+}
+
+// Simple traits for actual polymorphism needs
+trait Storage {
+    fn save(&self, key: &str, value: &[u8]) -> Result<(), Error>;
+    fn load(&self, key: &str) -> Result<Vec<u8>, Error>;
+}
+
+// Concrete types first
+struct FileStorage { path: PathBuf }
+struct MemoryStorage { data: HashMap<String, Vec<u8>> }
+```
+
+## Signs of Over-Abstraction
+
+| Sign | Symptom |
+|------|---------|
+| Single implementation | Generic trait with only one impl |
+| Type parameter soup | `T, U, V, W` everywhere |
+| Marker traits | Traits with no methods |
+| Deep trait bounds | `where T: A + B + C + D + E` |
+| Phantom generics | Type parameters not used meaningfully |
+
+## When to Generalize
+
+Generalize when:
+- You have 2+ concrete types that share behavior
+- You're writing library code for public consumption
+- Performance requires static dispatch
+- The abstraction simplifies the API
+
+Don't generalize when:
+- You "might need it later" (YAGNI)
+- Only one type will ever implement it
+- It makes code harder to understand
+
+## Rule of Three
+
+Wait until you have three similar concrete implementations before abstracting:
+
+```rust
+// Version 1: Just FileStorage
+struct FileStorage { /* ... */ }
+
+// Version 2: Added MemoryStorage, similar interface
+struct MemoryStorage { /* ... */ }
+
+// Version 3: Now Redis too - time to abstract
+trait Storage {
+    fn save(&self, key: &str, value: &[u8]) -> Result<()>;
+    fn load(&self, key: &str) -> Result<Vec<u8>>;
+}
+```
+
+## Prefer Concrete Types in Private Code
+
+```rust
+// Internal function - concrete type is fine
+fn process_orders(db: &PostgresDb, orders: Vec<Order>) { }
+
+// Public API - might benefit from abstraction
+pub fn process_orders<S: Storage>(storage: &S, orders: Vec<Order>) { }
+```
+
+## See Also
+
+- [type-generic-bounds](./type-generic-bounds.md) - Minimal bounds
+- [api-sealed-trait](./api-sealed-trait.md) - Controlled extension
+- [anti-type-erasure](./anti-type-erasure.md) - When Box<dyn> is wrong

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-panic-expected.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-panic-expected.md
@@ -1,0 +1,131 @@
+# anti-panic-expected
+
+> Don't panic on expected or recoverable errors
+
+## Why It Matters
+
+Panics crash the program. They're for unrecoverable situations—bugs, corrupted state, invariant violations. Using panic for expected conditions (network failures, file not found, invalid input) makes programs fragile and forces callers to catch panics or die.
+
+Use `Result` for recoverable errors.
+
+## Bad
+
+```rust
+// Network failures are expected
+fn fetch_data(url: &str) -> Data {
+    let response = reqwest::blocking::get(url)
+        .expect("network error");  // Crashes on timeout
+    response.json().expect("invalid json")  // Crashes on bad response
+}
+
+// User input is often invalid
+fn parse_config(input: &str) -> Config {
+    toml::from_str(input).expect("invalid config")  // Crashes on typo
+}
+
+// Files may not exist
+fn load_settings() -> Settings {
+    let content = fs::read_to_string("settings.json")
+        .expect("settings not found");  // Crashes if missing
+    serde_json::from_str(&content).expect("invalid settings")
+}
+
+// Custom panic for validation
+fn process_age(age: i32) {
+    if age < 0 {
+        panic!("age cannot be negative");  // Should return error
+    }
+}
+```
+
+## Good
+
+```rust
+// Return errors for expected failures
+fn fetch_data(url: &str) -> Result<Data, FetchError> {
+    let response = reqwest::blocking::get(url)
+        .context("failed to connect")?;
+    let data = response.json()
+        .context("failed to parse response")?;
+    Ok(data)
+}
+
+// Validate and return Result
+fn parse_config(input: &str) -> Result<Config, ConfigError> {
+    toml::from_str(input).map_err(ConfigError::Parse)
+}
+
+// Handle missing files gracefully
+fn load_settings() -> Result<Settings, SettingsError> {
+    let content = fs::read_to_string("settings.json")?;
+    let settings = serde_json::from_str(&content)?;
+    Ok(settings)
+}
+
+// Return error for validation failure
+fn process_age(age: i32) -> Result<(), ValidationError> {
+    if age < 0 {
+        return Err(ValidationError::NegativeAge);
+    }
+    Ok(())
+}
+```
+
+## When to Panic
+
+Panic IS appropriate for:
+
+```rust
+// Bug detection - invariant violated
+fn get_unchecked(&self, index: usize) -> &T {
+    assert!(index < self.len(), "index out of bounds - this is a bug");
+    unsafe { self.data.get_unchecked(index) }
+}
+
+// Unrecoverable state
+fn init() {
+    if !CAN_PROCEED {
+        panic!("system requirements not met");
+    }
+}
+
+// Tests
+#[test]
+fn test_fails() {
+    panic!("expected panic in test");
+}
+```
+
+## Decision Guide
+
+| Condition | Action |
+|-----------|--------|
+| Invalid user input | Return `Err` |
+| Network failure | Return `Err` |
+| File not found | Return `Err` |
+| Malformed data | Return `Err` |
+| Bug/impossible state | `panic!` or `unreachable!` |
+| Failed assertion in test | `panic!` |
+| Unrecoverable init failure | `panic!` |
+
+## Anti-pattern: panic! for Control Flow
+
+```rust
+// BAD: Using panic for control flow
+fn find_or_die(items: &[Item], id: u64) -> &Item {
+    items.iter()
+        .find(|i| i.id == id)
+        .unwrap_or_else(|| panic!("item {} not found", id))
+}
+
+// GOOD: Return Option or Result
+fn find(items: &[Item], id: u64) -> Option<&Item> {
+    items.iter().find(|i| i.id == id)
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Use Result
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap anti-pattern
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to expect

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-premature-optimize.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-premature-optimize.md
@@ -1,0 +1,156 @@
+# anti-premature-optimize
+
+> Don't optimize before profiling
+
+## Why It Matters
+
+Premature optimization wastes time, complicates code, and often targets the wrong bottlenecks. Most code isn't performance-critical; the hot 10% matters. Profile first, then optimize the actual bottlenecks with data-driven decisions.
+
+## Bad
+
+```rust
+// "Optimizing" without measurement
+fn sum(data: &[i32]) -> i32 {
+    // Using unsafe "for performance" without profiling
+    unsafe {
+        let mut sum = 0;
+        for i in 0..data.len() {
+            sum += *data.get_unchecked(i);
+        }
+        sum
+    }
+}
+
+// Complex caching with no evidence it's needed
+lazy_static! {
+    static ref CACHE: RwLock<HashMap<String, Arc<Result>>> = 
+        RwLock::new(HashMap::new());
+}
+
+// Hand-rolled data structures "for speed"
+struct MyVec<T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+}
+```
+
+## Good
+
+```rust
+// Simple, idiomatic - let compiler optimize
+fn sum(data: &[i32]) -> i32 {
+    data.iter().sum()
+}
+
+// Profile, then optimize if needed
+fn sum_optimized(data: &[i32]) -> i32 {
+    // After profiling showed this is a bottleneck,
+    // we measured that manual SIMD gives 3x speedup
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SIMD implementation with benchmark data
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        data.iter().sum()
+    }
+}
+
+// Use standard library - it's well-optimized
+let cache: HashMap<String, Result> = HashMap::new();
+```
+
+## Profiling Workflow
+
+```bash
+# 1. Write correct code first
+cargo build --release
+
+# 2. Profile with real workloads
+cargo flamegraph --bin my_app -- --real-args
+# or
+cargo bench
+
+# 3. Identify hotspots (top 10% of time)
+
+# 4. Measure before optimizing
+# 5. Optimize ONE thing
+# 6. Measure after - verify improvement
+# 7. Repeat if still slow
+```
+
+## Optimization Principles
+
+| Do | Don't |
+|----|-------|
+| Profile first | Guess at bottlenecks |
+| Optimize hotspots | Optimize everything |
+| Measure improvement | Assume it's faster |
+| Keep it simple | Add complexity speculatively |
+| Trust the compiler | Outsmart the compiler |
+
+## When to Optimize
+
+```rust
+// AFTER profiling shows this is 40% of runtime
+#[inline]
+fn hot_function(data: &[u8]) -> u64 {
+    // Optimized implementation justified by benchmarks
+}
+
+// Clear, measurable benefit documented
+/// Pre-allocated buffer for repeated formatting.
+/// Benchmarks show 3x speedup for >1000 calls/sec workloads.
+struct FormatterPool {
+    buffers: Vec<String>,
+}
+```
+
+## Common Premature Optimizations
+
+| Premature | Reality |
+|-----------|---------|
+| `#[inline(always)]` everywhere | Compiler usually knows better |
+| `unsafe` for bounds check removal | Iterator does this safely |
+| Custom allocator | Default is usually fine |
+| Object pooling | Allocator is fast enough |
+| Manual SIMD | Auto-vectorization works |
+
+## Profile Tools
+
+```bash
+# Sampling profiler
+perf record ./target/release/app && perf report
+
+# Flamegraph
+cargo install flamegraph
+cargo flamegraph
+
+# Criterion benchmarks
+cargo bench
+
+# Memory profiling
+valgrind --tool=massif ./target/release/app
+```
+
+## Document Optimizations
+
+```rust
+/// Lookup table for fast character classification.
+/// 
+/// # Performance
+/// 
+/// Benchmarked with criterion (benchmarks/char_class.rs):
+/// - Table lookup: 2.3ns/op
+/// - Match statement: 8.7ns/op
+/// 
+/// Justified for hot path in parser (called 10M+ times).
+static CHAR_CLASS: [CharClass; 256] = [/* ... */];
+```
+
+## See Also
+
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimize
+- [test-criterion-bench](./test-criterion-bench.md) - Benchmarking
+- [opt-inline-small](./opt-inline-small.md) - Inline guidelines

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-string-for-str.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-string-for-str.md
@@ -1,0 +1,122 @@
+# anti-string-for-str
+
+> Don't accept &String when &str works
+
+## Why It Matters
+
+`&String` is strictly less flexible than `&str`. A `&str` can be created from `String`, `&str`, literals, and slices. A `&String` requires exactly a `String`. This forces callers to allocate when they might not need to.
+
+## Bad
+
+```rust
+// Forces callers to have a String
+fn greet(name: &String) {
+    println!("Hello, {}", name);
+}
+
+// Caller must allocate
+greet(&"Alice".to_string());  // Unnecessary allocation
+greet(&name);                 // Only works if name is String
+
+// In struct
+struct Config {
+    name: String,
+}
+
+impl Config {
+    fn set_name(&mut self, name: &String) {  // Too restrictive
+        self.name = name.clone();
+    }
+}
+```
+
+## Good
+
+```rust
+// Accept &str - works with String, &str, literals
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// All these work
+greet("Alice");           // String literal
+greet(&name);             // &String coerces to &str
+greet(name.as_str());     // Explicit &str
+
+// In struct
+impl Config {
+    fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
+    }
+    
+    // Or accept owned String if caller usually has one
+    fn set_name_owned(&mut self, name: String) {
+        self.name = name;
+    }
+    
+    // Or be generic
+    fn set_name_into(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+}
+```
+
+## Deref Coercion
+
+`String` implements `Deref<Target = str>`, so `&String` automatically coerces to `&str`:
+
+```rust
+fn takes_str(s: &str) { }
+
+let owned = String::from("hello");
+takes_str(&owned);  // &String -> &str via Deref
+```
+
+## When to Accept &String
+
+Rarely. Maybe if you need `String`-specific methods:
+
+```rust
+fn needs_capacity(s: &String) -> usize {
+    s.capacity()  // Only String has capacity()
+}
+```
+
+But usually you'd take `&str` and let the caller manage the `String`.
+
+## Pattern: Flexible APIs
+
+```rust
+// Most flexible: accept anything that can become &str
+fn process(input: impl AsRef<str>) {
+    let s: &str = input.as_ref();
+    // ...
+}
+
+process("literal");
+process(String::from("owned"));
+process(&some_string);
+```
+
+## Similar Anti-patterns
+
+| Anti-pattern | Better |
+|--------------|--------|
+| `&String` | `&str` |
+| `&Vec<T>` | `&[T]` |
+| `&Box<T>` | `&T` |
+| `&PathBuf` | `&Path` |
+| `&OsString` | `&OsStr` |
+
+## Clippy Detection
+
+```toml
+[lints.clippy]
+ptr_arg = "warn"  # Catches &String, &Vec, &PathBuf
+```
+
+## See Also
+
+- [anti-vec-for-slice](./anti-vec-for-slice.md) - Similar pattern for Vec
+- [own-slice-over-vec](./own-slice-over-vec.md) - Slice patterns
+- [api-impl-asref](./api-impl-asref.md) - AsRef pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-stringly-typed.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-stringly-typed.md
@@ -1,0 +1,167 @@
+# anti-stringly-typed
+
+> Don't use strings where enums or newtypes would provide type safety
+
+## Why It Matters
+
+Strings are the most primitive way to represent data—they accept any value, provide no validation, and offer no IDE support. When you have a fixed set of valid values or a semantic type, use enums or newtypes. The compiler catches mistakes at compile time instead of runtime.
+
+## Bad
+
+```rust
+fn process_order(status: &str, priority: &str) {
+    // What are valid statuses? "pending"? "Pending"? "PENDING"?
+    // What are valid priorities? "high"? "1"? "urgent"?
+    match status {
+        "pending" => { ... }
+        "completed" => { ... }
+        _ => panic!("unknown status"),  // Runtime error
+    }
+}
+
+struct User {
+    email: String,    // Any string, even "not an email"
+    phone: String,    // Any string, even "hello"
+    user_id: String,  // Could be confused with other string IDs
+}
+
+// Easy to make mistakes
+process_order("complete", "high");  // Typo: "complete" vs "completed"
+process_order("high", "pending");   // Swapped arguments - compiles!
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OrderStatus {
+    Pending,
+    Processing,
+    Completed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Priority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+fn process_order(status: OrderStatus, priority: Priority) {
+    match status {
+        OrderStatus::Pending => { ... }
+        OrderStatus::Processing => { ... }
+        OrderStatus::Completed => { ... }
+        OrderStatus::Cancelled => { ... }
+    }  // Exhaustive - compiler checks all cases
+}
+
+// Validated newtypes
+struct Email(String);
+struct PhoneNumber(String);
+struct UserId(u64);
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, ValidationError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(ValidationError::InvalidEmail)
+        }
+    }
+}
+
+struct User {
+    email: Email,       // Must be valid email
+    phone: PhoneNumber, // Must be valid phone
+    user_id: UserId,    // Can't confuse with other IDs
+}
+
+// Compile errors catch mistakes
+process_order(OrderStatus::Completed, Priority::High);  // Clear and correct
+process_order(Priority::High, OrderStatus::Pending);    // Compile error!
+```
+
+## Parsing Strings to Types
+
+```rust
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy)]
+enum OrderStatus {
+    Pending,
+    Processing,
+    Completed,
+    Cancelled,
+}
+
+impl FromStr for OrderStatus {
+    type Err = ParseError;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "pending" => Ok(OrderStatus::Pending),
+            "processing" => Ok(OrderStatus::Processing),
+            "completed" => Ok(OrderStatus::Completed),
+            "cancelled" | "canceled" => Ok(OrderStatus::Cancelled),
+            _ => Err(ParseError::UnknownStatus(s.to_string())),
+        }
+    }
+}
+
+// Parse at boundary, use types internally
+fn handle_request(status_str: &str) -> Result<(), Error> {
+    let status: OrderStatus = status_str.parse()?;  // Validate once
+    process_order(status);  // Type-safe from here
+    Ok(())
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+// JSON: {"status": "in_progress"}
+// Deserialization validates automatically
+```
+
+## Error Messages
+
+```rust
+#[derive(Debug, Clone, Copy)]
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Color::Red => write!(f, "red"),
+            Color::Green => write!(f, "green"),
+            Color::Blue => write!(f, "blue"),
+        }
+    }
+}
+
+// Type-safe and displayable
+println!("Selected color: {}", Color::Red);
+```
+
+## See Also
+
+- [api-newtype-safety](./api-newtype-safety.md) - Newtype pattern
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Parse at boundaries
+- [type-newtype-ids](./type-newtype-ids.md) - Type-safe IDs

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-type-erasure.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-type-erasure.md
@@ -1,0 +1,134 @@
+# anti-type-erasure
+
+> Don't use Box<dyn Trait> when impl Trait works
+
+## Why It Matters
+
+`Box<dyn Trait>` (type erasure) introduces heap allocation and dynamic dispatch overhead. When you have a single concrete type or can use generics, `impl Trait` provides the same flexibility with zero overhead through monomorphization.
+
+## Bad
+
+```rust
+// Unnecessary type erasure
+fn get_iterator() -> Box<dyn Iterator<Item = i32>> {
+    Box::new((0..10).map(|x| x * 2))
+}
+
+// Boxing for no reason
+fn make_handler() -> Box<dyn Fn(i32) -> i32> {
+    Box::new(|x| x + 1)
+}
+
+// Vec of boxed trait objects when one type would do
+fn get_validators() -> Vec<Box<dyn Validator>> {
+    vec![
+        Box::new(LengthValidator),
+        Box::new(RegexValidator),
+    ]
+}
+```
+
+## Good
+
+```rust
+// impl Trait - zero overhead, inlined
+fn get_iterator() -> impl Iterator<Item = i32> {
+    (0..10).map(|x| x * 2)
+}
+
+// impl Fn - no boxing
+fn make_handler() -> impl Fn(i32) -> i32 {
+    |x| x + 1
+}
+
+// When mixed types are genuinely needed, Box is OK
+fn get_validators() -> Vec<Box<dyn Validator>> {
+    // Actually different types at runtime - Box is appropriate
+    config.validators.iter()
+        .map(|v| v.create_validator())
+        .collect()
+}
+```
+
+## When to Use Box<dyn Trait>
+
+Type erasure IS appropriate when:
+
+```rust
+// Heterogeneous collection of different types
+let handlers: Vec<Box<dyn Handler>> = vec![
+    Box::new(LogHandler),
+    Box::new(MetricsHandler),
+    Box::new(AuthHandler),
+];
+
+// Type cannot be known at compile time
+fn create_from_config(config: &Config) -> Box<dyn Database> {
+    match config.db_type {
+        DbType::Postgres => Box::new(PostgresDb::new()),
+        DbType::Sqlite => Box::new(SqliteDb::new()),
+    }
+}
+
+// Recursive types
+struct Node {
+    value: i32,
+    children: Vec<Box<dyn NodeTrait>>,
+}
+
+// Breaking cycles in complex ownership
+struct EventLoop {
+    handlers: Vec<Box<dyn EventHandler>>,
+}
+```
+
+## Comparison
+
+| Approach | Allocation | Dispatch | Binary Size |
+|----------|------------|----------|-------------|
+| `impl Trait` | Stack/inline | Static | Larger (monomorphization) |
+| `Box<dyn Trait>` | Heap | Dynamic | Smaller |
+| Generics `<T>` | Stack/inline | Static | Larger |
+
+## impl Trait Positions
+
+```rust
+// Return position - caller doesn't need to know concrete type
+fn process() -> impl Future<Output = Result> { }
+
+// Argument position - like generics but simpler
+fn handle(handler: impl Handler) { }
+
+// Can't use in trait definitions (use associated types instead)
+trait Processor {
+    type Output: Display;  // Not impl Display
+    fn process(&self) -> Self::Output;
+}
+```
+
+## Pattern: Enum Instead of dyn
+
+```rust
+// Instead of Box<dyn Shape>
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+    Triangle { base: f64, height: f64 },
+}
+
+impl Shape {
+    fn area(&self) -> f64 {
+        match self {
+            Shape::Circle { radius } => PI * radius * radius,
+            Shape::Rectangle { width, height } => width * height,
+            Shape::Triangle { base, height } => 0.5 * base * height,
+        }
+    }
+}
+```
+
+## See Also
+
+- [anti-over-abstraction](./anti-over-abstraction.md) - Excessive generics
+- [type-generic-bounds](./type-generic-bounds.md) - Generic constraints
+- [mem-box-large-variant](./mem-box-large-variant.md) - Boxing enum variants

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-unwrap-abuse.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-unwrap-abuse.md
@@ -1,0 +1,143 @@
+# anti-unwrap-abuse
+
+> Don't use `.unwrap()` in production code
+
+## Why It Matters
+
+`.unwrap()` panics on `None` or `Err`, crashing your program. In production, this means lost data, failed requests, and unhappy users. It also makes debugging harder since panic messages often lack context.
+
+## Bad
+
+```rust
+// Crashes if file doesn't exist
+let content = std::fs::read_to_string("config.toml").unwrap();
+
+// Crashes on invalid input
+let num: i32 = user_input.parse().unwrap();
+
+// Crashes if key missing
+let value = map.get("key").unwrap();
+
+// Crashes if channel closed
+let msg = receiver.recv().unwrap();
+```
+
+## Good
+
+```rust
+// Propagate with ?
+fn load_config() -> Result<Config, Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    Ok(toml::from_str(&content)?)
+}
+
+// Provide default
+let num: i32 = user_input.parse().unwrap_or(0);
+
+// Handle missing key
+let value = map.get("key").ok_or(Error::MissingKey)?;
+
+// Or use if-let
+if let Some(value) = map.get("key") {
+    process(value);
+}
+
+// Channel with proper handling
+match receiver.recv() {
+    Ok(msg) => handle(msg),
+    Err(_) => break,  // Channel closed
+}
+```
+
+## When unwrap() Is Acceptable
+
+```rust
+// 1. Tests - panics are expected failures
+#[test]
+fn test_parse() {
+    let result = parse("valid").unwrap();  // OK in tests
+    assert_eq!(result, expected);
+}
+
+// 2. Const/static initialization (compile-time guaranteed)
+static REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\d+$").unwrap()  // Known-valid pattern
+});
+
+// 3. After a check that guarantees success
+if map.contains_key("key") {
+    let value = map.get("key").unwrap();  // Just checked
+}
+// Better: use if-let or entry API instead
+
+// 4. Truly impossible cases with proof comment
+let last = vec.pop().unwrap();  
+// OK only if you just checked !vec.is_empty()
+// Better: use last() or pattern match
+```
+
+## Alternatives to unwrap()
+
+```rust
+// unwrap_or - provide default
+let x = opt.unwrap_or(default);
+
+// unwrap_or_default - use Default trait
+let x = opt.unwrap_or_default();
+
+// unwrap_or_else - compute default lazily
+let x = opt.unwrap_or_else(|| expensive_default());
+
+// ? operator - propagate errors
+let x = opt.ok_or(Error::Missing)?;
+
+// if let - handle Some/Ok case
+if let Some(x) = opt {
+    use_x(x);
+}
+
+// match - handle all cases
+match opt {
+    Some(x) => use_x(x),
+    None => handle_none(),
+}
+
+// map - transform if present
+let y = opt.map(|x| x + 1);
+
+// and_then - chain fallible operations
+let z = opt.and_then(|x| x.checked_add(1));
+```
+
+## expect() Is Slightly Better
+
+```rust
+// unwrap() - no context
+let file = File::open(path).unwrap();
+// Panics with: "called `Result::unwrap()` on an `Err` value: Os { code: 2, ... }"
+
+// expect() - adds context
+let file = File::open(path)
+    .expect("config file should exist at startup");
+// Panics with: "config file should exist at startup: Os { code: 2, ... }"
+
+// But still use only for invariants, not error handling
+```
+
+## Clippy Lint
+
+```rust
+// Enable these lints to catch unwrap usage:
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::expect_used)]  // Stricter
+
+// Or per-function:
+#[allow(clippy::unwrap_used)]
+fn tests_only() { }
+```
+
+## See Also
+
+- [err-question-mark](err-question-mark.md) - Use ? for propagation
+- [err-result-over-panic](err-result-over-panic.md) - Return Result instead of panicking
+- [anti-expect-lazy](anti-expect-lazy.md) - Don't use expect for recoverable errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/anti-vec-for-slice.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/anti-vec-for-slice.md
@@ -1,0 +1,121 @@
+# anti-vec-for-slice
+
+> Don't accept &Vec<T> when &[T] works
+
+## Why It Matters
+
+`&Vec<T>` is strictly less flexible than `&[T]`. A slice can be created from `Vec`, arrays, and other slice-like types. Accepting `&Vec<T>` forces callers to have exactly a `Vec`, preventing them from using arrays, slices, or other collections.
+
+## Bad
+
+```rust
+// Forces callers to have a Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// Caller must allocate
+let arr = [1, 2, 3, 4, 5];
+sum(&arr.to_vec());  // Unnecessary allocation
+
+// Slice won't work
+let slice: &[i32] = &[1, 2, 3];
+// sum(slice);  // Error: expected &Vec<i32>
+```
+
+## Good
+
+```rust
+// Accept slice - works with Vec, arrays, slices
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// All these work
+sum(&[1, 2, 3, 4, 5]);        // Array
+sum(&vec![1, 2, 3]);          // Vec
+sum(&numbers[1..3]);          // Slice of slice
+sum(numbers.as_slice());      // Explicit slice
+```
+
+## Deref Coercion
+
+`Vec<T>` implements `Deref<Target = [T]>`, so `&Vec<T>` automatically coerces to `&[T]`:
+
+```rust
+fn takes_slice(s: &[i32]) { }
+
+let vec = vec![1, 2, 3];
+takes_slice(&vec);  // &Vec<i32> -> &[i32] via Deref
+```
+
+## Mutable Slices
+
+Same applies to `&mut`:
+
+```rust
+// Bad
+fn double(numbers: &mut Vec<i32>) {
+    for n in numbers.iter_mut() {
+        *n *= 2;
+    }
+}
+
+// Good
+fn double(numbers: &mut [i32]) {
+    for n in numbers.iter_mut() {
+        *n *= 2;
+    }
+}
+```
+
+## When to Accept &Vec<T>
+
+Rarely. Only when you need Vec-specific operations:
+
+```rust
+fn needs_capacity(v: &Vec<i32>) -> usize {
+    v.capacity()  // Only Vec has capacity
+}
+
+fn might_grow(v: &mut Vec<i32>) {
+    v.push(42);  // Slice can't push
+}
+```
+
+## Pattern: Accepting Multiple Types
+
+```rust
+// Accept anything that can be viewed as a slice
+fn process<T: AsRef<[u8]>>(data: T) {
+    let bytes: &[u8] = data.as_ref();
+    // ...
+}
+
+process(&[1u8, 2, 3]);       // Array
+process(vec![1u8, 2, 3]);    // Vec
+process(&some_vec);          // &Vec
+process(b"bytes");           // Byte string
+```
+
+## Similar Anti-patterns
+
+| Anti-pattern | Better |
+|--------------|--------|
+| `&Vec<T>` | `&[T]` |
+| `&String` | `&str` |
+| `&PathBuf` | `&Path` |
+| `&Box<T>` | `&T` |
+
+## Clippy Detection
+
+```toml
+[lints.clippy]
+ptr_arg = "warn"  # Catches &Vec, &String, &PathBuf
+```
+
+## See Also
+
+- [anti-string-for-str](./anti-string-for-str.md) - Similar for String
+- [own-slice-over-vec](./own-slice-over-vec.md) - Slice patterns
+- [api-impl-asref](./api-impl-asref.md) - AsRef pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-builder-must-use.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-builder-must-use.md
@@ -1,0 +1,143 @@
+# api-builder-must-use
+
+> Mark builder methods with `#[must_use]` to prevent silent drops
+
+## Why It Matters
+
+Builder pattern methods return a modified builder. Without `#[must_use]`, calling a builder method and ignoring the return value silently does nothing—the builder is dropped, and the configuration is lost. This creates confusing bugs where code appears correct but has no effect.
+
+## Bad
+
+```rust
+struct RequestBuilder {
+    url: String,
+    timeout: Option<Duration>,
+    headers: Vec<(String, String)>,
+}
+
+impl RequestBuilder {
+    fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+    
+    fn header(mut self, key: &str, value: &str) -> Self {
+        self.headers.push((key.to_string(), value.to_string()));
+        self
+    }
+}
+
+// Bug: builder methods are ignored - no warning!
+let request = RequestBuilder::new("https://api.example.com");
+request.timeout(Duration::from_secs(30));  // Dropped silently!
+request.header("Authorization", "Bearer token");  // Dropped silently!
+let response = request.send();  // Sends with no timeout or headers
+```
+
+## Good
+
+```rust
+struct RequestBuilder {
+    url: String,
+    timeout: Option<Duration>,
+    headers: Vec<(String, String)>,
+}
+
+impl RequestBuilder {
+    #[must_use = "builder methods return modified builder - chain or assign"]
+    fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+    
+    #[must_use = "builder methods return modified builder - chain or assign"]
+    fn header(mut self, key: &str, value: &str) -> Self {
+        self.headers.push((key.to_string(), value.to_string()));
+        self
+    }
+}
+
+// Now warns: unused return value that must be used
+let request = RequestBuilder::new("https://api.example.com");
+request.timeout(Duration::from_secs(30));  // Warning!
+
+// Correct: chain methods
+let response = RequestBuilder::new("https://api.example.com")
+    .timeout(Duration::from_secs(30))
+    .header("Authorization", "Bearer token")
+    .send();
+```
+
+## Apply to Entire Type
+
+```rust
+#[must_use = "builders do nothing unless consumed"]
+struct ConfigBuilder {
+    log_level: Level,
+    max_connections: usize,
+}
+
+// Now all methods returning Self warn if ignored
+impl ConfigBuilder {
+    fn log_level(mut self, level: Level) -> Self {
+        self.log_level = level;
+        self
+    }
+    
+    fn max_connections(mut self, n: usize) -> Self {
+        self.max_connections = n;
+        self
+    }
+    
+    fn build(self) -> Config {
+        Config {
+            log_level: self.log_level,
+            max_connections: self.max_connections,
+        }
+    }
+}
+```
+
+## Message Guidelines
+
+```rust
+// Descriptive message helps users understand
+#[must_use = "builder methods return modified builder"]
+fn with_foo(self, foo: Foo) -> Self { ... }
+
+#[must_use = "this creates a new String and does not modify the original"]
+fn to_uppercase(&self) -> String { ... }
+
+#[must_use = "iterator adaptors are lazy - use .collect() to consume"]
+fn map<F>(self, f: F) -> Map<Self, F> { ... }
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+must_use_candidate = "warn"  # Suggests where #[must_use] would help
+return_self_not_must_use = "warn"  # Specifically for -> Self methods
+```
+
+## Standard Library Examples
+
+```rust
+// std::Option - must_use on map, and, or
+let x: Option<i32> = Some(5);
+x.map(|v| v * 2);  // Warning: unused return value
+
+// std::Result - must_use on the type itself
+#[must_use = "this `Result` may be an `Err` variant, which should be handled"]
+pub enum Result<T, E> { ... }
+
+// Iterator adaptors
+let v = vec![1, 2, 3];
+v.iter().map(|x| x * 2);  // Warning: iterators are lazy
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Builder pattern best practices
+- [api-must-use](./api-must-use.md) - General must_use guidelines
+- [err-result-over-panic](./err-result-over-panic.md) - Result types are must_use

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-builder-pattern.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-builder-pattern.md
@@ -1,0 +1,187 @@
+# api-builder-pattern
+
+> Use Builder pattern for complex construction
+
+## Why It Matters
+
+When a type has many optional parameters or complex initialization, the Builder pattern provides a clear, flexible API. It avoids constructors with many parameters (which are error-prone) and makes the code self-documenting.
+
+## Bad
+
+```rust
+// Constructor with many parameters - hard to read, easy to get wrong
+let client = Client::new(
+    "https://api.example.com",  // Which is which?
+    30,                          // Timeout? Retries?
+    true,                        // What does this mean?
+    None,
+    Some("auth_token"),
+    false,
+);
+
+// Or many Option fields
+struct Client {
+    url: String,
+    timeout: Option<Duration>,
+    retries: Option<u32>,
+    // ... 10 more optional fields
+}
+```
+
+## Good
+
+```rust
+#[derive(Default)]
+#[must_use = "builders do nothing unless you call build()"]
+pub struct ClientBuilder {
+    base_url: Option<String>,
+    timeout: Option<Duration>,
+    max_retries: u32,
+    auth_token: Option<String>,
+}
+
+impl ClientBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    
+    /// Sets the base URL for all requests.
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+    
+    /// Sets the request timeout. Default is 30 seconds.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+    
+    /// Sets the maximum number of retries. Default is 3.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.max_retries = n;
+        self
+    }
+    
+    /// Sets the authentication token.
+    pub fn auth_token(mut self, token: impl Into<String>) -> Self {
+        self.auth_token = Some(token.into());
+        self
+    }
+    
+    /// Builds the client with the configured options.
+    pub fn build(self) -> Result<Client, BuilderError> {
+        let base_url = self.base_url
+            .ok_or(BuilderError::MissingBaseUrl)?;
+        
+        Ok(Client {
+            base_url,
+            timeout: self.timeout.unwrap_or(Duration::from_secs(30)),
+            max_retries: self.max_retries,
+            auth_token: self.auth_token,
+        })
+    }
+}
+
+// Usage - clear and self-documenting
+let client = ClientBuilder::new()
+    .base_url("https://api.example.com")
+    .timeout(Duration::from_secs(10))
+    .max_retries(5)
+    .auth_token("secret")
+    .build()?;
+```
+
+## Builder Variations
+
+```rust
+// 1. Infallible builder (build() returns T, not Result)
+impl WidgetBuilder {
+    pub fn build(self) -> Widget {
+        Widget {
+            color: self.color.unwrap_or(Color::Black),
+            size: self.size.unwrap_or(Size::Medium),
+        }
+    }
+}
+
+// 2. Typestate builder (compile-time required field checking)
+pub struct ClientBuilder<Url> {
+    url: Url,
+    timeout: Option<Duration>,
+}
+
+pub struct NoUrl;
+pub struct HasUrl(String);
+
+impl ClientBuilder<NoUrl> {
+    pub fn new() -> Self {
+        Self { url: NoUrl, timeout: None }
+    }
+    
+    pub fn url(self, url: String) -> ClientBuilder<HasUrl> {
+        ClientBuilder { url: HasUrl(url), timeout: self.timeout }
+    }
+}
+
+impl ClientBuilder<HasUrl> {
+    pub fn build(self) -> Client {
+        // url is guaranteed to be set
+        Client { url: self.url.0, timeout: self.timeout }
+    }
+}
+
+// 3. Consuming vs borrowing (consuming is more common)
+// Consuming (takes self)
+pub fn timeout(mut self, t: Duration) -> Self { ... }
+
+// Borrowing (takes &mut self, allows reuse)
+pub fn timeout(&mut self, t: Duration) -> &mut Self { ... }
+```
+
+## Evidence from reqwest
+
+```rust
+// https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/client.rs
+
+#[must_use]
+pub struct ClientBuilder {
+    config: Config,
+}
+
+impl ClientBuilder {
+    pub fn new() -> ClientBuilder {
+        ClientBuilder {
+            config: Config::default(),
+        }
+    }
+    
+    pub fn timeout(mut self, timeout: Duration) -> ClientBuilder {
+        self.config.timeout = Some(timeout);
+        self
+    }
+    
+    pub fn build(self) -> Result<Client, Error> {
+        // Validation and construction
+    }
+}
+```
+
+## Key Attributes
+
+```rust
+#[derive(Default)]  // Enables MyBuilder::default()
+#[must_use = "builders do nothing unless you call build()"]
+pub struct MyBuilder { ... }
+
+impl MyBuilder {
+    #[must_use]  // Each method should have this
+    pub fn option(mut self, value: T) -> Self { ... }
+}
+```
+
+## See Also
+
+- [api-builder-must-use](api-builder-must-use.md) - Add #[must_use] to builders
+- [api-typestate](api-typestate.md) - Compile-time state machines
+- [api-impl-into](api-impl-into.md) - Accept impl Into for flexibility

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-common-traits.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-common-traits.md
@@ -1,0 +1,165 @@
+# api-common-traits
+
+> Implement standard traits (Debug, Clone, PartialEq, etc.) for public types
+
+## Why It Matters
+
+Standard traits make your types interoperable with the Rust ecosystem. `Debug` enables `println!("{:?}")` and error messages. `Clone` allows explicit duplication. `PartialEq` enables `==`. Without these, users can't use your types in common patterns like testing, collections, or debugging.
+
+## Bad
+
+```rust
+// Bare struct - severely limited usability
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+// Can't debug
+println!("{:?}", point);  // Error: Debug not implemented
+
+// Can't compare
+if point1 == point2 { }  // Error: PartialEq not implemented
+
+// Can't use in HashMap
+let mut map: HashMap<Point, Value> = HashMap::new();  // Error: Hash not implemented
+
+// Can't clone
+let copy = point.clone();  // Error: Clone not implemented
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+// Now everything works
+println!("{:?}", point);
+assert_eq!(point1, point2);
+let copy = point;  // Copy, not just Clone
+
+// For hashable types
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UserId(u64);
+
+let mut map: HashMap<UserId, User> = HashMap::new();
+```
+
+## Trait Derivation Guide
+
+| Trait | Derive When | Requirements |
+|-------|-------------|--------------|
+| `Debug` | Always for public types | All fields implement Debug |
+| `Clone` | Type can be duplicated | All fields implement Clone |
+| `Copy` | Small, simple types | All fields implement Copy, no Drop |
+| `PartialEq` | Comparison makes sense | All fields implement PartialEq |
+| `Eq` | Total equality | PartialEq, no floating-point fields |
+| `Hash` | Used as HashMap/HashSet key | Eq, consistent with PartialEq |
+| `Default` | Sensible default exists | All fields implement Default |
+| `PartialOrd` | Ordering makes sense | PartialEq, all fields implement PartialOrd |
+| `Ord` | Total ordering | Eq + PartialOrd, no floating-point |
+
+## Common Trait Bundles
+
+```rust
+// ID types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntityId(u64);
+
+// Value types
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Vector2 { x: f32, y: f32 }
+
+// Configuration
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Config {
+    name: String,
+    options: HashMap<String, String>,
+}
+
+// Error types
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    InvalidSyntax(String),
+    UnexpectedToken(Token),
+}
+```
+
+## Manual Implementations
+
+```rust
+// When derive doesn't do what you want
+struct CaseInsensitiveString(String);
+
+impl PartialEq for CaseInsensitiveString {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_lowercase() == other.0.to_lowercase()
+    }
+}
+
+impl Eq for CaseInsensitiveString {}
+
+impl Hash for CaseInsensitiveString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Must be consistent with PartialEq
+        self.0.to_lowercase().hash(state);
+    }
+}
+
+// Custom Debug for sensitive data
+struct Password(String);
+
+impl Debug for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Password([REDACTED])")
+    }
+}
+```
+
+## Serde Traits
+
+```rust
+use serde::{Serialize, Deserialize};
+
+// For serializable types
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiResponse {
+    pub status: String,
+    pub data: Vec<Item>,
+}
+
+// With custom serialization
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub verbose: bool,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}
+```
+
+## Minimum Recommended
+
+```rust
+// At minimum, public types should have:
+#[derive(Debug, Clone, PartialEq)]
+pub struct MyType { ... }
+
+// Add based on use case:
+// + Eq, Hash       → for HashMap keys
+// + Ord, PartialOrd → for BTreeMap, sorting
+// + Default        → for Option::unwrap_or_default()
+// + Copy           → for small value types
+// + Serialize      → for serialization
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - When to implement Copy
+- [api-default-impl](./api-default-impl.md) - Implementing Default
+- [doc-examples-section](./doc-examples-section.md) - Documenting trait implementations

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-default-impl.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-default-impl.md
@@ -1,0 +1,177 @@
+# api-default-impl
+
+> Implement `Default` for types with sensible default values
+
+## Why It Matters
+
+`Default` is a standard trait that provides a canonical way to create a default instance. It integrates with many ecosystem patterns: `Option::unwrap_or_default()`, `#[derive(Default)]`, struct update syntax `..Default::default()`, and generic code that requires `T: Default`. Implementing it makes your types more ergonomic.
+
+## Bad
+
+```rust
+struct Config {
+    timeout: Duration,
+    retries: u32,
+    verbose: bool,
+}
+
+impl Config {
+    // Custom constructor - works but non-standard
+    fn new() -> Self {
+        Config {
+            timeout: Duration::from_secs(30),
+            retries: 3,
+            verbose: false,
+        }
+    }
+}
+
+// Can't use with standard patterns
+let config: Config = Default::default();  // Error: Default not implemented
+let timeout = settings.get("timeout").unwrap_or_default();  // Won't work
+```
+
+## Good
+
+```rust
+#[derive(Default)]
+struct Config {
+    #[default = Duration::from_secs(30)]  // Nightly, or implement manually
+    timeout: Duration,
+    retries: u32,     // Defaults to 0 with derive
+    verbose: bool,    // Defaults to false with derive
+}
+
+// Or implement manually for custom defaults
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            timeout: Duration::from_secs(30),
+            retries: 3,
+            verbose: false,
+        }
+    }
+}
+
+// Now works with all standard patterns
+let config = Config::default();
+let config = Config { retries: 5, ..Default::default() };
+let value = map.get("key").cloned().unwrap_or_default();
+```
+
+## Derive vs Manual
+
+```rust
+// Derive: all fields use their own Default
+#[derive(Default)]
+struct Simple {
+    count: u32,      // 0
+    name: String,    // ""
+    items: Vec<i32>, // []
+}
+
+// Manual: when you need custom defaults
+struct Connection {
+    host: String,
+    port: u16,
+    timeout: Duration,
+}
+
+impl Default for Connection {
+    fn default() -> Self {
+        Connection {
+            host: "localhost".to_string(),
+            port: 8080,
+            timeout: Duration::from_secs(30),
+        }
+    }
+}
+```
+
+## Builder with Default
+
+```rust
+#[derive(Default)]
+struct ServerBuilder {
+    host: String,
+    port: u16,
+    workers: usize,
+}
+
+impl ServerBuilder {
+    fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+    
+    fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+}
+
+// Clean initialization
+let server = ServerBuilder::default()
+    .host("0.0.0.0")
+    .port(3000)
+    .build();
+```
+
+## Default with Required Fields
+
+```rust
+// When some fields have no sensible default, don't implement Default
+struct User {
+    id: UserId,       // No sensible default
+    name: String,     // Could default to ""
+}
+
+// Instead, provide a constructor
+impl User {
+    fn new(id: UserId, name: impl Into<String>) -> Self {
+        User { id, name: name.into() }
+    }
+}
+
+// Or use builder with required fields
+struct UserBuilder {
+    id: Option<UserId>,
+    name: String,
+}
+
+impl Default for UserBuilder {
+    fn default() -> Self {
+        UserBuilder {
+            id: None,
+            name: String::new(),
+        }
+    }
+}
+```
+
+## Generic Default
+
+```rust
+// Require Default in generic bounds when needed
+fn create_or_default<T: Default>(opt: Option<T>) -> T {
+    opt.unwrap_or_default()
+}
+
+// PhantomData is Default regardless of T
+use std::marker::PhantomData;
+struct Wrapper<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> Default for Wrapper<T> {
+    fn default() -> Self {
+        Wrapper { _marker: PhantomData }
+    }
+}
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Building complex types
+- [api-common-traits](./api-common-traits.md) - Other common traits to implement
+- [api-from-not-into](./api-from-not-into.md) - Conversion traits

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-extension-trait.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-extension-trait.md
@@ -1,0 +1,163 @@
+# api-extension-trait
+
+> Use extension traits to add methods to external types
+
+## Why It Matters
+
+Rust's orphan rules prevent implementing external traits on external types. Extension traits provide a workaround: define a new trait with your methods, then implement it for the external type. This pattern is used extensively in the ecosystem (e.g., `itertools::Itertools`, `tokio::AsyncReadExt`).
+
+## Bad
+
+```rust
+// Can't add methods directly to external types
+impl Vec<u8> {
+    fn as_hex(&self) -> String {
+        // Error: cannot define inherent impl for a type outside this crate
+    }
+}
+
+// Can't implement external trait for external type
+impl SomeExternalTrait for Vec<u8> {
+    // Error: orphan rules violation
+}
+```
+
+## Good
+
+```rust
+// Define an extension trait
+pub trait ByteSliceExt {
+    fn as_hex(&self) -> String;
+    fn is_ascii_printable(&self) -> bool;
+}
+
+// Implement for the external type
+impl ByteSliceExt for [u8] {
+    fn as_hex(&self) -> String {
+        self.iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    }
+    
+    fn is_ascii_printable(&self) -> bool {
+        self.iter().all(|b| b.is_ascii_graphic() || b.is_ascii_whitespace())
+    }
+}
+
+// Usage: import the trait to use the methods
+use my_crate::ByteSliceExt;
+
+let data: &[u8] = b"hello";
+println!("{}", data.as_hex());  // "68656c6c6f"
+```
+
+## Convention: Ext Suffix
+
+```rust
+// Standard naming: TypeExt for extending Type
+pub trait OptionExt<T> {
+    fn unwrap_or_log(self, msg: &str) -> Option<T>;
+}
+
+impl<T> OptionExt<T> for Option<T> {
+    fn unwrap_or_log(self, msg: &str) -> Option<T> {
+        if self.is_none() {
+            log::warn!("{}", msg);
+        }
+        self
+    }
+}
+
+// For generic extensions
+pub trait ResultExt<T, E> {
+    fn log_err(self) -> Self;
+}
+
+impl<T, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
+    fn log_err(self) -> Self {
+        if let Err(ref e) = self {
+            log::error!("{}", e);
+        }
+        self
+    }
+}
+```
+
+## Ecosystem Examples
+
+```rust
+// itertools::Itertools
+use itertools::Itertools;
+let groups = vec![1, 1, 2, 2, 3].into_iter().group_by(|x| *x);
+
+// futures::StreamExt
+use futures::StreamExt;
+let next = stream.next().await;
+
+// tokio::io::AsyncReadExt
+use tokio::io::AsyncReadExt;
+let mut buf = [0u8; 1024];
+reader.read(&mut buf).await?;
+
+// anyhow::Context
+use anyhow::Context;
+let content = std::fs::read_to_string(path)
+    .with_context(|| format!("failed to read {}", path))?;
+```
+
+## Scoped Extensions
+
+```rust
+// Extension only visible where imported
+mod string_utils {
+    pub trait StringExt {
+        fn truncate_ellipsis(&self, max_len: usize) -> String;
+    }
+    
+    impl StringExt for str {
+        fn truncate_ellipsis(&self, max_len: usize) -> String {
+            if self.len() <= max_len {
+                self.to_string()
+            } else {
+                format!("{}...", &self[..max_len.saturating_sub(3)])
+            }
+        }
+    }
+}
+
+// Only available when explicitly imported
+use string_utils::StringExt;
+let short = "very long string".truncate_ellipsis(10);
+```
+
+## Generic Extensions with Bounds
+
+```rust
+pub trait VecExt<T> {
+    fn push_if_unique(&mut self, item: T)
+    where
+        T: PartialEq;
+}
+
+impl<T> VecExt<T> for Vec<T> {
+    fn push_if_unique(&mut self, item: T)
+    where
+        T: PartialEq,
+    {
+        if !self.contains(&item) {
+            self.push(item);
+        }
+    }
+}
+
+// Works with any T: PartialEq
+let mut v = vec![1, 2, 3];
+v.push_if_unique(2);  // No-op
+v.push_if_unique(4);  // Adds 4
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Controlling trait implementations
+- [api-impl-into](./api-impl-into.md) - Using standard conversion traits
+- [name-as-free](./name-as-free.md) - Naming conventions for conversions

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-from-not-into.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-from-not-into.md
@@ -1,0 +1,146 @@
+# api-from-not-into
+
+> Implement `From<T>`, not `Into<U>` - From gives you Into for free
+
+## Why It Matters
+
+The standard library has a blanket implementation: `impl<T, U> Into<U> for T where U: From<T>`. This means implementing `From<T> for U` automatically gives you `Into<U> for T`. Implementing `Into` directly bypasses this and is considered non-idiomatic. Always implement `From`.
+
+## Bad
+
+```rust
+struct UserId(u64);
+
+// Non-idiomatic: implementing Into directly
+impl Into<UserId> for u64 {
+    fn into(self) -> UserId {
+        UserId(self)
+    }
+}
+
+// Works, but now you can't use From syntax
+let id = UserId::from(42);  // Error: From not implemented
+let id: UserId = 42.into(); // Works, but limited
+```
+
+## Good
+
+```rust
+struct UserId(u64);
+
+// Idiomatic: implement From
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        UserId(id)
+    }
+}
+
+// Now both work automatically
+let id = UserId::from(42);   // From syntax
+let id: UserId = 42.into();  // Into syntax (via blanket impl)
+
+// And Into bound works in generics
+fn process(id: impl Into<UserId>) {
+    let id: UserId = id.into();
+}
+process(42u64);  // Works!
+```
+
+## Blanket Implementation
+
+```rust
+// This is in std, you don't write it
+impl<T, U> Into<U> for T
+where
+    U: From<T>,
+{
+    fn into(self) -> U {
+        U::from(self)
+    }
+}
+
+// So when you implement From:
+impl From<String> for MyType { ... }
+
+// You automatically get:
+// impl Into<MyType> for String { ... }
+```
+
+## Multiple From Implementations
+
+```rust
+struct Email(String);
+
+impl From<String> for Email {
+    fn from(s: String) -> Self {
+        Email(s)
+    }
+}
+
+impl From<&str> for Email {
+    fn from(s: &str) -> Self {
+        Email(s.to_string())
+    }
+}
+
+// All of these work
+let e1 = Email::from("test@example.com");
+let e2 = Email::from(String::from("test@example.com"));
+let e3: Email = "test@example.com".into();
+let e4: Email = String::from("test@example.com").into();
+```
+
+## TryFrom for Fallible Conversions
+
+```rust
+use std::convert::TryFrom;
+
+struct PositiveInt(u32);
+
+// Fallible conversion
+impl TryFrom<i32> for PositiveInt {
+    type Error = &'static str;
+    
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value > 0 {
+            Ok(PositiveInt(value as u32))
+        } else {
+            Err("value must be positive")
+        }
+    }
+}
+
+// Usage
+let pos = PositiveInt::try_from(42)?;   // From-style
+let pos: PositiveInt = 42.try_into()?;  // Into-style (via blanket)
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+from_over_into = "warn"  # Warns when implementing Into instead of From
+```
+
+```rust
+// Clippy will warn:
+impl Into<Bar> for Foo {  // Warning: prefer From
+    fn into(self) -> Bar { ... }
+}
+```
+
+## When Into IS Needed (Rare)
+
+```rust
+// Only when implementing for external types in specific trait bounds
+// This is very rare and usually indicates a design issue
+
+// Example: you can't implement From<ExternalA> for ExternalB
+// because of orphan rules. But you usually shouldn't need to.
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - Using Into in function parameters
+- [err-from-impl](./err-from-impl.md) - From for error types
+- [api-newtype-safety](./api-newtype-safety.md) - Newtype conversions

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-impl-asref.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-impl-asref.md
@@ -1,0 +1,142 @@
+# api-impl-asref
+
+> Use `AsRef<T>` when you only need to borrow the inner data
+
+## Why It Matters
+
+`AsRef<T>` provides a cheap borrowed view of data without taking ownership or copying. Functions accepting `impl AsRef<T>` can work with multiple types that contain or represent `T`, making APIs flexible while avoiding unnecessary allocations. Use `AsRef` when you only need to read, `Into` when you need to own.
+
+## Bad
+
+```rust
+// Forces callers to provide exact types
+fn process_text(text: &str) { ... }
+fn read_file(path: &Path) { ... }
+
+// Can't call directly with owned types
+let s = String::from("hello");
+process_text(&s);  // Works but verbose
+
+let p = PathBuf::from("/file");
+read_file(&p);  // Works but verbose
+read_file("/file");  // Error! &str != &Path
+```
+
+## Good
+
+```rust
+// Accept anything that can be viewed as the target type
+fn process_text(text: impl AsRef<str>) {
+    let s: &str = text.as_ref();
+    println!("{}", s);
+}
+
+fn read_file(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
+    std::fs::read(path.as_ref())
+}
+
+// All of these work:
+process_text("literal");        // &str
+process_text(String::from("owned"));  // String
+process_text(Cow::from("cow")); // Cow<str>
+
+read_file("/path/to/file");     // &str  
+read_file(Path::new("/path"));  // &Path
+read_file(PathBuf::from("/path")); // PathBuf
+read_file(OsStr::new("/path")); // &OsStr
+```
+
+## AsRef vs Into vs Borrow
+
+```rust
+// AsRef<T>: cheap borrow, no ownership transfer
+fn read(p: impl AsRef<Path>) {
+    let path: &Path = p.as_ref();
+}
+
+// Into<T>: ownership transfer, may allocate
+fn store(p: impl Into<PathBuf>) {
+    let owned: PathBuf = p.into();
+}
+
+// Borrow<T>: like AsRef but with Eq/Hash consistency guarantee
+use std::borrow::Borrow;
+fn lookup<Q: ?Sized>(map: &HashMap<String, V>, key: &Q) -> Option<&V>
+where
+    String: Borrow<Q>,
+    Q: Hash + Eq,
+{
+    map.get(key)
+}
+```
+
+## Implement AsRef for Custom Types
+
+```rust
+struct Name(String);
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Name {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+// Now Name works with functions expecting AsRef<str>
+fn greet(name: impl AsRef<str>) {
+    println!("Hello, {}!", name.as_ref());
+}
+
+greet(Name("Alice".into()));
+```
+
+## Common AsRef Implementations
+
+```rust
+// Standard library provides many
+impl AsRef<str> for String { ... }
+impl AsRef<str> for str { ... }
+impl AsRef<[u8]> for str { ... }
+impl AsRef<[u8]> for String { ... }
+impl AsRef<[u8]> for Vec<u8> { ... }
+impl AsRef<Path> for str { ... }
+impl AsRef<Path> for String { ... }
+impl AsRef<Path> for PathBuf { ... }
+impl AsRef<Path> for OsStr { ... }
+impl AsRef<OsStr> for str { ... }
+```
+
+## When to Use Which
+
+| Trait | Use When |
+|-------|----------|
+| `&T` | Single type, simple API |
+| `AsRef<T>` | Read-only access, multiple input types |
+| `Into<T>` | Need to store/own the value |
+| `Borrow<T>` | HashMap/HashSet keys, Eq/Hash needed |
+| `Deref<Target=T>` | Smart pointer semantics |
+
+## Pattern: Optional AsRef Bound
+
+```rust
+// When T itself might be passed
+fn process<T: AsRef<U>, U>(value: T) {
+    let inner: &U = value.as_ref();
+}
+
+// More flexible: accept T or &T
+fn process<T: AsRef<U> + ?Sized, U: ?Sized>(value: &T) {
+    let inner: &U = value.as_ref();
+}
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - When to use Into instead
+- [own-slice-over-vec](./own-slice-over-vec.md) - Using slices for flexibility
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Preferring borrows

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-impl-into.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-impl-into.md
@@ -1,0 +1,160 @@
+# api-impl-into
+
+> Accept `impl Into<T>` for flexible APIs, implement `From<T>` for conversions
+
+## Why It Matters
+
+APIs that accept `impl Into<T>` are ergonomic—callers can pass the target type directly or any type that converts to it. This reduces boilerplate `.into()` calls at call sites. Implement `From<T>` rather than `Into<T>` because `From` implies `Into` through a blanket implementation.
+
+## Bad
+
+```rust
+// Requires exact type - forces callers to convert
+fn process_path(path: PathBuf) { ... }
+fn set_name(name: String) { ... }
+
+// Caller must convert explicitly
+process_path(PathBuf::from("/path/to/file"));
+process_path("/path/to/file".to_path_buf());  // Verbose
+process_path("/path/to/file".into());          // Explicit
+
+set_name(String::from("Alice"));
+set_name("Alice".to_string());  // Verbose
+```
+
+## Good
+
+```rust
+// Accept anything that converts to the target type
+fn process_path(path: impl Into<PathBuf>) {
+    let path = path.into();  // Convert once inside
+    // ...
+}
+
+fn set_name(name: impl Into<String>) {
+    let name = name.into();
+    // ...
+}
+
+// Callers are ergonomic
+process_path("/path/to/file");    // &str converts automatically
+process_path(PathBuf::from(".")); // PathBuf works too
+
+set_name("Alice");                // &str
+set_name(String::from("Alice"));  // String
+set_name(format!("User-{}", id)); // String from format!
+```
+
+## Implement From, Not Into
+
+```rust
+struct UserId(u64);
+
+// ✅ Implement From
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        UserId(id)
+    }
+}
+
+// Into is automatically provided by blanket impl
+let id: UserId = 42u64.into();  // Works!
+
+// ❌ Don't implement Into directly
+impl Into<UserId> for u64 {
+    fn into(self) -> UserId {
+        UserId(self)  // This works but is non-idiomatic
+    }
+}
+```
+
+## Common Conversions
+
+```rust
+// String-like types
+fn log_message(msg: impl Into<String>) { ... }
+log_message("literal");           // &str
+log_message(String::from("own")); // String
+log_message(Cow::from("cow"));    // Cow<str>
+
+// Path-like types  
+fn read_file(path: impl AsRef<Path>) { ... }  // AsRef for borrowed access
+fn write_file(path: impl Into<PathBuf>) { ... }  // Into when storing
+
+// Duration
+fn set_timeout(duration: impl Into<Duration>) { ... }
+set_timeout(Duration::from_secs(5));
+// Note: no blanket impl for integers, would need custom wrapper
+```
+
+## AsRef vs Into
+
+```rust
+// AsRef<T>: borrow as &T, no conversion cost
+fn count_bytes(data: impl AsRef<[u8]>) -> usize {
+    data.as_ref().len()  // Just borrows, no allocation
+}
+count_bytes("hello");  // &str -> &[u8]
+count_bytes(b"hello"); // &[u8] -> &[u8]
+count_bytes(vec![1, 2, 3]);  // &Vec<u8> -> &[u8]
+
+// Into<T>: convert to owned T, may allocate
+fn store_data(data: impl Into<Vec<u8>>) {
+    let owned: Vec<u8> = data.into();  // Takes ownership
+    // ...
+}
+```
+
+## When NOT to Use impl Into
+
+```rust
+// ❌ Trait objects need Sized
+fn process(handler: impl Into<Box<dyn Handler>>) { }
+// Better: just take Box<dyn Handler> directly
+
+// ❌ Recursive types
+struct Node {
+    children: Vec<impl Into<Node>>,  // Error: impl Trait not allowed here
+}
+
+// ❌ Performance-critical hot paths (minor overhead of trait dispatch)
+fn hot_path(value: impl Into<u64>) {
+    // Consider taking u64 directly if called billions of times
+}
+
+// ❌ When you need to name the type
+fn returns_impl() -> impl Into<String> { }  // Opaque, hard to use
+```
+
+## Builder Pattern with Into
+
+```rust
+struct Config {
+    name: String,
+    path: PathBuf,
+}
+
+impl Config {
+    fn new(name: impl Into<String>) -> Self {
+        Config {
+            name: name.into(),
+            path: PathBuf::new(),
+        }
+    }
+    
+    fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = path.into();
+        self
+    }
+}
+
+// Clean builder calls
+let config = Config::new("myapp")
+    .path("/etc/myapp");
+```
+
+## See Also
+
+- [api-impl-asref](./api-impl-asref.md) - When to use AsRef instead
+- [api-from-not-into](./api-from-not-into.md) - Why From is preferred
+- [err-from-impl](./err-from-impl.md) - From for error conversion

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-must-use.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-must-use.md
@@ -1,0 +1,125 @@
+# api-must-use
+
+> Mark types and functions with `#[must_use]` when ignoring results is likely a bug
+
+## Why It Matters
+
+Some return values should never be ignored—`Result`, locks, RAII guards, computed values that have no side effects. Without `#[must_use]`, silently discarding these values can introduce subtle bugs that are hard to detect. The attribute generates compiler warnings when the value is unused.
+
+## Bad
+
+```rust
+// Result ignored - error silently dropped
+fn send_email(to: &str, body: &str) -> Result<(), EmailError> { ... }
+
+send_email("user@example.com", "Hello!");  // No warning if Result ignored!
+// Email may have failed, but we don't know
+
+// Computed value ignored - likely a bug
+fn compute_checksum(data: &[u8]) -> u32 { ... }
+
+let data = vec![1, 2, 3, 4];
+compute_checksum(&data);  // Result discarded - pointless call
+```
+
+## Good
+
+```rust
+#[must_use = "this `Result` may be an `Err` that should be handled"]
+fn send_email(to: &str, body: &str) -> Result<(), EmailError> { ... }
+
+send_email("user@example.com", "Hello!");  
+// Warning: unused `Result` that must be used
+
+// Mark pure functions
+#[must_use = "this returns a new value and does not modify the input"]
+fn compute_checksum(data: &[u8]) -> u32 { ... }
+
+compute_checksum(&data);
+// Warning: unused return value of `compute_checksum` that must be used
+```
+
+## Apply to Types
+
+```rust
+// Mark the type itself when it should always be used
+#[must_use = "futures do nothing unless polled"]
+struct MyFuture<T> { ... }
+
+// Mark RAII guards
+#[must_use = "if unused, the lock will be immediately released"]
+struct MutexGuard<'a, T> { ... }
+
+// Mark results/errors
+#[must_use = "errors should be handled"]
+enum AppError { ... }
+```
+
+## Standard Library Examples
+
+```rust
+// Result and Option are #[must_use]
+let v: Vec<i32> = vec![1, 2, 3];
+v.first();  // Warning: unused Option
+
+// Iterator adapters are #[must_use]
+v.iter().map(|x| x * 2);  // Warning: iterators are lazy
+
+// String methods that return new values
+let s = "hello";
+s.to_uppercase();  // Warning: unused String
+```
+
+## When to Apply
+
+```rust
+// ✅ Pure functions (no side effects)
+#[must_use]
+fn add(a: i32, b: i32) -> i32 { a + b }
+
+// ✅ Builder methods returning Self
+#[must_use = "builder methods return a new builder"]
+fn with_timeout(self, t: Duration) -> Self { ... }
+
+// ✅ Fallible operations
+#[must_use]
+fn try_parse(s: &str) -> Result<Data, ParseError> { ... }
+
+// ✅ Iterators and futures (lazy)
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+struct Map<I, F> { ... }
+
+// ❌ Side-effecting functions where result is optional
+fn log(msg: &str) -> Result<(), io::Error> { ... }  // Might be ok to ignore
+
+// ❌ Methods with useful side effects
+fn vec.push(item);  // Mutates vec, no return to use
+```
+
+## Custom Messages
+
+```rust
+#[must_use = "creating a guard does nothing without assignment"]
+struct ScopeGuard { ... }
+
+#[must_use = "this returns the old value"]
+fn replace(&mut self, new: T) -> T { ... }
+
+#[must_use = "use `.await` to execute the future"]
+async fn fetch() -> Data { ... }
+```
+
+## Clippy Lints
+
+```toml
+[lints.clippy]
+must_use_candidate = "warn"      # Suggests where to add #[must_use]
+unused_must_use = "deny"          # Built-in, treat warnings as errors
+double_must_use = "warn"          # Redundant #[must_use]
+```
+
+## See Also
+
+- [api-builder-must-use](./api-builder-must-use.md) - Builder pattern must_use
+- [err-result-over-panic](./err-result-over-panic.md) - Result types require handling
+- [lint-deny-correctness](./lint-deny-correctness.md) - Enabling useful lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-newtype-safety.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-newtype-safety.md
@@ -1,0 +1,162 @@
+# api-newtype-safety
+
+> Use newtypes to prevent mixing semantically different values
+
+## Why It Matters
+
+Raw primitives like `u64` or `String` carry no semantic meaning. A function taking `(u64, u64)` can easily be called with arguments swapped. Newtypes wrap primitives in distinct types, making the compiler catch mistakes at compile time rather than runtime.
+
+## Bad
+
+```rust
+struct User {
+    id: u64,
+    group_id: u64,
+    created_at: u64,  // Unix timestamp
+}
+
+fn add_user_to_group(user_id: u64, group_id: u64) { ... }
+
+// Bug: arguments swapped - compiles fine, fails at runtime
+let user = User { id: 100, group_id: 5, created_at: 1234567890 };
+add_user_to_group(user.group_id, user.id);  // Silent bug!
+
+// Bug: wrong field used - timestamp passed as ID
+add_user_to_group(user.created_at, user.group_id);  // Compiles fine!
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UserId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct GroupId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Timestamp(u64);
+
+struct User {
+    id: UserId,
+    group_id: GroupId,
+    created_at: Timestamp,
+}
+
+fn add_user_to_group(user_id: UserId, group_id: GroupId) { ... }
+
+// Compile error: expected UserId, found GroupId
+let user = User { ... };
+add_user_to_group(user.group_id, user.id);  // Error!
+
+// Compile error: expected UserId, found Timestamp
+add_user_to_group(user.created_at, user.group_id);  // Error!
+```
+
+## Derive Common Traits
+
+```rust
+// Minimal: just enough for your use case
+#[derive(Debug, Clone, Copy)]
+struct MeterId(u32);
+
+// Full ID type: hashable, comparable, displayable
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OrderId(u64);
+
+impl std::fmt::Display for OrderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ORD-{:08}", self.0)
+    }
+}
+
+// With serde for serialization
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]  // Serializes as raw u64
+struct ProductId(u64);
+```
+
+## Constructor Patterns
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Email(String);
+
+impl Email {
+    /// Creates a new Email, validating the format.
+    pub fn new(s: &str) -> Result<Self, EmailError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(EmailError::InvalidFormat)
+        }
+    }
+    
+    /// Returns the email as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// Usage enforces validation
+let email = Email::new("user@example.com")?;  // Must go through validation
+```
+
+## Zero-Cost Abstraction
+
+```rust
+use std::mem::size_of;
+
+#[derive(Clone, Copy)]
+struct Miles(f64);
+
+#[derive(Clone, Copy)]
+struct Kilometers(f64);
+
+// Same size as raw f64
+assert_eq!(size_of::<Miles>(), size_of::<f64>());
+assert_eq!(size_of::<Kilometers>(), size_of::<f64>());
+
+// But can't accidentally mix them
+fn drive(distance: Miles) { ... }
+
+let km = Kilometers(100.0);
+drive(km);  // Error: expected Miles, found Kilometers
+
+// Explicit conversion
+impl From<Kilometers> for Miles {
+    fn from(km: Kilometers) -> Self {
+        Miles(km.0 * 0.621371)
+    }
+}
+
+drive(km.into());  // Explicit, visible conversion
+```
+
+## When Newtypes Help Most
+
+```rust
+// ✅ IDs that could be confused
+fn transfer(from: AccountId, to: AccountId, amount: Money) { ... }
+
+// ✅ Units that shouldn't mix
+struct Celsius(f64);
+struct Fahrenheit(f64);
+
+// ✅ Validated strings
+struct Username(String);  // Validated alphanumeric
+struct Password(String);  // Never logged
+
+// ✅ Different meanings of same type
+struct Milliseconds(u64);
+struct Seconds(u64);
+
+// ❌ Overkill: single use, no confusion possible
+struct X(i32);  // Just use i32
+```
+
+## See Also
+
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern for IDs
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven validation
+- [own-copy-small](./own-copy-small.md) - Making newtypes Copy

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-non-exhaustive.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-non-exhaustive.md
@@ -1,0 +1,177 @@
+# api-non-exhaustive
+
+> Use `#[non_exhaustive]` on public enums and structs for forward compatibility
+
+## Why It Matters
+
+Adding a variant to a public enum or a field to a public struct is normally a breaking change—downstream code may match exhaustively or use struct literal syntax. `#[non_exhaustive]` forces external code to use wildcards in matches and constructors, allowing you to add variants/fields in minor versions without breaking callers.
+
+## Bad
+
+```rust
+// Public enum - adding variant breaks downstream matches
+pub enum ErrorKind {
+    NotFound,
+    PermissionDenied,
+    TimedOut,
+}
+
+// Downstream code
+match error.kind() {
+    ErrorKind::NotFound => ...,
+    ErrorKind::PermissionDenied => ...,
+    ErrorKind::TimedOut => ...,
+    // No wildcard - will break when you add ErrorKind::Interrupted
+}
+
+// Public struct - adding field breaks downstream construction
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Downstream code
+let config = Config { name: "test".into(), value: 42 };
+// Will break when you add `pub enabled: bool`
+```
+
+## Good
+
+```rust
+// Can add variants in minor versions
+#[non_exhaustive]
+pub enum ErrorKind {
+    NotFound,
+    PermissionDenied,
+    TimedOut,
+    // Future: can add Interrupted here without breaking changes
+}
+
+// Downstream code MUST have wildcard
+match error.kind() {
+    ErrorKind::NotFound => ...,
+    ErrorKind::PermissionDenied => ...,
+    ErrorKind::TimedOut => ...,
+    _ => ...,  // Required by non_exhaustive
+}
+
+// Can add fields in minor versions
+#[non_exhaustive]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Downstream CANNOT use struct literal syntax
+// let config = Config { name: "test".into(), value: 42 };  // Error!
+
+// Must use constructor
+impl Config {
+    pub fn new(name: impl Into<String>, value: i32) -> Self {
+        Config { name: name.into(), value }
+    }
+}
+```
+
+## How It Works
+
+```rust
+#[non_exhaustive]
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+// Inside your crate: exhaustive match is allowed
+fn internal(s: Status) {
+    match s {
+        Status::Active => {},
+        Status::Inactive => {},
+        // No wildcard needed inside defining crate
+    }
+}
+
+// Outside your crate: wildcard required
+fn external(s: my_crate::Status) {
+    match s {
+        my_crate::Status::Active => {},
+        my_crate::Status::Inactive => {},
+        _ => {},  // REQUIRED
+    }
+}
+```
+
+## Struct Usage
+
+```rust
+#[non_exhaustive]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    // Provide constructor
+    pub fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+}
+
+// External code can read fields but not construct with literals
+fn external(p: Point) {
+    println!("x: {}, y: {}", p.x, p.y);  // Reading is fine
+    
+    // let p2 = Point { x: 1.0, y: 2.0 };  // Error!
+    let p2 = Point::new(1.0, 2.0);  // Must use constructor
+}
+```
+
+## Non-Exhaustive Variants
+
+```rust
+pub enum Message {
+    // Specific variant is non-exhaustive
+    #[non_exhaustive]
+    Error { code: u32, message: String },
+    
+    Ok(Data),
+}
+
+// Can destructure Ok normally
+// But Error requires `..` to handle future fields
+match msg {
+    Message::Ok(data) => {},
+    Message::Error { code, message, .. } => {},  // `..` required
+}
+```
+
+## When to Use
+
+```rust
+// ✅ Use for public API types that may evolve
+#[non_exhaustive]
+pub enum ApiError { ... }
+
+#[non_exhaustive]
+pub struct Options { ... }
+
+// ✅ Use for error types
+#[non_exhaustive]
+pub enum MyError { ... }
+
+// ❌ Don't use for internal types
+enum InternalState { ... }  // Not public, no concern
+
+// ❌ Don't use for stable, complete types
+pub enum Ordering {  // Less, Equal, Greater is complete
+    Less,
+    Equal,
+    Greater,
+}
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Controlling trait implementations
+- [err-custom-type](./err-custom-type.md) - Error type design
+- [api-builder-pattern](./api-builder-pattern.md) - Alternative to struct literals

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-parse-dont-validate.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-parse-dont-validate.md
@@ -1,0 +1,184 @@
+# api-parse-dont-validate
+
+> Parse into validated types at boundaries
+
+## Why It Matters
+
+Instead of validating data and hoping you remember to check everywhere, parse it into a type that can only be constructed from valid data. The type system then guarantees validity - you can't forget to validate because invalid states are unrepresentable.
+
+## Bad
+
+```rust
+// Validation scattered throughout codebase
+fn send_email(email: &str) -> Result<(), Error> {
+    // Did someone validate this already? Who knows!
+    if !is_valid_email(email) {
+        return Err(Error::InvalidEmail);
+    }
+    // Send email...
+}
+
+fn add_to_mailing_list(email: &str) -> Result<(), Error> {
+    // Duplicate validation, or did we forget?
+    if !is_valid_email(email) {
+        return Err(Error::InvalidEmail);
+    }
+    // Add to list...
+}
+
+// Easy to forget validation
+fn process_user_email(email: &str) {
+    // Oops, no validation!
+    database.store_email(email);
+}
+```
+
+## Good
+
+```rust
+/// A validated email address.
+/// Can only be constructed via `Email::parse()`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Email(String);
+
+impl Email {
+    /// Parses and validates an email address.
+    pub fn parse(s: impl Into<String>) -> Result<Self, EmailError> {
+        let s = s.into();
+        if Self::is_valid(&s) {
+            Ok(Email(s))
+        } else {
+            Err(EmailError::Invalid)
+        }
+    }
+    
+    fn is_valid(s: &str) -> bool {
+        s.contains('@') && s.len() > 3  // Simplified
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// Now functions can accept Email - guaranteed valid!
+fn send_email(email: &Email) -> Result<(), Error> {
+    // No validation needed - Email is always valid
+    smtp_send(email.as_str())
+}
+
+fn add_to_mailing_list(email: Email) {
+    // No validation needed
+    list.push(email);
+}
+```
+
+## More Examples
+
+```rust
+// Port number (1-65535)
+pub struct Port(u16);
+
+impl Port {
+    pub fn new(n: u16) -> Option<Self> {
+        if n > 0 { Some(Port(n)) } else { None }
+    }
+    
+    pub fn get(&self) -> u16 {
+        self.0
+    }
+}
+
+// Non-empty string
+pub struct NonEmptyString(String);
+
+impl NonEmptyString {
+    pub fn new(s: impl Into<String>) -> Option<Self> {
+        let s = s.into();
+        if s.is_empty() { None } else { Some(Self(s)) }
+    }
+}
+
+// Positive integer
+pub struct PositiveI32(i32);
+
+impl PositiveI32 {
+    pub fn new(n: i32) -> Option<Self> {
+        if n > 0 { Some(Self(n)) } else { None }
+    }
+}
+
+// Bounded value
+pub struct Percentage(u8);
+
+impl Percentage {
+    pub fn new(n: u8) -> Option<Self> {
+        if n <= 100 { Some(Self(n)) } else { None }
+    }
+}
+```
+
+## Parsing at Boundaries
+
+```rust
+// Parse at the system boundary (API, CLI, config file)
+fn handle_request(raw: RawRequest) -> Result<Response, Error> {
+    // Parse ALL inputs upfront
+    let email = Email::parse(&raw.email)?;
+    let age = Age::parse(raw.age)?;
+    let username = Username::parse(&raw.username)?;
+    
+    // Now work with validated types
+    process_user(email, age, username)
+}
+
+fn process_user(email: Email, age: Age, username: Username) {
+    // All inputs guaranteed valid - no checks needed
+}
+```
+
+## Evidence from sqlx
+
+```rust
+// sqlx parses SQL at compile time, ensuring query validity
+// https://github.com/launchbadge/sqlx/blob/master/src/macros/mod.rs
+
+// The query! macro parses and validates SQL
+let user = sqlx::query!("SELECT * FROM users WHERE id = ?", id)
+    .fetch_one(&pool)
+    .await?;
+
+// If SQL is invalid, compilation fails - invalid state unrepresentable
+```
+
+## Combining with Display
+
+```rust
+use std::fmt;
+
+pub struct Email(String);
+
+impl Email {
+    pub fn parse(s: &str) -> Result<Self, EmailError> { ... }
+}
+
+// Implement Display for easy printing
+impl fmt::Display for Email {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Implement AsRef for easy borrowing
+impl AsRef<str> for Email {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## See Also
+
+- [api-newtype-safety](api-newtype-safety.md) - Use newtypes for type safety
+- [type-newtype-validated](type-newtype-validated.md) - Newtypes for validated data
+- [api-typestate](api-typestate.md) - Compile-time state machines

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-sealed-trait.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-sealed-trait.md
@@ -1,0 +1,168 @@
+# api-sealed-trait
+
+> Use sealed traits to prevent external implementations while allowing use
+
+## Why It Matters
+
+Public traits can be implemented by anyone, which may be undesirable when you need to guarantee behavior or add methods in future versions. A sealed trait can be used by external code but not implemented by it, giving you control over implementations while maintaining a usable API.
+
+## Bad
+
+```rust
+// Anyone can implement this trait
+pub trait DatabaseDriver {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+}
+
+// External crate implements it incorrectly
+impl DatabaseDriver for MyBadDriver {
+    fn connect(&self, url: &str) -> Connection {
+        // Buggy implementation that doesn't handle errors
+        unsafe { force_connect(url) }
+    }
+}
+
+// Later, you want to add a required method - BREAKING CHANGE
+pub trait DatabaseDriver {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+    fn transaction(&self) -> Transaction;  // External impls now broken!
+}
+```
+
+## Good
+
+```rust
+// Create a private module with a private trait
+mod private {
+    pub trait Sealed {}
+}
+
+// Public trait requires the private trait
+pub trait DatabaseDriver: private::Sealed {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+}
+
+// Only your crate can implement Sealed, thus DatabaseDriver
+pub struct PostgresDriver;
+impl private::Sealed for PostgresDriver {}
+impl DatabaseDriver for PostgresDriver {
+    fn connect(&self, url: &str) -> Connection { ... }
+    fn execute(&self, query: &str) -> Result<Rows, Error> { ... }
+}
+
+pub struct MySqlDriver;
+impl private::Sealed for MySqlDriver {}
+impl DatabaseDriver for MySqlDriver {
+    fn connect(&self, url: &str) -> Connection { ... }
+    fn execute(&self, query: &str) -> Result<Rows, Error> { ... }
+}
+
+// External crate cannot implement - private::Sealed is not accessible
+// impl DatabaseDriver for ExternalDriver { }  // Error!
+
+// But external code CAN use the trait
+fn use_driver(driver: &impl DatabaseDriver) {
+    let conn = driver.connect("postgres://localhost");
+}
+```
+
+## Full Pattern
+
+```rust
+pub mod db {
+    mod private {
+        pub trait Sealed {}
+    }
+    
+    /// Database driver trait.
+    /// 
+    /// This trait is sealed and cannot be implemented outside this crate.
+    pub trait Driver: private::Sealed {
+        /// Connects to the database.
+        fn connect(&self, url: &str) -> Result<Connection, Error>;
+        
+        /// Executes a query.
+        fn execute(&self, sql: &str) -> Result<Rows, Error>;
+    }
+    
+    pub struct Postgres;
+    impl private::Sealed for Postgres {}
+    impl Driver for Postgres { ... }
+    
+    pub struct Sqlite;
+    impl private::Sealed for Sqlite {}
+    impl Driver for Sqlite { ... }
+}
+
+// Usage works fine
+use db::{Driver, Postgres};
+
+fn query(driver: &impl Driver) {
+    driver.execute("SELECT 1")?;
+}
+
+query(&Postgres);
+```
+
+## Benefits of Sealing
+
+```rust
+// 1. Add methods without breaking changes
+pub trait Format: private::Sealed {
+    fn format(&self) -> String;
+    
+    // Added later - not breaking because no external impls exist
+    fn format_pretty(&self) -> String {
+        self.format()  // Default implementation
+    }
+}
+
+// 2. Guarantee invariants
+pub trait SafeBuffer: private::Sealed {
+    // You control all implementations, so you know they're all correct
+    fn get(&self, index: usize) -> Option<&u8>;
+}
+
+// 3. Use as marker traits
+pub trait ValidConfig: private::Sealed {}
+// Only validated configs implement this
+```
+
+## Partially Sealed
+
+```rust
+// Allow implementing some methods but not all
+mod private {
+    pub trait SealedCore {}
+}
+
+pub trait Plugin: private::SealedCore {
+    // Sealed - only we implement
+    fn initialize(&self);
+    fn shutdown(&self);
+    
+    // Open - users can override
+    fn name(&self) -> &str { "unnamed" }
+}
+
+// Only we can add new required sealed methods
+// Users can customize open methods
+```
+
+## When to Seal
+
+| Seal When | Don't Seal When |
+|-----------|-----------------|
+| API stability is critical | You want extension points |
+| Implementation correctness is hard | Users need custom implementations |
+| You'll add methods later | Trait is simple and stable |
+| Safety invariants required | Standard patterns (Iterator, etc.) |
+
+## See Also
+
+- [api-non-exhaustive](./api-non-exhaustive.md) - Related pattern for enums/structs
+- [api-extension-trait](./api-extension-trait.md) - Adding methods to external types
+- [api-typestate](./api-typestate.md) - Compile-time state guarantees

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-serde-optional.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-serde-optional.md
@@ -1,0 +1,182 @@
+# api-serde-optional
+
+> Make serde a feature flag, not a hard dependency for library crates
+
+## Why It Matters
+
+Not all users of your library need serialization. Making serde a required dependency adds compile time and binary size for everyone. Feature flags let users opt-in to serde support only when needed, following Rust's philosophy of zero-cost abstractions and minimal dependencies.
+
+## Bad
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+// lib.rs
+use serde::{Serialize, Deserialize};
+
+// Every user pays for serde, even if they don't need it
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+```
+
+## Good
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
+
+// lib.rs
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Users opt-in:
+// my_crate = { version = "1.0", features = ["serde"] }
+```
+
+## Macro Pattern
+
+```rust
+// Reusable macro for serde derives
+#[cfg(feature = "serde")]
+macro_rules! impl_serde {
+    ($($t:ty),*) => {
+        $(
+            impl serde::Serialize for $t {
+                // ...
+            }
+            impl<'de> serde::Deserialize<'de> for $t {
+                // ...
+            }
+        )*
+    };
+}
+
+#[cfg(not(feature = "serde"))]
+macro_rules! impl_serde {
+    ($($t:ty),*) => {};
+}
+
+// Or use cfg_attr for derived impls
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+```
+
+## Feature Documentation
+
+```rust
+// lib.rs
+
+//! # Features
+//!
+//! - `serde`: Enables `Serialize` and `Deserialize` implementations for all types.
+//!
+//! # Example with serde
+//!
+//! ```toml
+//! [dependencies]
+//! my_crate = { version = "1.0", features = ["serde"] }
+//! ```
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+/// A configuration type.
+/// 
+/// When the `serde` feature is enabled, this type implements
+/// `Serialize` and `Deserialize`.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub struct Config {
+    pub name: String,
+}
+```
+
+## Multiple Optional Dependencies
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+rkyv = { version = "0.7", optional = true }
+borsh = { version = "0.10", optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
+rkyv = ["dep:rkyv"]
+borsh = ["dep:borsh"]
+
+// lib.rs
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+pub struct Message {
+    pub id: u64,
+    pub content: String,
+}
+```
+
+## Testing with Features
+
+```bash
+# Test without serde
+cargo test
+
+# Test with serde
+cargo test --features serde
+
+# Test all feature combinations
+cargo test --all-features
+```
+
+```rust
+// Test serde round-trip when feature enabled
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde_roundtrip() {
+    let config = Config { name: "test".into() };
+    let json = serde_json::to_string(&config).unwrap();
+    let parsed: Config = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, parsed);
+}
+```
+
+## When to Make Serde Required
+
+```rust
+// ✅ Required: Library is about serialization
+// (e.g., json-schema, config-file parser)
+[dependencies]
+serde = "1.0"
+
+// ✅ Required: Domain heavily uses serde
+// (e.g., API client, data format library)
+
+// ❌ Optional: General-purpose utility library
+// ❌ Optional: Math/algorithm library
+// ❌ Optional: Most libraries!
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Library structure
+- [api-common-traits](./api-common-traits.md) - Core trait implementations
+- [lint-deny-correctness](./lint-deny-correctness.md) - Feature testing

--- a/.cursor/skills/rust-skills-leonardomso/rules/api-typestate.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/api-typestate.md
@@ -1,0 +1,199 @@
+# api-typestate
+
+> Use typestate pattern to encode state machine invariants in the type system
+
+## Why It Matters
+
+State machines with runtime state checks ("are we connected?", "is the transaction started?") can have invalid transitions. The typestate pattern uses different types for each state, making invalid state transitions compile errors. The compiler enforces your state machine.
+
+## Bad
+
+```rust
+struct Connection {
+    state: ConnectionState,
+    socket: Option<TcpStream>,
+}
+
+enum ConnectionState {
+    Disconnected,
+    Connected,
+    Authenticated,
+}
+
+impl Connection {
+    fn send(&mut self, data: &[u8]) -> Result<(), Error> {
+        // Runtime check - can fail if called in wrong state
+        if self.state != ConnectionState::Authenticated {
+            return Err(Error::NotAuthenticated);
+        }
+        self.socket.as_mut().unwrap().write_all(data)?;
+        Ok(())
+    }
+    
+    fn authenticate(&mut self, password: &str) -> Result<(), Error> {
+        // Runtime check - can fail
+        if self.state != ConnectionState::Connected {
+            return Err(Error::NotConnected);
+        }
+        // ...
+    }
+}
+
+// Bug: forgot to authenticate
+let mut conn = Connection::new();
+conn.connect()?;
+conn.send(b"data")?;  // Runtime error: NotAuthenticated
+```
+
+## Good
+
+```rust
+// Different types for each state
+struct Disconnected;
+struct Connected { socket: TcpStream }
+struct Authenticated { socket: TcpStream, session: Session }
+
+struct Connection<State> {
+    state: State,
+}
+
+impl Connection<Disconnected> {
+    fn new() -> Self {
+        Connection { state: Disconnected }
+    }
+    
+    fn connect(self, addr: &str) -> Result<Connection<Connected>, Error> {
+        let socket = TcpStream::connect(addr)?;
+        Ok(Connection { state: Connected { socket } })
+    }
+}
+
+impl Connection<Connected> {
+    fn authenticate(self, password: &str) -> Result<Connection<Authenticated>, Error> {
+        let session = do_auth(&self.state.socket, password)?;
+        Ok(Connection {
+            state: Authenticated { socket: self.state.socket, session }
+        })
+    }
+}
+
+impl Connection<Authenticated> {
+    fn send(&mut self, data: &[u8]) -> Result<(), Error> {
+        // No runtime check needed - type guarantees we're authenticated
+        self.state.socket.write_all(data)?;
+        Ok(())
+    }
+}
+
+// Bug: forgot to authenticate
+let conn = Connection::new();
+let conn = conn.connect("server:8080")?;
+conn.send(b"data");  // Compile error! send() not available on Connection<Connected>
+
+// Correct usage
+let conn = Connection::new();
+let conn = conn.connect("server:8080")?;
+let mut conn = conn.authenticate("secret")?;
+conn.send(b"data")?;  // Works - type is Connection<Authenticated>
+```
+
+## Builder Typestate
+
+```rust
+// Enforce required fields via typestate
+struct BuilderNoUrl;
+struct BuilderWithUrl { url: String }
+
+struct RequestBuilder<State> {
+    state: State,
+    timeout: Option<Duration>,
+}
+
+impl RequestBuilder<BuilderNoUrl> {
+    fn new() -> Self {
+        RequestBuilder {
+            state: BuilderNoUrl,
+            timeout: None,
+        }
+    }
+    
+    fn url(self, url: &str) -> RequestBuilder<BuilderWithUrl> {
+        RequestBuilder {
+            state: BuilderWithUrl { url: url.to_string() },
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl RequestBuilder<BuilderWithUrl> {
+    fn timeout(mut self, t: Duration) -> Self {
+        self.timeout = Some(t);
+        self
+    }
+    
+    // Only available once URL is set
+    fn build(self) -> Request {
+        Request {
+            url: self.state.url,
+            timeout: self.timeout,
+        }
+    }
+}
+
+// Compile error: build() not available
+let bad = RequestBuilder::new().build();
+
+// Correct: must set URL first
+let good = RequestBuilder::new()
+    .url("https://example.com")
+    .timeout(Duration::from_secs(30))
+    .build();
+```
+
+## Transaction Example
+
+```rust
+struct NotStarted;
+struct InProgress { tx_id: u64 }
+struct Committed;
+
+struct Transaction<State> {
+    conn: Connection,
+    state: State,
+}
+
+impl Transaction<NotStarted> {
+    fn begin(conn: Connection) -> Result<Transaction<InProgress>, Error> {
+        let tx_id = conn.execute("BEGIN")?;
+        Ok(Transaction {
+            conn,
+            state: InProgress { tx_id },
+        })
+    }
+}
+
+impl Transaction<InProgress> {
+    fn execute(&mut self, sql: &str) -> Result<(), Error> {
+        self.conn.execute(sql)
+    }
+    
+    fn commit(self) -> Result<Transaction<Committed>, Error> {
+        self.conn.execute("COMMIT")?;
+        Ok(Transaction {
+            conn: self.conn,
+            state: Committed,
+        })
+    }
+    
+    fn rollback(self) -> Connection {
+        let _ = self.conn.execute("ROLLBACK");
+        self.conn
+    }
+}
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Basic builder pattern
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven invariants
+- [api-sealed-trait](./api-sealed-trait.md) - Restricting trait implementations

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-bounded-channel.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-bounded-channel.md
@@ -1,0 +1,175 @@
+# async-bounded-channel
+
+> Use bounded channels to apply backpressure and prevent unbounded memory growth
+
+## Why It Matters
+
+Unbounded channels grow without limit when producers outpace consumers. In production, this leads to memory exhaustion. Bounded channels apply backpressure—producers wait when the channel is full, naturally throttling the system. This prevents OOM and makes resource usage predictable.
+
+## Bad
+
+```rust
+use tokio::sync::mpsc;
+
+// Unbounded channel - can grow forever
+let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+
+// Fast producer, slow consumer = unbounded memory growth
+tokio::spawn(async move {
+    loop {
+        let msg = generate_message();
+        tx.send(msg).unwrap();  // Never blocks, never fails (until OOM)
+    }
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        slow_process(msg).await;  // Can't keep up
+    }
+});
+// Memory grows unboundedly until crash
+```
+
+## Good
+
+```rust
+use tokio::sync::mpsc;
+
+// Bounded channel - backpressure when full
+let (tx, mut rx) = mpsc::channel::<Message>(100);  // Max 100 items
+
+// Producer waits when channel full
+tokio::spawn(async move {
+    loop {
+        let msg = generate_message();
+        // Blocks if channel is full - natural backpressure
+        tx.send(msg).await.unwrap();
+    }
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        slow_process(msg).await;
+    }
+});
+// Memory usage capped at ~100 messages
+```
+
+## Choosing Buffer Size
+
+```rust
+// Too small: frequent blocking, reduced throughput
+let (tx, rx) = mpsc::channel::<Item>(1);
+
+// Too large: delayed backpressure, memory waste
+let (tx, rx) = mpsc::channel::<Item>(1_000_000);
+
+// Guidelines:
+// - Start with expected burst size
+// - Measure actual usage in production
+// - Err on the smaller side initially
+
+// Small items, high throughput
+let (tx, rx) = mpsc::channel::<u64>(1000);
+
+// Large items, moderate throughput  
+let (tx, rx) = mpsc::channel::<LargeStruct>(100);
+
+// Low latency requirement
+let (tx, rx) = mpsc::channel::<Command>(10);
+```
+
+## Handling Full Channel
+
+```rust
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+let (tx, mut rx) = mpsc::channel::<Message>(100);
+
+// Option 1: Wait indefinitely (default)
+tx.send(msg).await?;
+
+// Option 2: Try send, fail if full
+match tx.try_send(msg) {
+    Ok(()) => println!("Sent"),
+    Err(TrySendError::Full(msg)) => {
+        println!("Channel full, dropping message");
+    }
+    Err(TrySendError::Closed(msg)) => {
+        println!("Receiver dropped");
+    }
+}
+
+// Option 3: Timeout
+match timeout(Duration::from_secs(1), tx.send(msg)).await {
+    Ok(Ok(())) => println!("Sent"),
+    Ok(Err(_)) => println!("Channel closed"),
+    Err(_) => println!("Timeout - channel full for too long"),
+}
+
+// Option 4: send with permit reservation
+let permit = tx.reserve().await?;
+permit.send(msg);  // Guaranteed to succeed
+```
+
+## Channel Types
+
+```rust
+// mpsc: many producers, single consumer
+let (tx, rx) = mpsc::channel::<Message>(100);
+let tx2 = tx.clone();  // Can clone sender
+
+// oneshot: single value, one producer, one consumer
+let (tx, rx) = oneshot::channel::<Response>();
+tx.send(response);  // Can only send once
+
+// broadcast: multiple consumers, each gets all messages
+let (tx, _) = broadcast::channel::<Event>(100);
+let mut rx1 = tx.subscribe();
+let mut rx2 = tx.subscribe();
+
+// watch: single latest value, multiple consumers
+let (tx, rx) = watch::channel::<State>(initial);
+// Receivers see latest value, not all values
+```
+
+## Worker Pool Pattern
+
+```rust
+async fn process_with_workers(items: Vec<Item>) -> Vec<Result> {
+    let (tx, rx) = mpsc::channel(100);
+    let rx = Arc::new(Mutex::new(rx));
+    
+    // Spawn worker pool
+    let workers: Vec<_> = (0..4).map(|_| {
+        let rx = rx.clone();
+        tokio::spawn(async move {
+            loop {
+                let item = {
+                    let mut rx = rx.lock().await;
+                    rx.recv().await
+                };
+                match item {
+                    Some(item) => process(item).await,
+                    None => break,
+                }
+            }
+        })
+    }).collect();
+    
+    // Send items
+    for item in items {
+        tx.send(item).await.unwrap();
+    }
+    drop(tx);  // Signal workers to stop
+    
+    futures::future::join_all(workers).await;
+}
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Multi-producer patterns
+- [async-oneshot-response](./async-oneshot-response.md) - Request-response pattern
+- [async-watch-latest](./async-watch-latest.md) - Latest-value broadcasting

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-broadcast-pubsub.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-broadcast-pubsub.md
@@ -1,0 +1,185 @@
+# async-broadcast-pubsub
+
+> Use `broadcast` channel for pub/sub where all subscribers receive all messages
+
+## Why It Matters
+
+Unlike `mpsc` where one consumer receives each message, `broadcast` delivers each message to all subscribers. This is ideal for event broadcasting, real-time notifications, or when multiple components need to react to the same events independently.
+
+## Bad
+
+```rust
+use tokio::sync::mpsc;
+
+// mpsc only delivers to ONE consumer
+let (tx, mut rx) = mpsc::channel::<Event>(100);
+
+// Only one of these receives each message!
+let mut rx2 = ???;  // Can't clone receiver
+```
+
+## Good
+
+```rust
+use tokio::sync::broadcast;
+
+// broadcast delivers to ALL subscribers
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// Each subscriber gets ALL messages
+let mut rx1 = tx.subscribe();
+let mut rx2 = tx.subscribe();
+
+tokio::spawn(async move {
+    while let Ok(event) = rx1.recv().await {
+        handle_in_logger(event);
+    }
+});
+
+tokio::spawn(async move {
+    while let Ok(event) = rx2.recv().await {
+        handle_in_metrics(event);
+    }
+});
+
+// Both subscribers receive this
+tx.send(Event::UserLogin { user_id: 42 })?;
+```
+
+## Broadcast Semantics
+
+```rust
+use tokio::sync::broadcast;
+
+let (tx, mut rx1) = broadcast::channel::<i32>(16);
+let mut rx2 = tx.subscribe();
+
+tx.send(1)?;
+tx.send(2)?;
+
+// Both receive all messages
+assert_eq!(rx1.recv().await?, 1);
+assert_eq!(rx1.recv().await?, 2);
+assert_eq!(rx2.recv().await?, 1);
+assert_eq!(rx2.recv().await?, 2);
+```
+
+## Handling Lagging Receivers
+
+```rust
+use tokio::sync::broadcast::{self, error::RecvError};
+
+let (tx, mut rx) = broadcast::channel::<Event>(16);
+
+loop {
+    match rx.recv().await {
+        Ok(event) => {
+            process(event);
+        }
+        Err(RecvError::Lagged(count)) => {
+            // Receiver couldn't keep up, missed `count` messages
+            log::warn!("Missed {} events", count);
+            // Continue receiving new messages
+        }
+        Err(RecvError::Closed) => {
+            break;  // All senders dropped
+        }
+    }
+}
+```
+
+## Event Bus Pattern
+
+```rust
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug)]
+enum AppEvent {
+    UserLoggedIn { user_id: u64 },
+    OrderCreated { order_id: u64 },
+    SystemShutdown,
+}
+
+struct EventBus {
+    tx: broadcast::Sender<AppEvent>,
+}
+
+impl EventBus {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(1000);
+        EventBus { tx }
+    }
+    
+    fn publish(&self, event: AppEvent) {
+        // Ignore error if no subscribers
+        let _ = self.tx.send(event);
+    }
+    
+    fn subscribe(&self) -> broadcast::Receiver<AppEvent> {
+        self.tx.subscribe()
+    }
+}
+
+// Usage
+let bus = EventBus::new();
+
+// Logger subscribes
+let mut log_rx = bus.subscribe();
+tokio::spawn(async move {
+    while let Ok(event) = log_rx.recv().await {
+        log::info!("Event: {:?}", event);
+    }
+});
+
+// Metrics subscribes
+let mut metrics_rx = bus.subscribe();
+tokio::spawn(async move {
+    while let Ok(event) = metrics_rx.recv().await {
+        record_metric(&event);
+    }
+});
+
+// Publish events
+bus.publish(AppEvent::UserLoggedIn { user_id: 42 });
+```
+
+## Broadcast vs Watch
+
+```rust
+// broadcast: subscribers get ALL messages
+// Good for: events, logs, notifications
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// watch: subscribers get LATEST value only
+// Good for: config changes, state updates
+let (tx, _) = watch::channel(initial_state);
+
+// If subscriber is slow:
+// - broadcast: they receive old messages (or lag)
+// - watch: they skip to latest (no history)
+```
+
+## Clone Requirement
+
+```rust
+// broadcast requires Clone because message is cloned to each receiver
+use tokio::sync::broadcast;
+
+#[derive(Clone)]  // Required for broadcast
+struct Event {
+    data: String,
+}
+
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// For non-Clone types, wrap in Arc
+use std::sync::Arc;
+
+let (tx, _) = broadcast::channel::<Arc<LargeNonClone>>(100);
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Single-consumer channels
+- [async-watch-latest](./async-watch-latest.md) - Latest-value only
+- [async-bounded-channel](./async-bounded-channel.md) - Buffer sizing

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-cancellation-token.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-cancellation-token.md
@@ -1,0 +1,203 @@
+# async-cancellation-token
+
+> Use `CancellationToken` for graceful shutdown and task cancellation
+
+## Why It Matters
+
+Dropping a `JoinHandle` doesn't cancel the task—it just detaches it. For graceful shutdown, you need explicit cancellation. `tokio_util::sync::CancellationToken` provides a cooperative cancellation mechanism that tasks can check and respond to, enabling clean resource cleanup.
+
+## Bad
+
+```rust
+// Dropping handle doesn't stop the task
+let handle = tokio::spawn(async {
+    loop {
+        do_work().await;
+    }
+});
+
+drop(handle);  // Task continues running in background!
+
+// Using bool flag - not async-aware
+let running = Arc::new(AtomicBool::new(true));
+
+tokio::spawn({
+    let running = running.clone();
+    async move {
+        while running.load(Ordering::Relaxed) {
+            do_work().await;  // Can't wake up if blocked here
+        }
+    }
+});
+
+running.store(false, Ordering::Relaxed);
+// Task won't stop until current do_work() completes
+```
+
+## Good
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+let token = CancellationToken::new();
+
+let handle = tokio::spawn({
+    let token = token.clone();
+    async move {
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    println!("Shutting down gracefully");
+                    cleanup().await;
+                    break;
+                }
+                _ = do_work() => {
+                    // Work completed
+                }
+            }
+        }
+    }
+});
+
+// Later: trigger cancellation
+token.cancel();
+handle.await?;  // Task completes cleanly
+```
+
+## CancellationToken API
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+// Create token
+let token = CancellationToken::new();
+
+// Clone for sharing (cheap Arc-based clone)
+let token2 = token.clone();
+
+// Check if cancelled (non-blocking)
+if token.is_cancelled() {
+    return;
+}
+
+// Wait for cancellation (async)
+token.cancelled().await;
+
+// Trigger cancellation
+token.cancel();
+
+// Child tokens - cancelled when parent is cancelled
+let child = token.child_token();
+```
+
+## Hierarchical Cancellation
+
+```rust
+async fn run_server(shutdown: CancellationToken) {
+    let listener = TcpListener::bind("0.0.0.0:8080").await?;
+    
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                println!("Server shutting down");
+                break;
+            }
+            result = listener.accept() => {
+                let (socket, _) = result?;
+                // Each connection gets child token
+                let conn_token = shutdown.child_token();
+                tokio::spawn(handle_connection(socket, conn_token));
+            }
+        }
+    }
+    
+    // Child tokens auto-cancelled when we exit
+}
+
+async fn handle_connection(socket: TcpStream, token: CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => {
+                // Connection cleanup
+                break;
+            }
+            data = socket.read() => {
+                // Handle data
+            }
+        }
+    }
+}
+```
+
+## Graceful Shutdown Pattern
+
+```rust
+use tokio::signal;
+
+async fn main() -> Result<()> {
+    let shutdown = CancellationToken::new();
+    
+    // Spawn signal handler
+    let shutdown_trigger = shutdown.clone();
+    tokio::spawn(async move {
+        signal::ctrl_c().await.expect("failed to listen for Ctrl+C");
+        println!("Received Ctrl+C, initiating shutdown...");
+        shutdown_trigger.cancel();
+    });
+    
+    // Run application with shutdown token
+    run_app(shutdown).await
+}
+
+async fn run_app(shutdown: CancellationToken) -> Result<()> {
+    let mut tasks = JoinSet::new();
+    
+    tasks.spawn(worker_task(shutdown.child_token()));
+    tasks.spawn(server_task(shutdown.child_token()));
+    
+    // Wait for shutdown or task completion
+    tokio::select! {
+        _ = shutdown.cancelled() => {
+            println!("Shutdown requested, waiting for tasks...");
+        }
+        Some(result) = tasks.join_next() => {
+            // A task completed/failed
+            result??;
+        }
+    }
+    
+    // Wait for remaining tasks with timeout
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        async { while tasks.join_next().await.is_some() {} }
+    ).await.ok();
+    
+    Ok(())
+}
+```
+
+## DropGuard Pattern
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+// Auto-cancel on drop
+let token = CancellationToken::new();
+let guard = token.clone().drop_guard();
+
+tokio::spawn({
+    let token = token.clone();
+    async move {
+        token.cancelled().await;
+        println!("Cancelled!");
+    }
+});
+
+drop(guard);  // Automatically calls token.cancel()
+```
+
+## See Also
+
+- [async-joinset-structured](./async-joinset-structured.md) - Managing multiple tasks
+- [async-select-racing](./async-select-racing.md) - select! for cancellation
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime shutdown

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-clone-before-await.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-clone-before-await.md
@@ -1,0 +1,171 @@
+# async-clone-before-await
+
+> Clone Arc/Rc data before await points to avoid holding references across suspension
+
+## Why It Matters
+
+References held across `.await` points extend the future's lifetime and can cause borrow checker issues or prevent `Send` bounds. Cloning `Arc`/`Rc` before the await ensures the future only holds owned data, making it `Send` and avoiding lifetime complications.
+
+## Bad
+
+```rust
+use std::sync::Arc;
+
+async fn process(data: Arc<Data>) {
+    // Borrow extends across await - future is not Send
+    let slice = &data.items[..];  // Borrow of Arc contents
+    
+    expensive_async_operation().await;  // Await with active borrow
+    
+    use_slice(slice);  // Still using the borrow
+}
+
+// Error: future cannot be sent between threads safely
+// because `&[Item]` cannot be sent between threads safely
+tokio::spawn(process(data));
+```
+
+## Good
+
+```rust
+use std::sync::Arc;
+
+async fn process(data: Arc<Data>) {
+    // Clone what you need before await
+    let items = data.items.clone();  // Owned Vec
+    
+    expensive_async_operation().await;
+    
+    use_items(&items);  // Using owned data
+}
+
+// Or clone the Arc itself
+async fn share_data(data: Arc<Data>) {
+    let data = data.clone();  // Another Arc handle
+    
+    some_async_work().await;
+    
+    process(&data);  // Safe - we own the Arc
+}
+```
+
+## The Send Problem
+
+```rust
+// Futures must be Send to spawn on multi-threaded runtime
+async fn not_send() {
+    let rc = Rc::new(42);  // Rc is !Send
+    
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    
+    println!("{}", rc);  // rc held across await
+}
+
+tokio::spawn(not_send());  // ERROR: future is not Send
+
+// Fix: use Arc or don't hold across await
+async fn is_send() {
+    let arc = Arc::new(42);  // Arc is Send
+    
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    
+    println!("{}", arc);
+}
+
+tokio::spawn(is_send());  // OK
+```
+
+## Minimizing Clones
+
+```rust
+// Bad: clone everything eagerly
+async fn wasteful(data: Arc<LargeData>) {
+    let data = (*data).clone();  // Clones entire LargeData
+    async_work().await;
+    use_one_field(&data.small_field);
+}
+
+// Good: clone only what you need
+async fn efficient(data: Arc<LargeData>) {
+    let small = data.small_field.clone();  // Clone only needed field
+    async_work().await;
+    use_one_field(&small);
+}
+
+// Good: if you need the whole thing, keep the Arc
+async fn arc_efficient(data: Arc<LargeData>) {
+    let data = data.clone();  // Cheap Arc clone
+    async_work().await;
+    use_data(&data);  // Access through Arc
+}
+```
+
+## Spawn Pattern
+
+```rust
+// Common pattern: clone for spawned task
+let shared = Arc::new(SharedState::new());
+
+for i in 0..10 {
+    let shared = shared.clone();  // Clone before moving into spawn
+    tokio::spawn(async move {
+        // Task owns its Arc clone
+        shared.do_something(i).await;
+    });
+}
+```
+
+## Scope-Based Approach
+
+```rust
+// Limit borrow scope to before await
+async fn scoped(data: Arc<Data>) {
+    // Scope 1: borrow, compute, drop borrow
+    let computed = {
+        let slice = &data.items[..];  // Borrow
+        compute_something(slice)       // Use
+    };  // Borrow ends here
+    
+    // Now safe to await
+    expensive_async_operation().await;
+    
+    use_computed(computed);
+}
+```
+
+## MutexGuard Across Await
+
+```rust
+use tokio::sync::Mutex;
+
+// BAD: holding guard across await
+async fn bad(mutex: Arc<Mutex<Data>>) {
+    let mut guard = mutex.lock().await;
+    guard.value += 1;
+    
+    slow_operation().await;  // Guard held during await!
+    
+    guard.value += 1;
+}
+
+// GOOD: release before await
+async fn good(mutex: Arc<Mutex<Data>>) {
+    {
+        let mut guard = mutex.lock().await;
+        guard.value += 1;
+    }  // Guard released
+    
+    slow_operation().await;
+    
+    {
+        let mut guard = mutex.lock().await;
+        guard.value += 1;
+    }
+}
+```
+
+## See Also
+
+- [async-no-lock-await](./async-no-lock-await.md) - Lock guards across await
+- [own-arc-shared](./own-arc-shared.md) - Arc usage patterns
+- [async-spawn-blocking](./async-spawn-blocking.md) - Blocking in async

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-join-parallel.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-join-parallel.md
@@ -1,0 +1,158 @@
+# async-join-parallel
+
+> Use `join!` or `try_join!` for concurrent independent futures
+
+## Why It Matters
+
+Awaiting futures sequentially takes the sum of their durations. `join!` runs futures concurrently, taking only as long as the slowest one. For independent operations like multiple API calls or parallel file reads, this can dramatically reduce latency.
+
+## Bad
+
+```rust
+async fn fetch_data() -> (User, Posts, Comments) {
+    // Sequential: 300ms total (100 + 100 + 100)
+    let user = fetch_user().await;        // 100ms
+    let posts = fetch_posts().await;      // 100ms  
+    let comments = fetch_comments().await; // 100ms
+    
+    (user, posts, comments)
+}
+
+async fn read_configs() -> Result<(Config, Settings)> {
+    // Sequential: 20ms + 20ms = 40ms
+    let config = fs::read_to_string("config.toml").await?;
+    let settings = fs::read_to_string("settings.json").await?;
+    
+    Ok((parse_config(&config)?, parse_settings(&settings)?))
+}
+```
+
+## Good
+
+```rust
+use tokio::join;
+
+async fn fetch_data() -> (User, Posts, Comments) {
+    // Concurrent: ~100ms total (max of all three)
+    let (user, posts, comments) = join!(
+        fetch_user(),
+        fetch_posts(),
+        fetch_comments(),
+    );
+    
+    (user, posts, comments)
+}
+
+use tokio::try_join;
+
+async fn read_configs() -> Result<(Config, Settings)> {
+    // Concurrent: ~20ms total
+    let (config_str, settings_str) = try_join!(
+        fs::read_to_string("config.toml"),
+        fs::read_to_string("settings.json"),
+    )?;
+    
+    Ok((parse_config(&config_str)?, parse_settings(&settings_str)?))
+}
+```
+
+## join! vs try_join!
+
+```rust
+// join! - all futures run to completion, returns tuple
+let (a, b, c) = join!(future_a, future_b, future_c);
+
+// try_join! - short-circuits on first error
+let (a, b, c) = try_join!(fallible_a, fallible_b, fallible_c)?;
+// If fallible_b fails, returns Err immediately
+// Other futures may still be running (cancellation is async)
+```
+
+## futures::join_all for Dynamic Collections
+
+```rust
+use futures::future::join_all;
+
+async fn fetch_all_users(ids: &[u64]) -> Vec<User> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    join_all(futures).await
+}
+
+// With fallible futures
+use futures::future::try_join_all;
+
+async fn fetch_all_users(ids: &[u64]) -> Result<Vec<User>> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    try_join_all(futures).await
+}
+```
+
+## Limiting Concurrency
+
+```rust
+use futures::stream::{self, StreamExt};
+
+async fn fetch_with_limit(ids: &[u64]) -> Vec<Result<User>> {
+    stream::iter(ids)
+        .map(|id| fetch_user(*id))
+        .buffer_unordered(10)  // Max 10 concurrent requests
+        .collect()
+        .await
+}
+
+// Or with tokio::sync::Semaphore
+use tokio::sync::Semaphore;
+
+async fn fetch_with_semaphore(ids: &[u64]) -> Vec<User> {
+    let semaphore = Arc::new(Semaphore::new(10));
+    
+    let futures: Vec<_> = ids.iter().map(|id| {
+        let semaphore = semaphore.clone();
+        async move {
+            let _permit = semaphore.acquire().await.unwrap();
+            fetch_user(*id).await
+        }
+    }).collect();
+    
+    join_all(futures).await
+}
+```
+
+## When NOT to Use join!
+
+```rust
+// ❌ Dependent futures - must be sequential
+async fn create_and_populate() -> Result<()> {
+    let db = create_database().await?;   // Must complete first
+    populate_tables(&db).await?;          // Depends on db
+    Ok(())
+}
+
+// ❌ Short-circuiting logic
+async fn find_first() -> Option<Data> {
+    // Want to stop when one succeeds
+    // Use select! instead
+}
+
+// ❌ Shared mutable state
+async fn bad_shared_state() {
+    let counter = Arc::new(Mutex::new(0));
+    // This might work but can cause contention
+    join!(
+        increment(counter.clone()),
+        increment(counter.clone()),
+    );
+}
+```
+
+## See Also
+
+- [async-try-join](./async-try-join.md) - Error handling in concurrent futures
+- [async-select-racing](./async-select-racing.md) - Racing futures
+- [async-joinset-structured](./async-joinset-structured.md) - Dynamic task sets

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-joinset-structured.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-joinset-structured.md
@@ -1,0 +1,195 @@
+# async-joinset-structured
+
+> Use `JoinSet` for managing dynamic collections of spawned tasks
+
+## Why It Matters
+
+When spawning a variable number of tasks, collecting `JoinHandle`s in a `Vec` and using `join_all` works but lacks flexibility. `JoinSet` provides a better abstraction: add/remove tasks dynamically, get results as they complete, and abort all on drop. It's the idiomatic way to manage task collections.
+
+## Bad
+
+```rust
+// Manual handle management
+let mut handles: Vec<JoinHandle<Result<Data>>> = Vec::new();
+
+for url in urls {
+    handles.push(tokio::spawn(fetch(url)));
+}
+
+// Wait for all, in order (not as they complete)
+let results = futures::future::join_all(handles).await;
+
+// No easy way to cancel all, handle errors progressively, or add more tasks
+```
+
+## Good
+
+```rust
+use tokio::task::JoinSet;
+
+let mut set = JoinSet::new();
+
+for url in urls {
+    set.spawn(fetch(url.clone()));
+}
+
+// Process results as they complete
+while let Some(result) = set.join_next().await {
+    match result {
+        Ok(Ok(data)) => process(data),
+        Ok(Err(e)) => log::error!("Task failed: {}", e),
+        Err(e) => log::error!("Task panicked: {}", e),
+    }
+}
+
+// All tasks done, set is empty
+```
+
+## Dynamic Task Addition
+
+```rust
+use tokio::task::JoinSet;
+
+async fn worker_pool(mut rx: mpsc::Receiver<Task>) {
+    let mut set = JoinSet::new();
+    let max_concurrent = 10;
+    
+    loop {
+        tokio::select! {
+            // Accept new tasks if under limit
+            Some(task) = rx.recv(), if set.len() < max_concurrent => {
+                set.spawn(process_task(task));
+            }
+            
+            // Process completed tasks
+            Some(result) = set.join_next() => {
+                handle_result(result);
+            }
+            
+            // Exit when no tasks and channel closed
+            else => break,
+        }
+    }
+}
+```
+
+## Abort on Drop
+
+```rust
+use tokio::task::JoinSet;
+
+{
+    let mut set = JoinSet::new();
+    set.spawn(long_running_task());
+    set.spawn(another_task());
+    
+    // Early exit
+    return;
+}  // JoinSet dropped here - all tasks are aborted!
+
+// Explicit abort
+let mut set = JoinSet::new();
+set.spawn(task());
+set.abort_all();  // Cancel all tasks
+```
+
+## Error Handling Pattern
+
+```rust
+use tokio::task::JoinSet;
+
+async fn fetch_all(urls: &[String]) -> Vec<Result<Data, Error>> {
+    let mut set = JoinSet::new();
+    let mut results = Vec::new();
+    
+    for url in urls {
+        set.spawn(fetch(url.clone()));
+    }
+    
+    while let Some(join_result) = set.join_next().await {
+        let result = match join_result {
+            Ok(task_result) => task_result,
+            Err(join_error) => {
+                if join_error.is_panic() {
+                    Err(Error::TaskPanicked)
+                } else {
+                    Err(Error::TaskCancelled)
+                }
+            }
+        };
+        results.push(result);
+    }
+    
+    results
+}
+```
+
+## With Cancellation
+
+```rust
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+async fn run_workers(shutdown: CancellationToken) {
+    let mut set = JoinSet::new();
+    
+    for i in 0..4 {
+        let token = shutdown.child_token();
+        set.spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = do_work(i) => {}
+                }
+            }
+        });
+    }
+    
+    // Wait for shutdown
+    shutdown.cancelled().await;
+    
+    // Abort remaining tasks
+    set.abort_all();
+    
+    // Wait for all to finish (drain aborted tasks)
+    while set.join_next().await.is_some() {}
+}
+```
+
+## Spawning with Context
+
+```rust
+use tokio::task::JoinSet;
+
+let mut set: JoinSet<(usize, Result<Data, Error>)> = JoinSet::new();
+
+for (index, url) in urls.iter().enumerate() {
+    let url = url.clone();
+    set.spawn(async move {
+        (index, fetch(&url).await)
+    });
+}
+
+// Results include their index
+while let Some(result) = set.join_next().await {
+    if let Ok((index, data)) = result {
+        results[index] = Some(data);
+    }
+}
+```
+
+## JoinSet vs join_all
+
+| Feature | JoinSet | join_all |
+|---------|---------|----------|
+| Add tasks dynamically | Yes | No |
+| Results as-completed | Yes | No (all at once) |
+| Abort all on drop | Yes | No |
+| Cancel individual | Yes | No |
+| Memory efficient | Yes | Pre-allocates |
+
+## See Also
+
+- [async-join-parallel](./async-join-parallel.md) - Static concurrent futures
+- [async-cancellation-token](./async-cancellation-token.md) - Cancellation patterns
+- [async-try-join](./async-try-join.md) - Error handling in joins

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-mpsc-queue.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-mpsc-queue.md
@@ -1,0 +1,171 @@
+# async-mpsc-queue
+
+> Use `mpsc` channels for async message queues between tasks
+
+## Why It Matters
+
+`tokio::sync::mpsc` (multi-producer, single-consumer) is the workhorse channel for async Rust. It provides async send/receive, backpressure via bounded capacity, and efficient cloning of senders. It's the default choice for task-to-task communication.
+
+## Bad
+
+```rust
+use std::sync::mpsc;  // Wrong! Blocks the async runtime
+
+let (tx, rx) = std::sync::mpsc::channel();
+
+tokio::spawn(async move {
+    tx.send("hello").unwrap();  // Might block
+});
+
+tokio::spawn(async move {
+    let msg = rx.recv().unwrap();  // BLOCKS the executor thread!
+});
+```
+
+## Good
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<String>(100);
+
+tokio::spawn(async move {
+    tx.send("hello".to_string()).await.unwrap();
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+});
+```
+
+## Sender Cloning
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<Event>(100);
+
+// Multiple producers
+for i in 0..10 {
+    let tx = tx.clone();  // Cheap clone
+    tokio::spawn(async move {
+        tx.send(Event { source: i }).await.unwrap();
+    });
+}
+
+// Drop original sender so channel closes when all clones dropped
+drop(tx);
+
+// Consumer
+while let Some(event) = rx.recv().await {
+    process(event);
+}
+// Loop exits when all senders dropped
+```
+
+## Message Handler Pattern
+
+```rust
+use tokio::sync::mpsc;
+
+enum Command {
+    Get { key: String, reply: oneshot::Sender<Option<Value>> },
+    Set { key: String, value: Value },
+    Delete { key: String },
+}
+
+async fn run_store(mut commands: mpsc::Receiver<Command>) {
+    let mut store = HashMap::new();
+    
+    while let Some(cmd) = commands.recv().await {
+        match cmd {
+            Command::Get { key, reply } => {
+                let _ = reply.send(store.get(&key).cloned());
+            }
+            Command::Set { key, value } => {
+                store.insert(key, value);
+            }
+            Command::Delete { key } => {
+                store.remove(&key);
+            }
+        }
+    }
+}
+
+// Usage
+async fn client(tx: mpsc::Sender<Command>) -> Option<Value> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Command::Get { 
+        key: "foo".to_string(), 
+        reply: reply_tx 
+    }).await.unwrap();
+    
+    reply_rx.await.unwrap()
+}
+```
+
+## Graceful Shutdown
+
+```rust
+async fn worker(mut rx: mpsc::Receiver<Task>, shutdown: CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                // Drain remaining messages
+                while let Ok(task) = rx.try_recv() {
+                    process(task).await;
+                }
+                break;
+            }
+            Some(task) = rx.recv() => {
+                process(task).await;
+            }
+            else => break,  // Channel closed
+        }
+    }
+}
+```
+
+## WeakSender for Optional Producers
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<Message>(100);
+let weak = tx.downgrade();  // Doesn't keep channel alive
+
+tokio::spawn(async move {
+    // Strong sender - keeps channel alive
+    tx.send("from strong".into()).await.unwrap();
+});
+
+tokio::spawn(async move {
+    // Weak sender - may fail if strong senders dropped
+    if let Some(tx) = weak.upgrade() {
+        tx.send("from weak".into()).await.unwrap();
+    }
+});
+```
+
+## Permit Pattern
+
+```rust
+// Reserve slot before preparing message
+let permit = tx.reserve().await?;
+
+// Now we have guaranteed capacity
+let message = expensive_to_create_message();
+permit.send(message);  // Never fails
+
+// Useful when message creation is expensive
+// and you don't want to create it if channel is full
+```
+
+## See Also
+
+- [async-bounded-channel](./async-bounded-channel.md) - Why bounded channels
+- [async-oneshot-response](./async-oneshot-response.md) - Request-response with oneshot
+- [async-broadcast-pubsub](./async-broadcast-pubsub.md) - Multiple consumers

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-no-lock-await.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-no-lock-await.md
@@ -1,0 +1,156 @@
+# async-no-lock-await
+
+> Never hold `Mutex`/`RwLock` across `.await`
+
+## Why It Matters
+
+Holding a lock across an `.await` point can cause deadlocks and severely hurt performance. The task may be suspended while holding the lock, blocking all other tasks waiting for it - potentially indefinitely.
+
+## Bad
+
+```rust
+use tokio::sync::Mutex;
+
+async fn bad_update(state: &Mutex<State>) {
+    let mut guard = state.lock().await;
+    
+    // BAD: Lock held across await!
+    let data = fetch_from_network().await;
+    
+    guard.value = data;
+}  // Lock finally released
+
+// This can deadlock or starve other tasks
+```
+
+## Good
+
+```rust
+use tokio::sync::Mutex;
+
+async fn good_update(state: &Mutex<State>) {
+    // Fetch data BEFORE taking the lock
+    let data = fetch_from_network().await;
+    
+    // Lock only for the quick update
+    let mut guard = state.lock().await;
+    guard.value = data;
+}  // Lock released immediately
+
+// Alternative: Clone data out, process, then update
+async fn good_update_v2(state: &Mutex<State>) {
+    // Extract what we need
+    let id = {
+        let guard = state.lock().await;
+        guard.id.clone()
+    };  // Lock released!
+    
+    // Do async work without lock
+    let data = fetch_by_id(id).await;
+    
+    // Quick update
+    state.lock().await.value = data;
+}
+```
+
+## The Problem Visualized
+
+```rust
+// Task A:
+let guard = mutex.lock().await;    // Acquires lock
+expensive_io().await;              // Suspended, still holding lock!
+// ... many milliseconds pass ...
+drop(guard);                       // Finally releases
+
+// Task B, C, D:
+let guard = mutex.lock().await;    // All blocked waiting for A!
+```
+
+## Patterns for Extraction
+
+```rust
+use tokio::sync::Mutex;
+
+// Pattern 1: Clone out, process, update
+async fn pattern_clone(state: &Mutex<State>) {
+    let config = state.lock().await.config.clone();
+    let result = process_with_io(&config).await;
+    state.lock().await.result = result;
+}
+
+// Pattern 2: Compute closure, apply
+async fn pattern_closure(state: &Mutex<State>) {
+    let update = compute_update().await;
+    
+    state.lock().await.apply(update);
+}
+
+// Pattern 3: Message passing
+async fn pattern_message(
+    state: &Mutex<State>,
+    tx: mpsc::Sender<Update>,
+) {
+    let update = compute_update().await;
+    tx.send(update).await.unwrap();
+}
+
+// Separate task handles updates
+async fn state_manager(
+    state: Arc<Mutex<State>>,
+    mut rx: mpsc::Receiver<Update>,
+) {
+    while let Some(update) = rx.recv().await {
+        state.lock().await.apply(update);
+    }
+}
+```
+
+## Using RwLock
+
+```rust
+use tokio::sync::RwLock;
+
+async fn read_heavy(state: &RwLock<State>) {
+    // Multiple readers OK, but still don't hold across await
+    let value = {
+        let guard = state.read().await;
+        guard.value.clone()
+    };
+    
+    // Process without lock
+    let result = process(value).await;
+    
+    // Write lock for update
+    state.write().await.result = result;
+}
+```
+
+## std::sync::Mutex vs tokio::sync::Mutex
+
+```rust
+// std::sync::Mutex: Blocks the entire thread
+// - Use for quick, CPU-only operations
+// - NEVER use in async code with await inside
+
+// tokio::sync::Mutex: Async-aware, yields to runtime
+// - Use in async code
+// - Still don't hold across await points!
+
+// std::sync::Mutex in async (quick operation, OK):
+async fn quick_update(state: &std::sync::Mutex<State>) {
+    state.lock().unwrap().counter += 1;  // No await, OK
+}
+
+// tokio::sync::Mutex (must use if lock scope has await):
+async fn must_await_inside(state: &tokio::sync::Mutex<State>) {
+    let mut guard = state.lock().await;
+    // Only if you REALLY need the lock during async op
+    // (usually you don't - redesign instead)
+}
+```
+
+## See Also
+
+- [async-spawn-blocking](async-spawn-blocking.md) - Use spawn_blocking for CPU work
+- [async-clone-before-await](async-clone-before-await.md) - Clone data before await
+- [anti-lock-across-await](anti-lock-across-await.md) - Anti-pattern reference

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-oneshot-response.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-oneshot-response.md
@@ -1,0 +1,191 @@
+# async-oneshot-response
+
+> Use `oneshot` channel for request-response patterns
+
+## Why It Matters
+
+When one task needs to send a request and wait for exactly one response, `oneshot` is the perfect fit. It's a single-use channel optimized for this pattern—no buffering, no clone overhead. Combined with `mpsc`, it enables clean actor-style message passing.
+
+## Bad
+
+```rust
+// Using mpsc for single response - wasteful
+let (tx, mut rx) = mpsc::channel::<Response>(1);
+send_request().await;
+let response = rx.recv().await.unwrap();
+// Channel persists, could accidentally receive more
+
+// Using shared state - complex
+let result = Arc::new(Mutex::new(None));
+send_request(result.clone()).await;
+while result.lock().await.is_none() {
+    tokio::time::sleep(Duration::from_millis(10)).await;  // Polling!
+}
+```
+
+## Good
+
+```rust
+use tokio::sync::oneshot;
+
+let (tx, rx) = oneshot::channel::<Response>();
+
+// Send request with reply channel
+send_request(Request { data, reply: tx }).await;
+
+// Wait for response
+let response = rx.await?;
+
+// Channel is consumed - can't accidentally reuse
+```
+
+## Request-Response Pattern
+
+```rust
+use tokio::sync::{mpsc, oneshot};
+
+enum Request {
+    Get {
+        key: String,
+        reply: oneshot::Sender<Option<Value>>,
+    },
+    Set {
+        key: String,
+        value: Value,
+        reply: oneshot::Sender<bool>,
+    },
+}
+
+// Service handler
+async fn service(mut rx: mpsc::Receiver<Request>) {
+    let mut store = HashMap::new();
+    
+    while let Some(req) = rx.recv().await {
+        match req {
+            Request::Get { key, reply } => {
+                let value = store.get(&key).cloned();
+                let _ = reply.send(value);  // Ignore if receiver dropped
+            }
+            Request::Set { key, value, reply } => {
+                store.insert(key, value);
+                let _ = reply.send(true);
+            }
+        }
+    }
+}
+
+// Client
+async fn get_value(tx: &mpsc::Sender<Request>, key: &str) -> Option<Value> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Request::Get {
+        key: key.to_string(),
+        reply: reply_tx,
+    }).await.ok()?;
+    
+    reply_rx.await.ok()?
+}
+```
+
+## With Timeout
+
+```rust
+use tokio::time::{timeout, Duration};
+
+async fn request_with_timeout(
+    tx: &mpsc::Sender<Request>,
+    key: &str,
+) -> Result<Value, Error> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Request::Get {
+        key: key.to_string(),
+        reply: reply_tx,
+    }).await.map_err(|_| Error::ServiceDown)?;
+    
+    timeout(Duration::from_secs(5), reply_rx)
+        .await
+        .map_err(|_| Error::Timeout)?
+        .map_err(|_| Error::ServiceDown)?
+        .ok_or(Error::NotFound)
+}
+```
+
+## Error Handling
+
+```rust
+use tokio::sync::oneshot;
+
+let (tx, rx) = oneshot::channel::<String>();
+
+// Sender dropped without sending
+drop(tx);
+match rx.await {
+    Ok(value) => println!("Got: {}", value),
+    Err(oneshot::error::RecvError { .. }) => {
+        println!("Sender dropped");
+    }
+}
+
+// Receiver dropped before send
+let (tx, rx) = oneshot::channel::<String>();
+drop(rx);
+match tx.send("hello".to_string()) {
+    Ok(()) => println!("Sent"),
+    Err(value) => println!("Receiver dropped, value: {}", value),
+}
+```
+
+## Closed Detection
+
+```rust
+// Check if receiver is still waiting
+let (tx, rx) = oneshot::channel::<i32>();
+
+// In producer
+if tx.is_closed() {
+    println!("Receiver already gone, skip expensive computation");
+} else {
+    let result = expensive_computation();
+    tx.send(result).ok();
+}
+
+// Async wait for close
+let tx_clone = tx.clone();  // Note: can't actually clone, just showing concept
+tokio::select! {
+    _ = tx.closed() => println!("Receiver dropped"),
+    result = compute() => { tx.send(result).ok(); }
+}
+```
+
+## Response Type Wrapper
+
+```rust
+// Standardize request-response pattern
+struct RpcRequest<Req, Res> {
+    request: Req,
+    reply: oneshot::Sender<Res>,
+}
+
+impl<Req, Res> RpcRequest<Req, Res> {
+    fn new(request: Req) -> (Self, oneshot::Receiver<Res>) {
+        let (tx, rx) = oneshot::channel();
+        (RpcRequest { request, reply: tx }, rx)
+    }
+    
+    fn respond(self, response: Res) {
+        let _ = self.reply.send(response);
+    }
+}
+
+// Usage
+let (req, rx) = RpcRequest::new(GetUser { id: 42 });
+tx.send(req).await?;
+let user = rx.await?;
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Pair with oneshot for request-response
+- [async-bounded-channel](./async-bounded-channel.md) - Channel sizing
+- [async-select-racing](./async-select-racing.md) - Timeout patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-select-racing.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-select-racing.md
@@ -1,0 +1,198 @@
+# async-select-racing
+
+> Use `select!` to race futures and handle the first to complete
+
+## Why It Matters
+
+Sometimes you need the first result from multiple futures—timeout vs operation, cancellation vs work, or competing alternatives. `tokio::select!` lets you race futures and handle whichever completes first, while properly cancelling the others.
+
+## Bad
+
+```rust
+// Can't express "whichever finishes first"
+async fn fetch_with_fallback() -> Data {
+    match fetch_primary().await {
+        Ok(data) => data,
+        Err(_) => fetch_fallback().await.unwrap(),  // Sequential, not racing
+    }
+}
+
+// Manual timeout is error-prone
+async fn fetch_with_timeout() -> Option<Data> {
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > Duration::from_secs(5) {
+            return None;
+        }
+        // How do we check timeout while awaiting?
+    }
+}
+```
+
+## Good
+
+```rust
+use tokio::select;
+
+async fn fetch_with_timeout() -> Result<Data, Error> {
+    select! {
+        result = fetch_data() => result,
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            Err(Error::Timeout)
+        }
+    }
+}
+
+async fn fetch_with_fallback() -> Data {
+    select! {
+        result = fetch_primary() => {
+            match result {
+                Ok(data) => data,
+                Err(_) => fetch_fallback().await.unwrap()
+            }
+        }
+        _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            // Primary too slow, use fallback
+            fetch_fallback().await.unwrap()
+        }
+    }
+}
+```
+
+## select! Syntax
+
+```rust
+select! {
+    // Pattern = future => handler
+    result = async_operation() => {
+        // Handle result
+        println!("Got: {:?}", result);
+    }
+    
+    // Can bind with pattern matching
+    Ok(data) = fallible_operation() => {
+        process(data);
+    }
+    
+    // Conditional branches with if guards
+    msg = channel.recv(), if should_receive => {
+        handle_message(msg);
+    }
+    
+    // else branch for when all futures are disabled
+    else => {
+        println!("All branches disabled");
+    }
+}
+```
+
+## Cancellation Behavior
+
+```rust
+async fn select_example() {
+    select! {
+        _ = operation_a() => {
+            println!("A completed first");
+            // operation_b() is dropped/cancelled
+        }
+        _ = operation_b() => {
+            println!("B completed first");
+            // operation_a() is dropped/cancelled
+        }
+    }
+}
+
+// Futures are cancelled at their next .await point
+// For immediate cancellation, futures must be cancel-safe
+```
+
+## Biased Selection
+
+```rust
+// By default, select! randomly picks when multiple are ready
+// Use biased mode for deterministic priority
+select! {
+    biased;  // Check branches in order
+    
+    msg = high_priority.recv() => handle_high(msg),
+    msg = low_priority.recv() => handle_low(msg),
+}
+
+// Without biased, both channels have equal chance
+// when both have messages ready
+```
+
+## Loop with select!
+
+```rust
+async fn event_loop(
+    mut commands: mpsc::Receiver<Command>,
+    shutdown: CancellationToken,
+) {
+    loop {
+        select! {
+            _ = shutdown.cancelled() => {
+                println!("Shutting down");
+                break;
+            }
+            Some(cmd) = commands.recv() => {
+                process_command(cmd).await;
+            }
+            else => {
+                // commands channel closed
+                break;
+            }
+        }
+    }
+}
+```
+
+## Racing Multiple of Same Type
+
+```rust
+// Race multiple servers for fastest response
+async fn fastest_response(servers: &[String]) -> Result<Response> {
+    let futures = servers.iter()
+        .map(|s| fetch_from(s))
+        .collect::<Vec<_>>();
+    
+    // select! requires static branches, use select_all for dynamic
+    let (result, _index, _remaining) = 
+        futures::future::select_all(futures).await;
+    
+    result
+}
+```
+
+## Common Patterns
+
+```rust
+// Timeout
+select! {
+    result = operation() => result,
+    _ = sleep(Duration::from_secs(5)) => Err(Timeout),
+}
+
+// Cancellation
+select! {
+    result = operation() => result,
+    _ = cancel_token.cancelled() => Err(Cancelled),
+}
+
+// Interval with cancellation
+let mut interval = tokio::time::interval(Duration::from_secs(1));
+loop {
+    select! {
+        _ = shutdown.cancelled() => break,
+        _ = interval.tick() => {
+            do_periodic_work().await;
+        }
+    }
+}
+```
+
+## See Also
+
+- [async-cancellation-token](./async-cancellation-token.md) - Cancellation patterns
+- [async-join-parallel](./async-join-parallel.md) - All futures, not racing
+- [async-bounded-channel](./async-bounded-channel.md) - Channel operations in select

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-spawn-blocking.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-spawn-blocking.md
@@ -1,0 +1,154 @@
+# async-spawn-blocking
+
+> Use `spawn_blocking` for CPU-intensive work
+
+## Why It Matters
+
+Async runtimes like Tokio use a small number of threads to handle many tasks. CPU-intensive or blocking operations on these threads starve other tasks. `spawn_blocking` moves such work to a dedicated thread pool.
+
+## Bad
+
+```rust
+// BAD: Blocks the async runtime thread
+async fn process_image(data: &[u8]) -> ProcessedImage {
+    // CPU-intensive work on async thread!
+    let resized = resize_image(data);      // Blocks!
+    let compressed = compress(resized);     // Blocks!
+    compressed
+}
+
+// BAD: Synchronous file I/O in async context
+async fn read_large_file(path: &Path) -> Vec<u8> {
+    std::fs::read(path).unwrap()  // Blocks the runtime!
+}
+```
+
+## Good
+
+```rust
+use tokio::task;
+
+// GOOD: Offload CPU work to blocking pool
+async fn process_image(data: Vec<u8>) -> ProcessedImage {
+    task::spawn_blocking(move || {
+        let resized = resize_image(&data);
+        compress(resized)
+    })
+    .await
+    .expect("spawn_blocking failed")
+}
+
+// GOOD: Use async file I/O
+async fn read_large_file(path: &Path) -> tokio::io::Result<Vec<u8>> {
+    tokio::fs::read(path).await
+}
+
+// GOOD: Or spawn_blocking for unavoidable sync I/O
+async fn read_with_sync_lib(path: PathBuf) -> Vec<u8> {
+    task::spawn_blocking(move || {
+        sync_library::read_file(&path)
+    })
+    .await
+    .unwrap()
+}
+```
+
+## What Counts as Blocking
+
+```rust
+// CPU-intensive operations
+- Cryptographic operations (hashing, encryption)
+- Image/video processing
+- Compression/decompression
+- Complex parsing
+- Mathematical computations
+
+// Blocking I/O
+- std::fs operations
+- Synchronous database drivers
+- Synchronous HTTP clients
+- Thread::sleep
+
+// Example thresholds (rough guidelines):
+// < 10µs: OK on async thread
+// 10µs - 1ms: Consider spawn_blocking
+// > 1ms: Definitely spawn_blocking
+```
+
+## Practical Examples
+
+```rust
+// Password hashing (CPU-intensive)
+async fn hash_password(password: String) -> String {
+    task::spawn_blocking(move || {
+        bcrypt::hash(password, bcrypt::DEFAULT_COST).unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+// JSON parsing of large documents
+async fn parse_large_json(data: String) -> serde_json::Value {
+    task::spawn_blocking(move || {
+        serde_json::from_str(&data).unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+// Compression
+async fn compress_data(data: Vec<u8>) -> Vec<u8> {
+    task::spawn_blocking(move || {
+        let mut encoder = flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::default(),
+        );
+        encoder.write_all(&data).unwrap();
+        encoder.finish().unwrap()
+    })
+    .await
+    .unwrap()
+}
+```
+
+## spawn_blocking vs spawn
+
+```rust
+// spawn: Runs async code on runtime threads
+tokio::spawn(async {
+    // Async code here
+    some_async_operation().await;
+});
+
+// spawn_blocking: Runs sync code on blocking thread pool
+tokio::task::spawn_blocking(|| {
+    // Synchronous, possibly CPU-intensive code
+    heavy_computation();
+});
+
+// spawn_blocking returns JoinHandle that can be awaited
+let result = tokio::task::spawn_blocking(|| {
+    expensive_sync_operation()
+}).await?;
+```
+
+## Rayon for Parallel CPU Work
+
+```rust
+// For parallel CPU work, consider Rayon inside spawn_blocking
+async fn parallel_process(items: Vec<Item>) -> Vec<Output> {
+    task::spawn_blocking(move || {
+        use rayon::prelude::*;
+        items.par_iter()
+            .map(|item| cpu_intensive_transform(item))
+            .collect()
+    })
+    .await
+    .unwrap()
+}
+```
+
+## See Also
+
+- [async-tokio-fs](async-tokio-fs.md) - Use tokio::fs for async file I/O
+- [async-no-lock-await](async-no-lock-await.md) - Don't hold locks across await

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-tokio-fs.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-tokio-fs.md
@@ -1,0 +1,167 @@
+# async-tokio-fs
+
+> Use `tokio::fs` instead of `std::fs` in async code
+
+## Why It Matters
+
+`std::fs` operations are blocking—they stop the current thread until the syscall completes. In async code, this blocks the executor thread, preventing it from running other tasks. `tokio::fs` wraps filesystem operations in `spawn_blocking`, keeping the executor responsive.
+
+## Bad
+
+```rust
+async fn process_files(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let mut contents = Vec::new();
+    
+    for path in paths {
+        // BLOCKS the entire executor thread!
+        let data = std::fs::read_to_string(path)?;
+        contents.push(data);
+    }
+    
+    Ok(contents)
+}
+
+// While reading a file, NO other tasks can run on this thread
+```
+
+## Good
+
+```rust
+use tokio::fs;
+
+async fn process_files(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let mut contents = Vec::new();
+    
+    for path in paths {
+        // Non-blocking: allows other tasks to run
+        let data = fs::read_to_string(path).await?;
+        contents.push(data);
+    }
+    
+    Ok(contents)
+}
+
+// Even better: concurrent reads
+async fn process_files_concurrent(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let futures: Vec<_> = paths.iter()
+        .map(|path| fs::read_to_string(path))
+        .collect();
+    
+    futures::future::try_join_all(futures).await
+}
+```
+
+## tokio::fs API
+
+```rust
+use tokio::fs;
+
+// Reading
+let contents = fs::read_to_string("file.txt").await?;
+let bytes = fs::read("file.bin").await?;
+
+// Writing
+fs::write("output.txt", "contents").await?;
+
+// File operations
+let file = fs::File::open("file.txt").await?;
+let file = fs::File::create("new.txt").await?;
+
+// Directory operations
+fs::create_dir("new_dir").await?;
+fs::create_dir_all("nested/dir/path").await?;
+fs::remove_dir("empty_dir").await?;
+fs::remove_dir_all("dir_with_contents").await?;
+
+// Metadata
+let metadata = fs::metadata("file.txt").await?;
+let canonical = fs::canonicalize("./relative").await?;
+
+// Rename/remove
+fs::rename("old.txt", "new.txt").await?;
+fs::remove_file("file.txt").await?;
+
+// Read directory
+let mut entries = fs::read_dir("some_dir").await?;
+while let Some(entry) = entries.next_entry().await? {
+    println!("{}", entry.path().display());
+}
+```
+
+## Async File I/O
+
+```rust
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, AsyncBufReadExt, BufReader};
+
+// Read with buffer
+let mut file = File::open("large.bin").await?;
+let mut buffer = vec![0u8; 4096];
+let bytes_read = file.read(&mut buffer).await?;
+
+// Read all
+let mut contents = Vec::new();
+file.read_to_end(&mut contents).await?;
+
+// Write
+let mut file = File::create("output.bin").await?;
+file.write_all(b"data").await?;
+file.flush().await?;
+
+// Buffered line reading
+let file = File::open("lines.txt").await?;
+let reader = BufReader::new(file);
+let mut lines = reader.lines();
+
+while let Some(line) = lines.next_line().await? {
+    println!("{}", line);
+}
+```
+
+## When std::fs is Acceptable
+
+```rust
+// Startup/initialization (before async runtime)
+fn main() {
+    let config = std::fs::read_to_string("config.toml")
+        .expect("config file required");
+    
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(run_with_config(config));
+}
+
+// Single-threaded current_thread runtime (less impact)
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Still prefer tokio::fs, but impact is lower
+}
+
+// When file operations are rare and quick
+// (e.g., reading small config once per hour)
+```
+
+## Performance Considerations
+
+```rust
+// tokio::fs uses spawn_blocking internally
+// For many small files, the overhead adds up
+
+// Batch operations when possible
+let paths: Vec<_> = entries.iter()
+    .map(|e| e.path())
+    .collect();
+
+let contents = futures::future::try_join_all(
+    paths.iter().map(|p| fs::read_to_string(p))
+).await?;
+
+// For heavy I/O, consider memory-mapped files
+// (requires unsafe or mmap crate)
+```
+
+## See Also
+
+- [async-spawn-blocking](./async-spawn-blocking.md) - How tokio::fs works internally
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime configuration
+- [err-context-chain](./err-context-chain.md) - Adding path context to IO errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-tokio-runtime.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-tokio-runtime.md
@@ -1,0 +1,169 @@
+# async-tokio-runtime
+
+> Configure Tokio runtime appropriately for your workload
+
+## Why It Matters
+
+Tokio's default multi-threaded runtime isn't always optimal. CPU-bound work needs different configuration than IO-bound work. Incorrect configuration leads to poor performance, blocked workers, or resource exhaustion. Understanding runtime options lets you tune for your specific use case.
+
+## Bad
+
+```rust
+// Default runtime for everything - not optimal
+#[tokio::main]
+async fn main() {
+    // CPU-heavy work on async executor starves IO tasks
+    for data in datasets {
+        let result = heavy_computation(data).await;
+    }
+}
+
+// Single-threaded when multi-threaded is needed
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Can't utilize multiple cores for concurrent tasks
+    for _ in 0..1000 {
+        tokio::spawn(async { /* IO work */ });
+    }
+}
+```
+
+## Good
+
+```rust
+// Multi-threaded for concurrent IO (default)
+#[tokio::main]
+async fn main() {
+    // Good for many concurrent network connections
+    let handles: Vec<_> = urls.iter()
+        .map(|url| tokio::spawn(fetch(url.clone())))
+        .collect();
+    
+    futures::future::join_all(handles).await;
+}
+
+// Current-thread for single-threaded scenarios
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Good for single-connection clients, simpler debugging
+    let client = Client::new();
+    client.run().await;
+}
+
+// Custom configuration
+#[tokio::main(worker_threads = 4)]
+async fn main() {
+    // Limit to 4 worker threads
+}
+
+// Or manual setup for more control
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .thread_name("my-worker")
+        .build()
+        .unwrap();
+    
+    runtime.block_on(async_main());
+}
+```
+
+## Runtime Types
+
+| Runtime | Use Case | Configuration |
+|---------|----------|---------------|
+| Multi-thread | IO-bound, many connections | `#[tokio::main]` (default) |
+| Current-thread | CLI tools, tests, single connection | `flavor = "current_thread"` |
+| Custom | Fine-tuned performance | `Builder::new_*()` |
+
+## Worker Thread Tuning
+
+```rust
+use tokio::runtime::Builder;
+
+// IO-bound: more threads than cores can help
+let io_runtime = Builder::new_multi_thread()
+    .worker_threads(num_cpus::get() * 2)  // IO can benefit from oversubscription
+    .max_blocking_threads(32)              // For spawn_blocking calls
+    .enable_io()
+    .enable_time()
+    .build()?;
+
+// CPU-bound: match core count
+let cpu_runtime = Builder::new_multi_thread()
+    .worker_threads(num_cpus::get())       // No benefit from more than cores
+    .build()?;
+```
+
+## Multiple Runtimes
+
+```rust
+// Separate runtimes for different workloads
+struct App {
+    io_runtime: Runtime,
+    cpu_runtime: Runtime,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            io_runtime: Builder::new_multi_thread()
+                .worker_threads(8)
+                .thread_name("io-worker")
+                .build()
+                .unwrap(),
+            cpu_runtime: Builder::new_multi_thread()
+                .worker_threads(4)
+                .thread_name("cpu-worker")
+                .build()
+                .unwrap(),
+        }
+    }
+    
+    fn spawn_io<F>(&self, future: F) 
+    where F: Future + Send + 'static, F::Output: Send + 'static 
+    {
+        self.io_runtime.spawn(future);
+    }
+    
+    fn spawn_cpu<F>(&self, task: F) 
+    where F: FnOnce() + Send + 'static 
+    {
+        self.cpu_runtime.spawn_blocking(task);
+    }
+}
+```
+
+## Runtime in Tests
+
+```rust
+// Single test runtime
+#[tokio::test]
+async fn test_single() {
+    assert!(true);
+}
+
+// Multi-threaded test
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent() {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move { tx.send(42).unwrap() });
+    assert_eq!(rx.await.unwrap(), 42);
+}
+
+// Custom runtime in test
+#[test]
+fn test_with_custom_runtime() {
+    let rt = Builder::new_current_thread().build().unwrap();
+    rt.block_on(async {
+        // test code
+    });
+}
+```
+
+## See Also
+
+- [async-spawn-blocking](./async-spawn-blocking.md) - Handling blocking code
+- [async-no-lock-await](./async-no-lock-await.md) - Avoiding lock issues
+- [async-joinset-structured](./async-joinset-structured.md) - Managing spawned tasks

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-try-join.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-try-join.md
@@ -1,0 +1,172 @@
+# async-try-join
+
+> Use `try_join!` for concurrent fallible operations with early return on error
+
+## Why It Matters
+
+When running multiple fallible operations concurrently, `try_join!` returns `Err` as soon as any future fails, without waiting for the others. This provides fail-fast behavior while still running operations in parallel. For many operations, use `futures::future::try_join_all`.
+
+## Bad
+
+```rust
+// Sequential - slow and no early return benefit
+async fn fetch_all() -> Result<(A, B, C)> {
+    let a = fetch_a().await?;  // If this fails, we wait for nothing
+    let b = fetch_b().await?;  // But if this fails, we waited for A
+    let c = fetch_c().await?;
+    Ok((a, b, c))
+}
+
+// join! ignores errors
+async fn fetch_all() -> (Result<A>, Result<B>, Result<C>) {
+    let (a, b, c) = join!(fetch_a(), fetch_b(), fetch_c());
+    // All complete even if first one failed
+    (a, b, c)  // Now we have to handle three Results
+}
+```
+
+## Good
+
+```rust
+use tokio::try_join;
+
+async fn fetch_all() -> Result<(A, B, C)> {
+    // Concurrent AND fail-fast
+    let (a, b, c) = try_join!(
+        fetch_a(),
+        fetch_b(),
+        fetch_c(),
+    )?;
+    
+    Ok((a, b, c))
+}
+
+// For dynamic collections
+use futures::future::try_join_all;
+
+async fn fetch_users(ids: &[u64]) -> Result<Vec<User>> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    try_join_all(futures).await
+}
+```
+
+## Error Handling Patterns
+
+```rust
+// Different error types - need common error type
+async fn mixed_operations() -> Result<(A, B), Error> {
+    let (a, b) = try_join!(
+        fetch_a().map_err(Error::from),  // Convert errors
+        fetch_b().map_err(Error::from),
+    )?;
+    Ok((a, b))
+}
+
+// Collect all results, then handle errors
+async fn all_or_nothing(ids: &[u64]) -> Result<Vec<User>> {
+    try_join_all(ids.iter().map(|id| fetch_user(*id))).await
+}
+
+// Collect successes, log failures
+async fn best_effort(ids: &[u64]) -> Vec<User> {
+    let results = futures::future::join_all(
+        ids.iter().map(|id| fetch_user(*id))
+    ).await;
+    
+    results.into_iter()
+        .filter_map(|r| match r {
+            Ok(user) => Some(user),
+            Err(e) => {
+                log::warn!("Failed to fetch user: {}", e);
+                None
+            }
+        })
+        .collect()
+}
+```
+
+## Cancellation Behavior
+
+```rust
+// try_join! cancels remaining futures on error
+async fn with_cancellation() -> Result<()> {
+    // If fetch_a() fails, fetch_b() and fetch_c() are dropped
+    // But "dropped" != "immediately stopped"
+    // They stop at their next .await point
+    
+    try_join!(
+        async {
+            fetch_a().await?;
+            cleanup_a().await;  // May not run if other future fails
+            Ok::<_, Error>(())
+        },
+        async {
+            fetch_b().await?;
+            cleanup_b().await;  // May not run if other future fails
+            Ok::<_, Error>(())
+        },
+    )?;
+    
+    Ok(())
+}
+
+// For guaranteed cleanup, use Drop guards or explicit handling
+```
+
+## With Timeout
+
+```rust
+use tokio::time::{timeout, Duration};
+
+async fn fetch_with_timeout() -> Result<(A, B)> {
+    timeout(
+        Duration::from_secs(10),
+        try_join!(fetch_a(), fetch_b())
+    )
+    .await
+    .map_err(|_| Error::Timeout)?
+}
+
+// Per-operation timeout
+async fn individual_timeouts() -> Result<(A, B)> {
+    try_join!(
+        timeout(Duration::from_secs(5), fetch_a())
+            .map_err(|_| Error::Timeout)
+            .and_then(|r| async { r }),
+        timeout(Duration::from_secs(5), fetch_b())
+            .map_err(|_| Error::Timeout)
+            .and_then(|r| async { r }),
+    )
+}
+```
+
+## try_join! vs FuturesUnordered
+
+```rust
+use futures::stream::{FuturesUnordered, StreamExt};
+
+// try_join!: wait for all, fail fast
+let (a, b, c) = try_join!(fa, fb, fc)?;
+
+// FuturesUnordered: process as they complete
+let mut futures = FuturesUnordered::new();
+futures.push(fetch_a());
+futures.push(fetch_b());
+futures.push(fetch_c());
+
+while let Some(result) = futures.next().await {
+    match result {
+        Ok(data) => process(data),
+        Err(e) => return Err(e),  // Can fail fast manually
+    }
+}
+```
+
+## See Also
+
+- [async-join-parallel](./async-join-parallel.md) - Non-fallible concurrent futures
+- [async-select-racing](./async-select-racing.md) - First-to-complete semantics
+- [err-question-mark](./err-question-mark.md) - Error propagation

--- a/.cursor/skills/rust-skills-leonardomso/rules/async-watch-latest.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/async-watch-latest.md
@@ -1,0 +1,189 @@
+# async-watch-latest
+
+> Use `watch` channel for sharing the latest value with multiple observers
+
+## Why It Matters
+
+`watch` is optimized for scenarios where receivers only care about the most recent value, not the history of changes. Unlike `broadcast`, slow receivers don't lag—they simply skip intermediate values. This is perfect for configuration, state, or status that should always reflect the current situation.
+
+## Bad
+
+```rust
+// Using broadcast when only latest value matters
+let (tx, _) = broadcast::channel::<Config>(100);
+
+// Receivers might process stale configs if they're slow
+// And they waste time processing intermediate values
+
+// Using mpsc with buffered stale values
+let (tx, mut rx) = mpsc::channel::<Status>(100);
+// Receiver might process outdated statuses
+```
+
+## Good
+
+```rust
+use tokio::sync::watch;
+
+let (tx, rx) = watch::channel(Config::default());
+
+// Multiple observers
+let rx1 = rx.clone();
+let rx2 = rx.clone();
+
+// Observer 1: waits for changes
+tokio::spawn(async move {
+    let mut rx = rx1;
+    while rx.changed().await.is_ok() {
+        let config = rx.borrow();
+        apply_config(&*config);
+    }
+});
+
+// Observer 2: also sees all changes
+tokio::spawn(async move {
+    let mut rx = rx2;
+    while rx.changed().await.is_ok() {
+        let config = rx.borrow();
+        log_config_change(&*config);
+    }
+});
+
+// Update the value
+tx.send(Config::new())?;
+```
+
+## watch Semantics
+
+```rust
+use tokio::sync::watch;
+
+let (tx, mut rx) = watch::channel("initial");
+
+// Immediate read - no waiting
+assert_eq!(*rx.borrow(), "initial");
+
+// Wait for change
+tx.send("updated")?;
+rx.changed().await?;
+assert_eq!(*rx.borrow(), "updated");
+
+// Multiple rapid updates - receiver sees latest
+tx.send("v1")?;
+tx.send("v2")?;
+tx.send("v3")?;
+rx.changed().await?;
+assert_eq!(*rx.borrow(), "v3");  // Skipped v1, v2
+```
+
+## Configuration Reload Pattern
+
+```rust
+use tokio::sync::watch;
+use std::sync::Arc;
+
+struct AppConfig {
+    log_level: Level,
+    max_connections: usize,
+}
+
+async fn config_watcher(tx: watch::Sender<Arc<AppConfig>>) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        
+        if let Ok(new_config) = reload_config_from_disk() {
+            // Only notifies if value actually changed
+            tx.send_if_modified(|current| {
+                if *current != new_config {
+                    *current = Arc::new(new_config);
+                    true
+                } else {
+                    false
+                }
+            });
+        }
+    }
+}
+
+async fn worker(mut config_rx: watch::Receiver<Arc<AppConfig>>) {
+    loop {
+        tokio::select! {
+            _ = config_rx.changed() => {
+                let config = config_rx.borrow().clone();
+                reconfigure(&config);
+            }
+            _ = do_work() => {}
+        }
+    }
+}
+```
+
+## State Machine Updates
+
+```rust
+#[derive(Clone, PartialEq)]
+enum ConnectionState {
+    Disconnected,
+    Connecting,
+    Connected,
+    Error(String),
+}
+
+struct Connection {
+    state_tx: watch::Sender<ConnectionState>,
+    state_rx: watch::Receiver<ConnectionState>,
+}
+
+impl Connection {
+    async fn wait_connected(&mut self) -> Result<(), Error> {
+        loop {
+            let state = self.state_rx.borrow().clone();
+            match state {
+                ConnectionState::Connected => return Ok(()),
+                ConnectionState::Error(e) => return Err(Error::Connection(e)),
+                _ => {
+                    self.state_rx.changed().await?;
+                }
+            }
+        }
+    }
+}
+```
+
+## Borrow vs Clone
+
+```rust
+use tokio::sync::watch;
+
+let (tx, rx) = watch::channel(vec![1, 2, 3]);
+
+// borrow() returns Ref - must not hold across await
+{
+    let data = rx.borrow();
+    println!("{:?}", *data);
+}  // Ref dropped here
+
+// For use across await, clone the data
+let data = rx.borrow().clone();
+some_async_operation().await;
+use_data(&data);  // Safe
+
+// Or use borrow_and_update() to mark as seen
+let data = rx.borrow_and_update().clone();
+```
+
+## watch vs broadcast vs mpsc
+
+| Feature | watch | broadcast | mpsc |
+|---------|-------|-----------|------|
+| Receivers | Multiple | Multiple | Single |
+| Message delivery | Latest only | All messages | All messages |
+| Slow receiver | Skips to latest | Lags/misses | Backpressure |
+| Clone required | No | Yes | No |
+| Best for | Config, status | Events | Work queues |
+
+## See Also
+
+- [async-broadcast-pubsub](./async-broadcast-pubsub.md) - When history matters
+- [async-mpsc-queue](./async-mpsc-queue.md) - Work queue patterns
+- [async-cancellation-token](./async-cancellation-token.md) - Related pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-all-public.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-all-public.md
@@ -1,0 +1,113 @@
+# doc-all-public
+
+> Document all public items with `///` doc comments
+
+## Why It Matters
+
+Public items define your crate's API contract. Without documentation, users must read source code to understand how to use your library. Well-documented APIs reduce support burden, improve adoption, and serve as the primary reference for users.
+
+Rust's `cargo doc` generates beautiful HTML documentation from doc comments, but only if you write them.
+
+## Bad
+
+```rust
+pub struct Config {
+    pub timeout: Duration,
+    pub retries: u32,
+    pub base_url: String,
+}
+
+pub fn connect(config: Config) -> Result<Connection, Error> {
+    // ...
+}
+
+pub enum Status {
+    Pending,
+    Active,
+    Failed,
+}
+```
+
+## Good
+
+```rust
+/// Configuration for establishing a connection to the service.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::Config;
+/// use std::time::Duration;
+///
+/// let config = Config {
+///     timeout: Duration::from_secs(30),
+///     retries: 3,
+///     base_url: "https://api.example.com".to_string(),
+/// };
+/// ```
+pub struct Config {
+    /// Maximum time to wait for a response before timing out.
+    pub timeout: Duration,
+    
+    /// Number of retry attempts for failed requests.
+    pub retries: u32,
+    
+    /// Base URL for all API requests.
+    pub base_url: String,
+}
+
+/// Establishes a connection using the provided configuration.
+///
+/// # Errors
+///
+/// Returns an error if the connection cannot be established
+/// or if the configuration is invalid.
+pub fn connect(config: Config) -> Result<Connection, Error> {
+    // ...
+}
+
+/// Represents the current status of a job.
+pub enum Status {
+    /// Job is waiting to be processed.
+    Pending,
+    /// Job is currently being processed.
+    Active,
+    /// Job has failed and will not be retried.
+    Failed,
+}
+```
+
+## What to Document
+
+| Item Type | Required Content |
+|-----------|------------------|
+| Structs | Purpose, usage example |
+| Struct fields | What the field represents |
+| Enums | When to use each variant |
+| Enum variants | What state it represents |
+| Functions | What it does, parameters, return value |
+| Traits | Contract and expected behavior |
+| Trait methods | Default implementation behavior |
+| Type aliases | Why the alias exists |
+| Constants | What the value represents |
+
+## Enforcement
+
+Enable the `missing_docs` lint to catch undocumented public items:
+
+```rust
+#![warn(missing_docs)]
+```
+
+Or in `Cargo.toml` for workspace-wide enforcement:
+
+```toml
+[workspace.lints.rust]
+missing_docs = "warn"
+```
+
+## See Also
+
+- [doc-module-inner](./doc-module-inner.md) - Module-level documentation
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [lint-missing-docs](./lint-missing-docs.md) - Enforcing documentation

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-cargo-metadata.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-cargo-metadata.md
@@ -1,0 +1,147 @@
+# doc-cargo-metadata
+
+> Fill `Cargo.toml` metadata for published crates
+
+## Why It Matters
+
+Cargo.toml metadata appears on crates.io, in search results, and helps users evaluate your crate. Missing metadata makes your crate look unprofessional, harder to find, and harder to trust. Complete metadata improves discoverability and adoption.
+
+## Bad
+
+```toml
+[package]
+name = "my-awesome-crate"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# ...
+```
+
+## Good
+
+```toml
+[package]
+name = "my-awesome-crate"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+# Required for crates.io
+description = "A fast, ergonomic HTTP client for Rust"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/username/my-awesome-crate"
+
+# Highly recommended
+documentation = "https://docs.rs/my-awesome-crate"
+readme = "README.md"
+keywords = ["http", "client", "async", "networking"]
+categories = ["network-programming", "web-programming::http-client"]
+authors = ["Your Name <you@example.com>"]
+homepage = "https://my-awesome-crate.dev"
+
+# Optional but helpful
+include = ["src/**/*", "Cargo.toml", "LICENSE*", "README.md"]
+exclude = ["tests/fixtures/*", ".github/*"]
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+# ...
+```
+
+## Required Fields for Publishing
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Crate name on crates.io |
+| `version` | Semver version |
+| `license` or `license-file` | SPDX license identifier |
+| `description` | One-line summary (≤256 chars) |
+
+## Recommended Fields
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `repository` | Link to source code | `https://github.com/user/repo` |
+| `documentation` | Link to docs | `https://docs.rs/crate` |
+| `readme` | Path to README | `README.md` |
+| `keywords` | Search terms (max 5) | `["http", "async"]` |
+| `categories` | crates.io categories | `["network-programming"]` |
+| `rust-version` | MSRV | `"1.70"` |
+
+## Keywords Best Practices
+
+```toml
+# Good: specific, searchable terms
+keywords = ["json", "serialization", "serde", "parsing"]
+
+# Bad: too generic or redundant
+keywords = ["rust", "library", "awesome", "fast", "best"]
+```
+
+## Categories
+
+Choose from [crates.io categories](https://crates.io/category_slugs):
+
+```toml
+categories = [
+    "network-programming",
+    "web-programming::http-client",
+    "asynchronous",
+]
+```
+
+## License Patterns
+
+```toml
+# Single license
+license = "MIT"
+
+# Dual license (common in Rust ecosystem)
+license = "MIT OR Apache-2.0"
+
+# Custom license file
+license-file = "LICENSE"
+```
+
+## Include/Exclude
+
+Control what gets published:
+
+```toml
+# Explicit include (whitelist)
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "LICENSE*",
+    "README.md",
+    "CHANGELOG.md",
+]
+
+# Or exclude (blacklist)
+exclude = [
+    "tests/fixtures/large-file.bin",
+    ".github/*",
+    "benches/*",
+]
+```
+
+## Verification
+
+Check your package before publishing:
+
+```bash
+# See what will be included
+cargo package --list
+
+# Check metadata
+cargo publish --dry-run
+```
+
+## See Also
+
+- [doc-module-inner](./doc-module-inner.md) - Crate-level documentation
+- [lint-cargo-metadata](./lint-cargo-metadata.md) - Linting Cargo.toml
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace management

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-errors-section.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-errors-section.md
@@ -1,0 +1,122 @@
+# doc-errors-section
+
+> Include `# Errors` section for fallible functions
+
+## Why It Matters
+
+Functions returning `Result` can fail in specific, documented ways. The `# Errors` section tells users exactly when and why a function might return an error, enabling them to handle failures appropriately without reading source code.
+
+This is especially critical for library code where users cannot easily inspect implementation details.
+
+## Bad
+
+```rust
+/// Opens a file and reads its contents.
+pub fn read_file(path: &Path) -> Result<String, Error> {
+    // Users have no idea what errors to expect
+}
+
+/// Connects to the database.
+pub async fn connect(url: &str) -> Result<Connection, DbError> {
+    // Multiple failure modes, none documented
+}
+```
+
+## Good
+
+```rust
+/// Opens a file and reads its contents as a UTF-8 string.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist ([`Error::NotFound`])
+/// - The process lacks permission to read the file ([`Error::PermissionDenied`])
+/// - The file contains invalid UTF-8 ([`Error::InvalidUtf8`])
+pub fn read_file(path: &Path) -> Result<String, Error> {
+    // ...
+}
+
+/// Establishes a connection to the database.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The URL is malformed ([`DbError::InvalidUrl`])
+/// - The database server is unreachable ([`DbError::ConnectionFailed`])
+/// - Authentication fails ([`DbError::AuthenticationFailed`])
+/// - The connection pool is exhausted ([`DbError::PoolExhausted`])
+pub async fn connect(url: &str) -> Result<Connection, DbError> {
+    // ...
+}
+```
+
+## Error Documentation Patterns
+
+### Simple Single Error
+
+```rust
+/// Parses a string as an integer.
+///
+/// # Errors
+///
+/// Returns [`ParseIntError`] if the string is not a valid integer.
+pub fn parse_int(s: &str) -> Result<i64, ParseIntError> {
+    s.parse()
+}
+```
+
+### Multiple Error Variants
+
+```rust
+/// Sends an HTTP request and returns the response.
+///
+/// # Errors
+///
+/// | Error | Condition |
+/// |-------|-----------|
+/// | [`HttpError::Timeout`] | Request exceeded timeout duration |
+/// | [`HttpError::InvalidUrl`] | URL could not be parsed |
+/// | [`HttpError::ConnectionRefused`] | Server refused connection |
+/// | [`HttpError::TlsError`] | TLS handshake failed |
+pub fn send(request: Request) -> Result<Response, HttpError> {
+    // ...
+}
+```
+
+### Propagated Errors
+
+```rust
+/// Loads configuration from a file.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The configuration file cannot be read (IO error)
+/// - The file contains invalid TOML syntax
+/// - Required fields are missing from the configuration
+///
+/// The underlying error is wrapped with context about which
+/// configuration file failed to load.
+pub fn load_config(path: &Path) -> Result<Config, anyhow::Error> {
+    // ...
+}
+```
+
+## Linking to Error Types
+
+Use intra-doc links to connect error variants to their definitions:
+
+```rust
+/// # Errors
+///
+/// Returns [`ValidationError::TooShort`] if the input is less than
+/// the minimum length, or [`ValidationError::InvalidChars`] if it
+/// contains forbidden characters.
+```
+
+## See Also
+
+- [doc-panics-section](./doc-panics-section.md) - Documenting panics
+- [err-doc-errors](./err-doc-errors.md) - Error documentation patterns
+- [doc-intra-links](./doc-intra-links.md) - Linking to types

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-examples-section.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-examples-section.md
@@ -1,0 +1,161 @@
+# doc-examples-section
+
+> Include `# Examples` with runnable code
+
+## Why It Matters
+
+Examples are the most valuable part of documentation. They show users exactly how to use your API. Rust's doc tests ensure examples stay correct as code evolves.
+
+## Bad
+
+```rust
+/// Parses a string into a Foo.
+pub fn parse(s: &str) -> Result<Foo, Error> {
+    // No examples - users have to guess usage
+}
+
+/// A widget for doing things.
+/// 
+/// This widget is very useful.
+pub struct Widget {
+    // Still no examples
+}
+```
+
+## Good
+
+```rust
+/// Parses a string into a Foo.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::parse;
+///
+/// let foo = parse("hello").unwrap();
+/// assert_eq!(foo.name(), "hello");
+/// ```
+///
+/// Handles empty strings:
+///
+/// ```
+/// use my_crate::parse;
+///
+/// let foo = parse("").unwrap();
+/// assert!(foo.is_empty());
+/// ```
+pub fn parse(s: &str) -> Result<Foo, Error> {
+    // ...
+}
+```
+
+## Use ? Not unwrap()
+
+```rust
+/// Loads configuration from a file.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use my_crate::Config;
+///
+/// let config = Config::load("config.toml")?;
+/// println!("Port: {}", config.port);
+/// # Ok(())
+/// # }
+/// ```
+pub fn load(path: &str) -> Result<Config, Error> {
+    // ...
+}
+```
+
+## Hide Setup Code
+
+```rust
+/// Processes items from a database.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Database, Item};
+/// # fn get_db() -> Database { Database::mock() }
+/// let db = get_db();
+/// let items = db.process_items()?;
+/// assert!(!items.is_empty());
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+pub fn process_items(&self) -> Result<Vec<Item>, Error> {
+    // ...
+}
+```
+
+## Multiple Examples
+
+```rust
+/// Creates a new buffer with the specified capacity.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use my_crate::Buffer;
+///
+/// let buf = Buffer::with_capacity(1024);
+/// assert_eq!(buf.capacity(), 1024);
+/// ```
+///
+/// Zero capacity creates an empty buffer:
+///
+/// ```
+/// use my_crate::Buffer;
+///
+/// let buf = Buffer::with_capacity(0);
+/// assert!(buf.is_empty());
+/// ```
+pub fn with_capacity(cap: usize) -> Self {
+    // ...
+}
+```
+
+## Show Error Cases
+
+```rust
+/// Divides two numbers.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::divide;
+///
+/// assert_eq!(divide(10, 2), Ok(5));
+/// ```
+///
+/// Division by zero returns an error:
+///
+/// ```
+/// use my_crate::{divide, MathError};
+///
+/// assert_eq!(divide(10, 0), Err(MathError::DivisionByZero));
+/// ```
+pub fn divide(a: i32, b: i32) -> Result<i32, MathError> {
+    // ...
+}
+```
+
+## Running Doc Tests
+
+```bash
+# Run all doc tests
+cargo test --doc
+
+# Run doc tests for specific item
+cargo test --doc my_function
+```
+
+## See Also
+
+- [doc-question-mark](doc-question-mark.md) - Use ? in examples
+- [doc-hidden-setup](doc-hidden-setup.md) - Hide setup code with #
+- [doc-errors-section](doc-errors-section.md) - Document error conditions

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-hidden-setup.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-hidden-setup.md
@@ -1,0 +1,149 @@
+# doc-hidden-setup
+
+> Use `# ` prefix to hide example setup code
+
+## Why It Matters
+
+Doc examples often require setup code (imports, struct initialization, mock data) that distracts from the main point. The `# ` prefix hides lines from rendered documentation while keeping them in the compiled test, showing users only the relevant code.
+
+This keeps examples focused and readable while ensuring they still compile and run.
+
+## Bad
+
+```rust
+/// Processes a batch of items.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::{Processor, Config, Item};
+/// use std::sync::Arc;
+/// 
+/// let config = Config {
+///     batch_size: 100,
+///     timeout_ms: 5000,
+///     retry_count: 3,
+/// };
+/// let processor = Processor::new(Arc::new(config));
+/// let items = vec![
+///     Item::new("a"),
+///     Item::new("b"),
+///     Item::new("c"),
+/// ];
+/// 
+/// // This is the actual example - buried after 15 lines of setup
+/// let results = processor.process_batch(&items)?;
+/// assert!(results.all_succeeded());
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+pub fn process_batch(&self, items: &[Item]) -> Result<Results, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Processes a batch of items.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Processor, Config, Item, Error};
+/// # use std::sync::Arc;
+/// # let config = Config { batch_size: 100, timeout_ms: 5000, retry_count: 3 };
+/// # let processor = Processor::new(Arc::new(config));
+/// # let items = vec![Item::new("a"), Item::new("b"), Item::new("c")];
+/// let results = processor.process_batch(&items)?;
+/// assert!(results.all_succeeded());
+/// # Ok::<(), Error>(())
+/// ```
+pub fn process_batch(&self, items: &[Item]) -> Result<Results, Error> {
+    // ...
+}
+```
+
+Users see only:
+
+```rust
+let results = processor.process_batch(&items)?;
+assert!(results.all_succeeded());
+```
+
+## What to Hide
+
+| Hide | Show |
+|------|------|
+| `use` statements | Core API usage |
+| Type definitions | Method calls |
+| Mock/test data setup | Key parameters |
+| Error handling boilerplate | Return value handling |
+| `Ok(())` return | Assertions (sometimes) |
+
+## Pattern: Hiding Multi-Line Setup
+
+```rust
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Client, Request};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let client = Client::builder()
+/// #     .timeout(30)
+/// #     .retry(3)
+/// #     .build()?;
+/// let response = client.send(Request::get("/users"))?;
+/// println!("Status: {}", response.status());
+/// # Ok(())
+/// # }
+/// ```
+```
+
+## Pattern: Showing Setup When Relevant
+
+Sometimes setup IS the point—don't hide it:
+
+```rust
+/// Creates a new client with custom configuration.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::Client;
+///
+/// // Configuration IS the example - show it
+/// let client = Client::builder()
+///     .base_url("https://api.example.com")
+///     .timeout_secs(30)
+///     .max_retries(3)
+///     .build()?;
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+```
+
+## Pattern: `ignore` and `no_run`
+
+For examples that shouldn't run in tests:
+
+```rust
+/// # Examples
+///
+/// ```no_run
+/// # use my_crate::Server;
+/// // This would actually start a server - don't run in tests
+/// let server = Server::bind("0.0.0.0:8080").await?;
+/// server.run().await?;
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+
+/// ```ignore
+/// // Pseudocode or incomplete example
+/// let magic = do_something_undefined();
+/// ```
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Writing examples
+- [doc-question-mark](./doc-question-mark.md) - Using `?` in examples
+- [test-doctest-examples](./test-doctest-examples.md) - Doctests as tests

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-intra-links.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-intra-links.md
@@ -1,0 +1,138 @@
+# doc-intra-links
+
+> Use intra-doc links to reference types and items
+
+## Why It Matters
+
+Intra-doc links (`[TypeName]`, `[method](Self::method)`) create clickable references in generated documentation. They're verified at doc-build time, catching broken links early. Unlike URL links, they automatically update when items are renamed or moved.
+
+## Bad
+
+```rust
+/// Returns the length of the buffer.
+/// 
+/// See also `capacity()` for the allocated size, and the
+/// `Buffer` struct for more details.
+pub fn len(&self) -> usize {
+    self.data.len()
+}
+
+/// Parses the input using std::str::FromStr trait.
+/// Check the Error enum for possible failures.
+pub fn parse<T: FromStr>(input: &str) -> Result<T, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Returns the length of the buffer.
+/// 
+/// See also [`capacity()`](Self::capacity) for the allocated size, and
+/// [`Buffer`] for more details.
+pub fn len(&self) -> usize {
+    self.data.len()
+}
+
+/// Parses the input using [`FromStr`] trait.
+/// Check [`Error`] for possible failures.
+///
+/// [`FromStr`]: std::str::FromStr
+pub fn parse<T: FromStr>(input: &str) -> Result<T, Error> {
+    // ...
+}
+```
+
+## Link Syntax
+
+| Syntax | Links To | Example |
+|--------|----------|---------|
+| `[Name]` | Item in scope | `[Vec]`, `[Option]` |
+| `[path::Name]` | Fully qualified item | `[std::vec::Vec]` |
+| `[Self::method]` | Method on current type | `[Self::new]` |
+| `[Type::method]` | Method on other type | `[String::new]` |
+| `[Type::CONST]` | Associated constant | `[usize::MAX]` |
+| `[text](path)` | Custom text | `[see here](Self::len)` |
+
+## Common Patterns
+
+### Linking to Self Members
+
+```rust
+impl Buffer {
+    /// Creates an empty buffer.
+    ///
+    /// Use [`with_capacity`](Self::with_capacity) if you know the size.
+    pub fn new() -> Self { /* ... */ }
+    
+    /// Creates a buffer with pre-allocated capacity.
+    ///
+    /// See [`new`](Self::new) for the default constructor.
+    pub fn with_capacity(cap: usize) -> Self { /* ... */ }
+}
+```
+
+### Linking to Trait Methods
+
+```rust
+/// Converts to a string representation.
+///
+/// This is the implementation of [`Display::fmt`](std::fmt::Display::fmt).
+impl Display for MyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // ...
+    }
+}
+```
+
+### Disambiguation
+
+When names conflict, use suffixes:
+
+```rust
+/// See [`foo()`](fn@foo) for the function and [`foo`](mod@foo) for the module.
+
+/// Works with [`Error`](struct@Error) struct or [`Error`](trait@Error) trait.
+```
+
+| Suffix | Item Type |
+|--------|-----------|
+| `fn@` | Function |
+| `mod@` | Module |
+| `struct@` | Struct |
+| `enum@` | Enum |
+| `trait@` | Trait |
+| `type@` | Type alias |
+| `const@` | Constant |
+| `macro@` | Macro |
+
+### Reference-Style Links
+
+For repeated links or long paths:
+
+```rust
+/// Parses using [`serde`] with [`Deserialize`] trait.
+/// Returns a [`Result`] that may contain [`Error`].
+///
+/// [`serde`]: https://serde.rs
+/// [`Deserialize`]: serde::Deserialize
+/// [`Result`]: std::result::Result
+/// [`Error`]: crate::Error
+```
+
+## Verification
+
+Enable link checking in CI:
+
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+```
+
+This fails if any intra-doc links are broken.
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documenting public items
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-link-types.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-link-types.md
@@ -1,0 +1,169 @@
+# doc-link-types
+
+> Use intra-doc links to connect related types and functions
+
+## Why It Matters
+
+Intra-doc links (`[`TypeName`]`) create clickable references in generated documentation. They enable navigation between related items, verify that referenced items exist at compile time, and update automatically when items are renamed. Plain text references become stale and unclickable.
+
+## Bad
+
+```rust
+/// Parses input and returns a ParseResult.
+/// 
+/// See also: ParseError for error types.
+/// Uses the Tokenizer internally.
+pub fn parse(input: &str) -> ParseResult {
+    // "ParseResult", "ParseError", "Tokenizer" are not clickable
+    // No verification they exist
+}
+```
+
+## Good
+
+```rust
+/// Parses input and returns a [`ParseResult`].
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidSyntax`] if the input contains invalid tokens.
+/// Returns [`ParseError::UnexpectedEof`] if the input ends prematurely.
+///
+/// # Related
+///
+/// - [`Tokenizer`] - The underlying tokenizer used by this parser
+/// - [`parse_file`] - Convenience function for parsing files
+/// - [`ParseOptions`] - Configuration options for parsing
+pub fn parse(input: &str) -> ParseResult {
+    // All links are clickable and verified
+}
+```
+
+## Link Syntax
+
+```rust
+/// Basic link to type in same module
+/// See [`MyType`] for details.
+
+/// Link to method
+/// Use [`MyType::new`] to create instances.
+
+/// Link to associated type
+/// Returns [`Iterator::Item`].
+
+/// Link to module
+/// See the [`parser`] module.
+
+/// Link to external crate type
+/// Works with [`std::collections::HashMap`].
+
+/// Link with custom text
+/// See [the parser][`parse`] for details.
+
+/// Link to module item
+/// See [`crate::utils::helper`].
+
+/// Link to parent module item
+/// See [`super::Parent`].
+```
+
+## Common Patterns
+
+```rust
+/// A configuration builder.
+///
+/// # Example
+///
+/// ```
+/// use my_crate::Config;
+///
+/// let config = Config::builder()
+///     .timeout(30)
+///     .build()?;
+/// ```
+///
+/// # Methods
+///
+/// - [`Config::builder`] - Create a new builder
+/// - [`Config::default`] - Create with defaults
+///
+/// # Related Types
+///
+/// - [`ConfigBuilder`] - The builder returned by [`Config::builder`]
+/// - [`ConfigError`] - Errors that can occur when building
+pub struct Config { ... }
+
+impl Config {
+    /// Creates a new [`ConfigBuilder`].
+    ///
+    /// This is equivalent to [`ConfigBuilder::new`].
+    pub fn builder() -> ConfigBuilder { ... }
+}
+```
+
+## Linking to Trait Items
+
+```rust
+/// Implements [`Iterator`] for lazy evaluation.
+///
+/// The [`Iterator::next`] method advances the cursor.
+/// 
+/// For parallel iteration, see [`rayon::ParallelIterator`].
+pub struct MyIterator { ... }
+
+impl Iterator for MyIterator {
+    /// Advances and returns the next value.
+    ///
+    /// See also [`Iterator::nth`] for skipping elements.
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+```
+
+## Broken Link Detection
+
+```bash
+# Catch broken intra-doc links
+RUSTDOCFLAGS="-D warnings" cargo doc
+
+# Or in CI
+cargo doc --no-deps 2>&1 | grep "warning: unresolved link"
+```
+
+```toml
+# Cargo.toml - deny broken links
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
+```
+
+## Module-Level Documentation
+
+```rust
+//! # Parser Module
+//!
+//! This module provides parsing utilities.
+//!
+//! ## Main Types
+//!
+//! - [`Parser`] - The main parser struct
+//! - [`Token`] - Tokens produced by tokenization
+//! - [`Ast`] - The abstract syntax tree
+//!
+//! ## Functions
+//!
+//! - [`parse`] - Parse a string
+//! - [`parse_file`] - Parse a file
+//!
+//! ## Errors
+//!
+//! All functions return [`ParseError`] on failure.
+
+pub struct Parser { ... }
+pub enum Token { ... }
+pub struct Ast { ... }
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Code examples in docs
+- [err-doc-errors](./err-doc-errors.md) - Documenting errors
+- [lint-deny-correctness](./lint-deny-correctness.md) - Lint settings

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-module-inner.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-module-inner.md
@@ -1,0 +1,116 @@
+# doc-module-inner
+
+> Use `//!` for module-level documentation
+
+## Why It Matters
+
+Inner doc comments (`//!`) document the module itself, not the next item. They appear at the top of module files and describe the module's purpose, contents, and usage patterns. This helps users understand what a module provides before diving into individual items.
+
+Module docs are the first thing users see in `cargo doc` when navigating to a module.
+
+## Bad
+
+```rust
+// This module handles authentication
+// It provides JWT and session-based auth
+
+mod auth;
+
+pub use auth::*;
+```
+
+```rust
+// auth.rs
+/// Authentication utilities  // Wrong: this documents nothing useful
+use std::collections::HashMap;
+
+pub struct Session { /* ... */ }
+```
+
+## Good
+
+```rust
+//! Authentication and authorization utilities.
+//!
+//! This module provides multiple authentication strategies:
+//!
+//! - [`JwtAuth`] - JSON Web Token based authentication
+//! - [`SessionAuth`] - Cookie-based session authentication
+//! - [`ApiKeyAuth`] - API key authentication for services
+//!
+//! # Examples
+//!
+//! ```
+//! use my_crate::auth::{JwtAuth, Authenticator};
+//!
+//! let auth = JwtAuth::new("secret-key");
+//! let token = auth.generate_token(&user)?;
+//! ```
+//!
+//! # Feature Flags
+//!
+//! - `jwt` - Enables JWT authentication (enabled by default)
+//! - `sessions` - Enables session-based authentication
+
+use std::collections::HashMap;
+
+pub struct Session { /* ... */ }
+```
+
+## Where to Use Inner Docs
+
+| Location | Purpose |
+|----------|---------|
+| `lib.rs` | Crate-level documentation (appears on crate root) |
+| `mod.rs` | Module documentation for directory modules |
+| `module.rs` | Module documentation for single-file modules |
+
+## Crate Root Example
+
+```rust
+//! # My Awesome Crate
+//!
+//! `my_crate` provides utilities for handling complex workflows.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use my_crate::prelude::*;
+//!
+//! let workflow = Workflow::builder()
+//!     .add_step(Step::new("fetch"))
+//!     .add_step(Step::new("process"))
+//!     .build();
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`workflow`] - Core workflow engine
+//! - [`steps`] - Built-in workflow steps
+//! - [`prelude`] - Common imports
+//!
+//! ## Feature Flags
+//!
+//! | Feature | Description |
+//! |---------|-------------|
+//! | `async` | Async workflow execution |
+//! | `serde` | Serialization support |
+
+pub mod workflow;
+pub mod steps;
+pub mod prelude;
+```
+
+## Key Sections for Module Docs
+
+1. **Brief description** - One-line summary
+2. **Overview** - What the module provides
+3. **Examples** - How to use it
+4. **Feature flags** - Optional functionality
+5. **See Also** - Related modules
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documenting public items
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Crate metadata

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-panics-section.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-panics-section.md
@@ -1,0 +1,128 @@
+# doc-panics-section
+
+> Include `# Panics` section for functions that can panic
+
+## Why It Matters
+
+Panics are exceptional conditions that crash the program (or unwind the stack). Users need to know when a function might panic so they can ensure preconditions are met or avoid the function in contexts where panics are unacceptable (e.g., `no_std`, embedded, FFI).
+
+If a function can panic, document exactly when.
+
+## Bad
+
+```rust
+/// Returns the element at the given index.
+pub fn get(index: usize) -> &T {
+    &self.data[index]  // Panics if out of bounds - not documented!
+}
+
+/// Divides two numbers.
+pub fn divide(a: i32, b: i32) -> i32 {
+    a / b  // Panics on division by zero - not documented!
+}
+```
+
+## Good
+
+```rust
+/// Returns the element at the given index.
+///
+/// # Panics
+///
+/// Panics if `index` is out of bounds (i.e., `index >= self.len()`).
+///
+/// # Examples
+///
+/// ```
+/// let v = vec![1, 2, 3];
+/// assert_eq!(v.get(1), &2);
+/// ```
+pub fn get(&self, index: usize) -> &T {
+    &self.data[index]
+}
+
+/// Divides two numbers.
+///
+/// # Panics
+///
+/// Panics if `divisor` is zero.
+///
+/// For a non-panicking version, use [`checked_divide`].
+pub fn divide(dividend: i32, divisor: i32) -> i32 {
+    dividend / divisor
+}
+
+/// Divides two numbers, returning `None` if the divisor is zero.
+pub fn checked_divide(dividend: i32, divisor: i32) -> Option<i32> {
+    if divisor == 0 {
+        None
+    } else {
+        Some(dividend / divisor)
+    }
+}
+```
+
+## Common Panic Conditions
+
+| Operation | Panic Condition |
+|-----------|-----------------|
+| Index access `[i]` | Index out of bounds |
+| Division `/`, `%` | Division by zero |
+| `.unwrap()` | `None` or `Err` value |
+| `.expect()` | `None` or `Err` value |
+| `slice::split_at(mid)` | `mid > len` |
+| `Vec::remove(i)` | `i >= len` |
+| Overflow (debug) | Integer overflow |
+
+## Pattern: Panic vs Return Error
+
+Document why you chose to panic vs return `Result`:
+
+```rust
+/// Creates a new buffer with the given capacity.
+///
+/// # Panics
+///
+/// Panics if `capacity` is zero. A buffer must have at least
+/// one byte of capacity.
+///
+/// This panics rather than returning an error because a zero-capacity
+/// buffer represents a programming error, not a runtime condition.
+pub fn new(capacity: usize) -> Self {
+    assert!(capacity > 0, "capacity must be non-zero");
+    // ...
+}
+```
+
+## Pattern: Debug-Only Panics
+
+```rust
+/// Adds an item to the collection.
+///
+/// # Panics
+///
+/// In debug builds, panics if the collection is at capacity.
+/// In release builds, this is a no-op when at capacity.
+pub fn push(&mut self, item: T) {
+    debug_assert!(self.len < self.capacity, "collection at capacity");
+    // ...
+}
+```
+
+## Provide Non-Panicking Alternatives
+
+When documenting a panicking function, point to safe alternatives:
+
+```rust
+/// # Panics
+///
+/// Panics if the index is out of bounds.
+///
+/// For a non-panicking version, use [`get`] which returns `Option<&T>`.
+```
+
+## See Also
+
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors
+- [doc-safety-section](./doc-safety-section.md) - Documenting unsafe
+- [err-result-over-panic](./err-result-over-panic.md) - Preferring Result

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-question-mark.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-question-mark.md
@@ -1,0 +1,136 @@
+# doc-question-mark
+
+> Use `?` in examples, not `.unwrap()`
+
+## Why It Matters
+
+Doc examples should model best practices. Using `.unwrap()` teaches users to ignore errors, while `?` demonstrates proper error propagation. Examples with `?` also fail the doctest if an error occurs, catching bugs in documentation.
+
+Rust doctests wrap examples in a function that returns `Result<(), E>` by default when you use `?`, making this pattern easy to adopt.
+
+## Bad
+
+```rust
+/// Reads a configuration file.
+///
+/// # Examples
+///
+/// ```
+/// let config = Config::from_file("config.toml").unwrap();
+/// println!("{:?}", config.database_url);
+/// ```
+pub fn from_file(path: &str) -> Result<Config, Error> {
+    // ...
+}
+
+/// Fetches data from the API.
+///
+/// # Examples
+///
+/// ```
+/// let client = Client::new();
+/// let response = client.get("https://api.example.com").unwrap();
+/// let data: Data = response.json().unwrap();
+/// ```
+pub async fn get(&self, url: &str) -> Result<Response, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Reads a configuration file.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Config, Error};
+/// # fn main() -> Result<(), Error> {
+/// let config = Config::from_file("config.toml")?;
+/// println!("{:?}", config.database_url);
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_file(path: &str) -> Result<Config, Error> {
+    // ...
+}
+
+/// Fetches data from the API.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use my_crate::{Client, Data, Error};
+/// # async fn example() -> Result<(), Error> {
+/// let client = Client::new();
+/// let response = client.get("https://api.example.com").await?;
+/// let data: Data = response.json().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn get(&self, url: &str) -> Result<Response, Error> {
+    // ...
+}
+```
+
+## Doctest Wrapper Pattern
+
+Rust wraps doc examples in a function. You can make this explicit:
+
+```rust
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let value = parse_config("key=value")?;
+/// assert_eq!(value.key, "value");
+/// # Ok(())
+/// # }
+/// ```
+```
+
+Or use the implicit wrapper (Rust 2021+):
+
+```rust
+/// # Examples
+///
+/// ```
+/// # use my_crate::parse_config;
+/// let value = parse_config("key=value")?;
+/// assert_eq!(value.key, "value");
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+```
+
+## When to Use `.unwrap()`
+
+There are specific cases where `.unwrap()` is acceptable in examples:
+
+```rust
+/// # Examples
+///
+/// ```
+/// // Static regex that is known at compile time to be valid
+/// let re = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+///
+/// // Parsing a literal that cannot fail
+/// let n: i32 = "42".parse().unwrap();
+/// ```
+```
+
+But still prefer `?` when demonstrating error handling patterns.
+
+## Comparison
+
+| Pattern | Behavior on Error | Teaches |
+|---------|-------------------|---------|
+| `.unwrap()` | Panics with generic message | Bad habits |
+| `.expect()` | Panics with custom message | Slightly better |
+| `?` | Propagates error, test fails | Best practices |
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Writing examples
+- [doc-hidden-setup](./doc-hidden-setup.md) - Hiding setup code
+- [err-question-mark](./err-question-mark.md) - Error propagation

--- a/.cursor/skills/rust-skills-leonardomso/rules/doc-safety-section.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/doc-safety-section.md
@@ -1,0 +1,131 @@
+# doc-safety-section
+
+> Include `# Safety` section for unsafe functions
+
+## Why It Matters
+
+Unsafe functions require callers to uphold invariants that the compiler cannot verify. The `# Safety` section documents exactly what the caller must guarantee for the function to be sound. Without this, users cannot safely call the function.
+
+This is not optional—it's a requirement for sound unsafe code.
+
+## Bad
+
+```rust
+/// Reads a value from a raw pointer.
+pub unsafe fn read_ptr<T>(ptr: *const T) -> T {
+    // What guarantees must the caller provide? Unknown!
+    ptr.read()
+}
+
+/// Creates a string from raw parts.
+pub unsafe fn string_from_raw(ptr: *mut u8, len: usize, cap: usize) -> String {
+    String::from_raw_parts(ptr, len, cap)
+}
+```
+
+## Good
+
+```rust
+/// Reads a value from a raw pointer.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+/// - `ptr` is valid for reads of `size_of::<T>()` bytes
+/// - `ptr` is properly aligned for type `T`
+/// - `ptr` points to a properly initialized value of type `T`
+/// - The memory referenced by `ptr` is not mutated during this call
+pub unsafe fn read_ptr<T>(ptr: *const T) -> T {
+    ptr.read()
+}
+
+/// Creates a `String` from raw parts.
+///
+/// # Safety
+///
+/// The caller must guarantee that:
+/// - `ptr` was allocated by the same allocator that `String` uses
+/// - `len` is less than or equal to `cap`
+/// - The first `len` bytes at `ptr` are valid UTF-8
+/// - `cap` is the capacity that `ptr` was allocated with
+/// - No other code will use `ptr` after this call (ownership is transferred)
+///
+/// Violating these requirements leads to undefined behavior including
+/// memory corruption, use-after-free, or invalid UTF-8 in strings.
+pub unsafe fn string_from_raw(ptr: *mut u8, len: usize, cap: usize) -> String {
+    String::from_raw_parts(ptr, len, cap)
+}
+```
+
+## Key Elements of Safety Documentation
+
+| Element | Description |
+|---------|-------------|
+| **Preconditions** | What must be true before calling |
+| **Pointer validity** | Alignment, null-ness, lifetime |
+| **Memory ownership** | Who owns what, transfer semantics |
+| **Invariants** | Type invariants that must hold |
+| **Consequences** | What happens if violated |
+
+## Pattern: Unsafe Trait Implementations
+
+```rust
+/// A type that can be safely zeroed.
+///
+/// # Safety
+///
+/// Implementing this trait guarantees that:
+/// - All bit patterns of zeros represent a valid value of this type
+/// - The type has no padding bytes that could leak data
+/// - The type contains no references or pointers
+pub unsafe trait Zeroable {
+    fn zeroed() -> Self;
+}
+
+// SAFETY: u32 is a primitive integer type where all zero bits
+// represent a valid value (0).
+unsafe impl Zeroable for u32 {
+    fn zeroed() -> Self {
+        0
+    }
+}
+```
+
+## Pattern: Unsafe Blocks in Safe Functions
+
+When a safe function contains unsafe blocks, document the invariants:
+
+```rust
+/// Returns a reference to the element at the given index.
+///
+/// Returns `None` if the index is out of bounds.
+pub fn get(&self, index: usize) -> Option<&T> {
+    if index < self.len {
+        // SAFETY: We just verified that index < len, so this
+        // access is within bounds.
+        Some(unsafe { self.data.get_unchecked(index) })
+    } else {
+        None
+    }
+}
+```
+
+## Common Safety Requirements
+
+```rust
+/// # Safety
+///
+/// - Pointer must be non-null
+/// - Pointer must be aligned to `align_of::<T>()`
+/// - Pointer must be valid for reads/writes of `size_of::<T>()` bytes
+/// - Pointer must point to an initialized value of `T`
+/// - The referenced memory must not be accessed through any other pointer
+///   for the duration of the returned reference
+/// - The total size must not exceed `isize::MAX`
+```
+
+## See Also
+
+- [doc-panics-section](./doc-panics-section.md) - Documenting panics
+- [lint-unsafe-doc](./lint-unsafe-doc.md) - Enforcing unsafe documentation
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-anyhow-app.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-anyhow-app.md
@@ -1,0 +1,179 @@
+# err-anyhow-app
+
+> Use `anyhow` for application error handling
+
+## Why It Matters
+
+Applications often don't need typed errors - they just need to report what went wrong with good context. `anyhow` provides easy error handling with context chaining, backtraces, and conversion from any error type.
+
+## Bad
+
+```rust
+// Tedious type management
+fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
+    let path = find_config()?;  // Returns FindError
+    let content = std::fs::read_to_string(&path)?;  // Returns io::Error
+    let config: Config = toml::from_str(&content)?;  // Returns toml::Error
+    validate(&config)?;  // Returns ValidationError
+    Ok(config)
+}
+
+// No context - hard to debug
+fn process() -> Result<(), Box<dyn std::error::Error>> {
+    let data = fetch()?;  // Which fetch failed?
+    transform(data)?;     // What was being transformed?
+    save()?;              // Where was it saving to?
+    Ok(())
+}
+```
+
+## Good
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_config() -> Result<Config> {
+    let path = find_config()
+        .context("failed to locate config file")?;
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read config from {}", path.display()))?;
+    
+    let config: Config = toml::from_str(&content)
+        .context("failed to parse config as TOML")?;
+    
+    validate(&config)
+        .context("config validation failed")?;
+    
+    Ok(config)
+}
+
+// Error message: "config validation failed: field 'port' must be > 0"
+// Full chain preserved for debugging
+```
+
+## Key Features
+
+```rust
+use anyhow::{anyhow, bail, ensure, Context, Result};
+
+fn example() -> Result<()> {
+    // Create ad-hoc errors
+    let err = anyhow!("something went wrong");
+    
+    // Early return with error
+    bail!("aborting due to {}", reason);
+    
+    // Assert with error
+    ensure!(condition, "condition was false");
+    
+    // Add context to any error
+    risky_operation()
+        .context("risky operation failed")?;
+    
+    // Dynamic context
+    fetch(url)
+        .with_context(|| format!("failed to fetch {}", url))?;
+    
+    Ok(())
+}
+```
+
+## Main Function Pattern
+
+```rust
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+
+// Or with custom exit handling
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);  // Pretty-print with causes
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    // Application logic
+    Ok(())
+}
+```
+
+## Error Display Formats
+
+```rust
+use anyhow::Result;
+
+fn show_error(err: anyhow::Error) {
+    // Just the top-level message
+    println!("{}", err);
+    // "config validation failed"
+    
+    // With cause chain (# alternate format)
+    println!("{:#}", err);
+    // "config validation failed: field 'port' must be > 0"
+    
+    // Debug format with backtrace
+    println!("{:?}", err);
+    // Full backtrace if RUST_BACKTRACE=1
+    
+    // Iterate through cause chain
+    for cause in err.chain() {
+        println!("Caused by: {}", cause);
+    }
+}
+```
+
+## Combining with thiserror
+
+```rust
+// In your library crate - typed errors
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("rate limited")]
+    RateLimited,
+    #[error("not found: {0}")]
+    NotFound(String),
+}
+
+// In your application - anyhow for handling
+use anyhow::{Context, Result};
+
+fn fetch_user(id: u64) -> Result<User> {
+    api::get_user(id)
+        .with_context(|| format!("failed to fetch user {}", id))
+}
+
+// Can still downcast if needed
+fn handle_error(err: anyhow::Error) {
+    if let Some(api_err) = err.downcast_ref::<ApiError>() {
+        match api_err {
+            ApiError::RateLimited => wait_and_retry(),
+            ApiError::NotFound(id) => log_missing(id),
+        }
+    }
+}
+```
+
+## When to Use Which
+
+| Situation | Use |
+|-----------|-----|
+| Library public API | `thiserror` |
+| Application code | `anyhow` |
+| CLI tools | `anyhow` |
+| Internal library code | Either |
+| Need to match error variants | `thiserror` |
+| Just need to report errors | `anyhow` |
+
+## See Also
+
+- [err-thiserror-lib](err-thiserror-lib.md) - Use thiserror for libraries
+- [err-context-chain](err-context-chain.md) - Add context to errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-context-chain.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-context-chain.md
@@ -1,0 +1,144 @@
+# err-context-chain
+
+> Add context with `.context()` or `.with_context()`
+
+## Why It Matters
+
+Raw errors often lack information about what operation failed. Adding context creates an error chain that tells the full story: what you were trying to do, and why it failed.
+
+## Bad
+
+```rust
+// Raw error - no context
+fn load_user(id: u64) -> Result<User, Error> {
+    let path = format!("users/{}.json", id);
+    let content = std::fs::read_to_string(&path)?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+// Error message: "No such file or directory (os error 2)"
+// Which file? What were we doing?
+```
+
+## Good
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let path = format!("users/{}.json", id);
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read user file: {}", path))?;
+    
+    let user: User = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse user {} JSON", id))?;
+    
+    Ok(user)
+}
+
+// Error: "failed to parse user 42 JSON"
+// Caused by: "expected ':' at line 5 column 12"
+```
+
+## context() vs with_context()
+
+```rust
+// context() - static string (slight allocation)
+fs::read_to_string(path)
+    .context("failed to read config")?;
+
+// with_context() - lazy evaluation (only allocates on error)
+fs::read_to_string(path)
+    .with_context(|| format!("failed to read {}", path))?;
+
+// Use with_context() when:
+// - Message includes runtime data (format!)
+// - Computing the message is expensive
+// - Error path is cold (most of the time)
+```
+
+## Building Context Chains
+
+```rust
+fn process_order(order_id: u64) -> Result<()> {
+    let order = fetch_order(order_id)
+        .with_context(|| format!("failed to fetch order {}", order_id))?;
+    
+    let user = load_user(order.user_id)
+        .with_context(|| format!("failed to load user for order {}", order_id))?;
+    
+    let payment = process_payment(&order, &user)
+        .context("payment processing failed")?;
+    
+    ship_order(&order, &payment)
+        .context("shipping failed")?;
+    
+    Ok(())
+}
+
+// Full error chain:
+// "shipping failed"
+// Caused by: "carrier API returned 503"
+// Caused by: "connection refused"
+```
+
+## Displaying Error Chains
+
+```rust
+fn main() {
+    if let Err(e) = run() {
+        // Just top-level message
+        eprintln!("Error: {}", e);
+        
+        // Full chain with alternate format
+        eprintln!("Error: {:#}", e);
+        
+        // Debug format (includes backtrace if enabled)
+        eprintln!("Error: {:?}", e);
+        
+        // Iterate through chain
+        for (i, cause) in e.chain().enumerate() {
+            eprintln!("  {}: {}", i, cause);
+        }
+    }
+}
+```
+
+## With thiserror
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("failed to load config from {path}")]
+    ConfigLoad {
+        path: String,
+        #[source]
+        cause: std::io::Error,
+    },
+    
+    #[error("failed to connect to database")]
+    Database {
+        #[source]
+        cause: sqlx::Error,
+    },
+}
+
+// Usage
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| AppError::ConfigLoad {
+            path: path.to_string(),
+            cause: e,
+        })?;
+    // ...
+}
+```
+
+## See Also
+
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications
+- [err-source-chain](err-source-chain.md) - Use #[source] to chain errors
+- [err-question-mark](err-question-mark.md) - Use ? for propagation

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-custom-type.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-custom-type.md
@@ -1,0 +1,152 @@
+# err-custom-type
+
+> Define custom error types for domain-specific failures
+
+## Why It Matters
+
+Generic errors like `String`, `Box<dyn Error>`, or catch-all enums obscure what can actually go wrong. Custom error types document failure modes in the type system, enable pattern matching for specific handling, and provide clear API contracts. They make your code self-documenting and help callers handle errors appropriately.
+
+## Bad
+
+```rust
+// Generic string errors - no structure
+fn validate_user(user: &User) -> Result<(), String> {
+    if user.name.is_empty() {
+        return Err("Name is empty".to_string());
+    }
+    if user.age > 150 {
+        return Err("Age is invalid".to_string());
+    }
+    Ok(())
+}
+
+// Caller can't match on specific errors
+match validate_user(&user) {
+    Ok(()) => save(user),
+    Err(msg) => {
+        // Can only do string comparison - fragile!
+        if msg.contains("Name") {
+            prompt_for_name()
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ValidationError {
+    #[error("name cannot be empty")]
+    EmptyName,
+    
+    #[error("name exceeds maximum length of {max} characters")]
+    NameTooLong { max: usize, actual: usize },
+    
+    #[error("invalid age {0}: must be between 0 and 150")]
+    InvalidAge(u8),
+    
+    #[error("email format is invalid: {0}")]
+    InvalidEmail(String),
+}
+
+fn validate_user(user: &User) -> Result<(), ValidationError> {
+    if user.name.is_empty() {
+        return Err(ValidationError::EmptyName);
+    }
+    if user.name.len() > 100 {
+        return Err(ValidationError::NameTooLong { 
+            max: 100, 
+            actual: user.name.len() 
+        });
+    }
+    if user.age > 150 {
+        return Err(ValidationError::InvalidAge(user.age));
+    }
+    Ok(())
+}
+
+// Caller can match specifically
+match validate_user(&user) {
+    Ok(()) => save(user),
+    Err(ValidationError::EmptyName) => prompt_for_name(),
+    Err(ValidationError::InvalidAge(age)) => {
+        show_error(&format!("Please enter a valid age (you entered {})", age))
+    }
+    Err(e) => show_error(&e.to_string()),
+}
+```
+
+## Error Type Design Guidelines
+
+```rust
+// 1. Group related errors in domain-specific enums
+#[derive(Error, Debug)]
+pub enum AuthError {
+    #[error("invalid credentials")]
+    InvalidCredentials,
+    #[error("account locked after {attempts} failed attempts")]
+    AccountLocked { attempts: u32 },
+    #[error("token expired")]
+    TokenExpired,
+}
+
+#[derive(Error, Debug)]
+pub enum PaymentError {
+    #[error("insufficient funds: need {required}, have {available}")]
+    InsufficientFunds { required: Decimal, available: Decimal },
+    #[error("card declined: {reason}")]
+    CardDeclined { reason: String },
+}
+
+// 2. Include relevant data for error handling/display
+#[derive(Error, Debug)]
+pub enum FileError {
+    #[error("file not found: {path}")]
+    NotFound { path: PathBuf },
+    #[error("permission denied for {path}")]
+    PermissionDenied { path: PathBuf },
+}
+
+// 3. Consider #[non_exhaustive] for public APIs
+#[derive(Error, Debug)]
+#[non_exhaustive]  // Allows adding variants without breaking changes
+pub enum ApiError {
+    #[error("rate limited")]
+    RateLimited,
+    #[error("not found")]
+    NotFound,
+}
+```
+
+## When to Use What
+
+| Error Pattern | Use Case |
+|---------------|----------|
+| Custom enum | Library with specific failure modes |
+| `thiserror` | Libraries needing `std::error::Error` |
+| `anyhow::Error` | Applications, prototypes |
+| Struct with source | Single error type with wrapped cause |
+
+## Struct-Based Errors
+
+For single error types with rich context:
+
+```rust
+#[derive(Error, Debug)]
+#[error("query failed for table '{table}' with filter '{filter}'")]
+pub struct QueryError {
+    pub table: String,
+    pub filter: String,
+    #[source]
+    pub source: DatabaseError,
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - thiserror for error definitions
+- [err-anyhow-app](./err-anyhow-app.md) - When to use anyhow instead
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-doc-errors.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-doc-errors.md
@@ -1,0 +1,145 @@
+# err-doc-errors
+
+> Document error conditions with `# Errors` section in doc comments
+
+## Why It Matters
+
+Users of your API need to know what can go wrong and why. The `# Errors` documentation section is the standard Rust convention for describing when a function returns `Err`. Good error documentation helps callers handle errors appropriately and understand the contract of your API.
+
+## Bad
+
+```rust
+/// Loads a configuration from the specified path.
+pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    // No documentation of error conditions
+    // Caller must read source code to understand what can fail
+}
+
+/// Parses and validates the input string.
+/// 
+/// Returns the parsed value.  // What about errors?
+pub fn parse_input(input: &str) -> Result<Value, ParseError> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Loads a configuration from the specified path.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file at `path` does not exist or cannot be read
+/// - The file contents are not valid TOML
+/// - Required configuration keys are missing
+/// - Configuration values are out of valid ranges
+///
+/// # Examples
+///
+/// ```
+/// # use mylib::{load_config, ConfigError};
+/// # fn main() -> Result<(), ConfigError> {
+/// let config = load_config("app.toml")?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    // ...
+}
+
+/// Parses and validates the input string as a positive integer.
+///
+/// # Errors
+///
+/// Returns [`ParseError::Empty`] if the input is empty.
+/// Returns [`ParseError::InvalidFormat`] if the input contains non-digit characters.
+/// Returns [`ParseError::Overflow`] if the value exceeds `i64::MAX`.
+/// Returns [`ParseError::NotPositive`] if the value is zero or negative.
+pub fn parse_positive_int(input: &str) -> Result<i64, ParseError> {
+    // ...
+}
+```
+
+## Linking to Error Variants
+
+```rust
+/// Attempts to connect to the database.
+///
+/// # Errors
+///
+/// This function will return an error if:
+///
+/// - [`DbError::ConnectionFailed`] - The database server is unreachable
+/// - [`DbError::AuthenticationFailed`] - Invalid credentials
+/// - [`DbError::Timeout`] - Connection attempt exceeded timeout
+/// - [`DbError::TlsError`] - TLS handshake failed
+///
+/// See [`DbError`] for more details on each variant.
+pub fn connect(config: &DbConfig) -> Result<Connection, DbError> {
+    // ...
+}
+```
+
+## Panic vs Error Documentation
+
+```rust
+/// Divides two numbers.
+///
+/// # Errors
+///
+/// Returns [`MathError::DivisionByZero`] if `divisor` is zero.
+///
+/// # Panics
+///
+/// Panics if called from a non-main thread (debug builds only).
+pub fn divide(dividend: i64, divisor: i64) -> Result<i64, MathError> {
+    // ...
+}
+```
+
+## Error Section Format Options
+
+```rust
+// Style 1: Bullet list (good for multiple conditions)
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist
+/// - The file cannot be read
+/// - The content is invalid UTF-8
+
+// Style 2: Returns statements (good for mapping to variants)
+/// # Errors
+///
+/// Returns [`Error::NotFound`] if the item doesn't exist.
+/// Returns [`Error::PermissionDenied`] if access is forbidden.
+
+// Style 3: Prose (good for complex conditions)
+/// # Errors
+///
+/// This function returns an error when the input fails validation.
+/// Validation includes checking that all required fields are present,
+/// that numeric fields are within allowed ranges, and that string
+/// fields match their expected formats.
+```
+
+## Clippy Lint
+
+```toml
+# Cargo.toml - require error documentation
+[lints.clippy]
+missing_errors_doc = "warn"
+```
+
+```rust
+// This will warn without # Errors section
+pub fn might_fail() -> Result<(), Error> { Ok(()) }
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Examples in documentation
+- [err-thiserror-lib](./err-thiserror-lib.md) - Defining error types
+- [api-must-use](./api-must-use.md) - Marking Results as must_use

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-expect-bugs-only.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-expect-bugs-only.md
@@ -1,0 +1,133 @@
+# err-expect-bugs-only
+
+> Use `expect()` only for invariants that indicate bugs, not user errors
+
+## Why It Matters
+
+`expect()` is better than `unwrap()` because it provides context, but it still panics. Reserve it for situations where failure indicates a bug in your code—a violated invariant, not a user error or external failure. The message should explain why the invariant should hold, helping future developers understand and fix the bug.
+
+## Bad
+
+```rust
+// User input can legitimately fail - don't expect
+fn parse_user_input(input: &str) -> Config {
+    serde_json::from_str(input)
+        .expect("Invalid JSON")  // User error, not a bug!
+}
+
+// Network can fail - don't expect
+fn fetch_data(url: &str) -> Data {
+    reqwest::get(url)
+        .expect("Network request failed")  // External failure!
+        .json()
+        .expect("Invalid response")
+}
+
+// File might not exist - don't expect
+fn load_config() -> Config {
+    let content = fs::read_to_string("config.json")
+        .expect("Config file missing");  // Environment issue!
+}
+```
+
+## Good
+
+```rust
+// Invariant: after insert, key exists
+fn cache_and_get(&mut self, key: String, value: Value) -> &Value {
+    self.cache.insert(key.clone(), value);
+    self.cache.get(&key)
+        .expect("BUG: key must exist immediately after insert")
+}
+
+// Invariant: regex is compile-time constant
+fn create_parser() -> Regex {
+    Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+        .expect("BUG: date regex is invalid - this is a compile-time constant")
+}
+
+// Invariant: already validated
+fn process_validated(data: ValidatedData) -> Result<Output, ProcessError> {
+    let value = data.required_field
+        .expect("BUG: ValidatedData guarantees required_field is Some");
+    // ...
+}
+
+// Invariant: type system guarantees
+fn get_first<T>(vec: Vec<T>) -> T 
+where 
+    Vec<T>: NonEmpty,  // Hypothetical trait
+{
+    vec.into_iter().next()
+        .expect("BUG: NonEmpty Vec cannot be empty")
+}
+```
+
+## expect() Message Guidelines
+
+Messages should:
+1. Start with "BUG:" or similar to indicate it's an invariant
+2. Explain WHY the invariant should hold
+3. Help developers fix the issue
+
+```rust
+// ❌ Bad messages
+.expect("failed")                    // No context
+.expect("should not be None")        // Doesn't explain why
+.expect("Invalid state")             // Vague
+
+// ✅ Good messages
+.expect("BUG: HashMap entry exists after insert")
+.expect("BUG: validated input must parse - validation is broken")
+.expect("BUG: static regex compilation failed - regex syntax error in source")
+```
+
+## Pattern: Validate Once, expect() After
+
+```rust
+struct ValidatedEmail(String);
+
+impl ValidatedEmail {
+    pub fn new(email: &str) -> Result<Self, EmailError> {
+        // Validation happens here, returns Result
+        if !is_valid_email(email) {
+            return Err(EmailError::Invalid);
+        }
+        Ok(ValidatedEmail(email.to_string()))
+    }
+    
+    pub fn domain(&self) -> &str {
+        // After validation, expect() is fine
+        self.0.split('@').nth(1)
+            .expect("BUG: ValidatedEmail must contain @")
+    }
+}
+```
+
+## Alternatives When expect() Is Wrong
+
+```rust
+// Don't: expect on user data
+let port: u16 = input.parse().expect("Invalid port");
+
+// Do: Return Result
+let port: u16 = input.parse().map_err(|_| ConfigError::InvalidPort)?;
+
+// Do: Provide default
+let port: u16 = input.parse().unwrap_or(8080);
+
+// Do: Handle explicitly
+let port: u16 = match input.parse() {
+    Ok(p) => p,
+    Err(_) => {
+        log::warn!("Invalid port '{}', using default", input);
+        8080
+    }
+};
+```
+
+## See Also
+
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoiding unwrap in production
+- [err-result-over-panic](./err-result-over-panic.md) - When to return Result
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven validation

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-from-impl.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-from-impl.md
@@ -1,0 +1,152 @@
+# err-from-impl
+
+> Implement `From<E>` for error conversions to enable `?` operator
+
+## Why It Matters
+
+The `?` operator automatically converts errors using `From` trait. By implementing `From<SourceError> for YourError`, you enable seamless error propagation without explicit `.map_err()` calls. This makes error handling code cleaner and ensures consistent error wrapping throughout your codebase.
+
+## Bad
+
+```rust
+#[derive(Debug)]
+enum AppError {
+    Io(std::io::Error),
+    Parse(serde_json::Error),
+    Database(diesel::result::Error),
+}
+
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| AppError::Io(e))?;  // Manual conversion everywhere
+    
+    let config: Config = serde_json::from_str(&content)
+        .map_err(|e| AppError::Parse(e))?;  // Repeated boilerplate
+    
+    save_to_db(&config)
+        .map_err(|e| AppError::Database(e))?;  // Gets tedious
+    
+    Ok(config)
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug)]
+enum AppError {
+    Io(std::io::Error),
+    Parse(serde_json::Error),
+    Database(diesel::result::Error),
+}
+
+// Implement From for each source error type
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> Self {
+        AppError::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(err: serde_json::Error) -> Self {
+        AppError::Parse(err)
+    }
+}
+
+impl From<diesel::result::Error> for AppError {
+    fn from(err: diesel::result::Error) -> Self {
+        AppError::Database(err)
+    }
+}
+
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)?;  // Auto-converts
+    let config: Config = serde_json::from_str(&content)?;  // Clean!
+    save_to_db(&config)?;
+    Ok(config)
+}
+```
+
+## Use thiserror for Automatic From
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum AppError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),  // Auto-generates From impl
+    
+    #[error("Parse error: {0}")]
+    Parse(#[from] serde_json::Error),  // #[from] does the work
+    
+    #[error("Database error: {0}")]
+    Database(#[from] diesel::result::Error),
+}
+
+// Now ? just works
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)?;
+    let config: Config = serde_json::from_str(&content)?;
+    save_to_db(&config)?;
+    Ok(config)
+}
+```
+
+## From with Context
+
+Sometimes you need to add context during conversion:
+
+```rust
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config from '{path}': {source}")]
+    ReadFailed {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+// Can't use #[from] when you need extra context
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|source| ConfigError::ReadFailed {
+            path: path.to_string(),
+            source,
+        })?;
+    // ...
+}
+
+// Or use anyhow for ad-hoc context
+use anyhow::{Context, Result};
+
+fn load_config(path: &str) -> Result<Config> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config from '{}'", path))?;
+    // ...
+}
+```
+
+## Blanket From Implementations
+
+Be careful with blanket implementations:
+
+```rust
+// ❌ Too broad - conflicts with other From impls
+impl<E: std::error::Error> From<E> for AppError {
+    fn from(err: E) -> Self {
+        AppError::Other(err.to_string())
+    }
+}
+
+// ✅ Specific implementations
+impl From<std::io::Error> for AppError { ... }
+impl From<ParseIntError> for AppError { ... }
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Using thiserror for libraries
+- [err-source-chain](./err-source-chain.md) - Preserving error chains
+- [err-question-mark](./err-question-mark.md) - The ? operator

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-lowercase-msg.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-lowercase-msg.md
@@ -1,0 +1,124 @@
+# err-lowercase-msg
+
+> Start error messages lowercase, no trailing punctuation
+
+## Why It Matters
+
+Error messages are often chained, logged, or displayed with additional context. Consistent formatting—lowercase start, no trailing period—allows clean composition: "failed to load config: invalid JSON: unexpected token". Mixed case and punctuation create awkward output: "Failed to load config.: Invalid JSON.: Unexpected token.".
+
+## Bad
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file.")]  // Capital F, trailing period
+    ReadFailed(#[from] std::io::Error),
+    
+    #[error("Invalid JSON format!")]  // Capital I, exclamation
+    ParseFailed(#[from] serde_json::Error),
+    
+    #[error("The requested key was not found")]  // Reads like a sentence
+    KeyNotFound(String),
+}
+
+// Chained output: "Config load error: Failed to read config file.: No such file"
+// Awkward capitalization and punctuation
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("failed to read config file")]  // lowercase, no period
+    ReadFailed(#[from] std::io::Error),
+    
+    #[error("invalid JSON format")]  // lowercase, no period
+    ParseFailed(#[from] serde_json::Error),
+    
+    #[error("key not found: {0}")]  // lowercase, data at end
+    KeyNotFound(String),
+}
+
+// Chained output: "config load error: failed to read config file: no such file"
+// Clean, consistent
+```
+
+## Rust Standard Library Convention
+
+The standard library follows this convention:
+
+```rust
+// std::io::Error messages
+"entity not found"
+"permission denied"
+"connection refused"
+
+// std::num::ParseIntError
+"invalid digit found in string"
+
+// std::str::Utf8Error  
+"invalid utf-8 sequence"
+```
+
+## Formatting Guidelines
+
+| Do | Don't |
+|----|-------|
+| `"failed to parse config"` | `"Failed to parse config."` |
+| `"invalid input: expected number"` | `"Invalid input - expected a number!"` |
+| `"connection timed out after {0}s"` | `"Connection Timed Out After {0} seconds."` |
+| `"key '{0}' not found"` | `"Key Not Found: {0}"` |
+
+## Context Addition Pattern
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let data = fetch(id)
+        .with_context(|| format!("failed to fetch user {}", id))?;
+    
+    parse_user(data)
+        .with_context(|| "failed to parse user data")?
+}
+
+// Output: "failed to fetch user 42: connection refused"
+// All lowercase, clean chain
+```
+
+## Display vs Debug
+
+```rust
+#[derive(Error, Debug)]
+#[error("invalid configuration")]  // Display: for users/logs
+pub struct ConfigError {
+    path: PathBuf,
+    source: io::Error,
+}
+
+// Debug output (for developers) can have more detail
+// Display output (for users) should be clean
+```
+
+## When to Use Capitals
+
+```rust
+// Proper nouns / acronyms keep their case
+#[error("invalid JSON syntax")]     // JSON is an acronym
+#[error("OAuth token expired")]     // OAuth is a proper noun
+#[error("HTTP request failed")]     // HTTP is an acronym
+
+// Error codes can be uppercase
+#[error("error code E0001: invalid input")]
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Error definition with thiserror
+- [err-context-chain](./err-context-chain.md) - Adding context to errors
+- [doc-examples-section](./doc-examples-section.md) - Documentation conventions

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-no-unwrap-prod.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-no-unwrap-prod.md
@@ -1,0 +1,115 @@
+# err-no-unwrap-prod
+
+> Avoid `unwrap()` in production code; use `?`, `expect()`, or handle errors
+
+## Why It Matters
+
+`unwrap()` panics on `None` or `Err` without any context about what went wrong. In production, this creates cryptic crash messages that are hard to debug. Either propagate errors with `?`, use `expect()` with a message explaining the invariant, or handle the error explicitly.
+
+## Bad
+
+```rust
+fn process_request(req: Request) -> Response {
+    let user_id = req.headers.get("X-User-Id").unwrap();  // Why did it fail?
+    let user = database.find_user(user_id).unwrap();       // Which operation?
+    let data = user.preferences.get("theme").unwrap();     // No context
+    
+    Response::new(data)
+}
+
+// Crash message: "called `Option::unwrap()` on a `None` value"
+// Where? Why? No idea.
+```
+
+## Good
+
+```rust
+// Option 1: Propagate with ?
+fn process_request(req: Request) -> Result<Response, AppError> {
+    let user_id = req.headers
+        .get("X-User-Id")
+        .ok_or(AppError::MissingHeader("X-User-Id"))?;
+    
+    let user = database.find_user(user_id)?;
+    
+    let data = user.preferences
+        .get("theme")
+        .ok_or(AppError::MissingPreference("theme"))?;
+    
+    Ok(Response::new(data))
+}
+
+// Option 2: expect() for invariants (not user input)
+fn get_config_value(&self, key: &str) -> &str {
+    self.config
+        .get(key)
+        .expect("BUG: required config key missing after validation")
+}
+
+// Option 3: Provide defaults
+fn get_theme(user: &User) -> &str {
+    user.preferences
+        .get("theme")
+        .unwrap_or(&"default")
+}
+
+// Option 4: Match for complex handling
+fn process_optional(value: Option<Data>) -> ProcessedData {
+    match value {
+        Some(data) => process(data),
+        None => {
+            log::warn!("No data provided, using fallback");
+            ProcessedData::default()
+        }
+    }
+}
+```
+
+## `expect()` vs `unwrap()`
+
+```rust
+// Bad: no context
+let port = config.get("port").unwrap();
+
+// Better: explains the invariant
+let port = config.get("port")
+    .expect("config must contain 'port' after validation");
+
+// Best: propagate if it's not truly an invariant
+let port = config.get("port")
+    .ok_or_else(|| ConfigError::MissingKey("port"))?;
+```
+
+## Alternatives to unwrap()
+
+| Situation | Use Instead |
+|-----------|-------------|
+| Can propagate error | `?` operator |
+| Has sensible default | `unwrap_or()`, `unwrap_or_default()` |
+| Default requires computation | `unwrap_or_else(\|\| ...)` |
+| Internal invariant | `expect("explanation")` |
+| Need to handle both cases | `match` or `if let` |
+
+## Clippy Lints
+
+```toml
+# Cargo.toml
+[lints.clippy]
+unwrap_used = "warn"      # Warn on unwrap()
+expect_used = "warn"       # Also warn on expect() (stricter)
+```
+
+```rust
+// Allow in specific places where it's justified
+#[allow(clippy::unwrap_used)]
+fn definitely_safe() {
+    // Unwrap is safe here because...
+    let x = Some(5).unwrap();
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Return Result instead of panicking
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When expect() is appropriate
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Patterns for avoiding unwrap

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-question-mark.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-question-mark.md
@@ -1,0 +1,151 @@
+# err-question-mark
+
+> Use `?` operator for clean propagation
+
+## Why It Matters
+
+The `?` operator is Rust's idiomatic way to propagate errors. It's concise, readable, and automatically converts between compatible error types using `From`. It replaces verbose `match` or `unwrap()` calls.
+
+## Bad
+
+```rust
+// Verbose match-based error handling
+fn load_config() -> Result<Config, Error> {
+    let content = match std::fs::read_to_string("config.toml") {
+        Ok(c) => c,
+        Err(e) => return Err(Error::Io(e)),
+    };
+    
+    let config = match toml::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => return Err(Error::Parse(e)),
+    };
+    
+    Ok(config)
+}
+
+// Or worse - using unwrap
+fn load_config_bad() -> Config {
+    let content = std::fs::read_to_string("config.toml").unwrap();
+    toml::from_str(&content).unwrap()
+}
+```
+
+## Good
+
+```rust
+fn load_config() -> Result<Config, Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    let config = toml::from_str(&content)?;
+    Ok(config)
+}
+
+// Even more concise
+fn load_config() -> Result<Config, Error> {
+    Ok(toml::from_str(&std::fs::read_to_string("config.toml")?)?)
+}
+```
+
+## How ? Works
+
+```rust
+// This:
+let x = expr?;
+
+// Expands roughly to:
+let x = match expr {
+    Ok(val) => val,
+    Err(err) => return Err(From::from(err)),
+};
+```
+
+## Combining with Context
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let path = format!("users/{}.json", id);
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read user file: {}", path))?;
+    
+    let user: User = serde_json::from_str(&content)
+        .context("failed to parse user JSON")?;
+    
+    Ok(user)
+}
+```
+
+## ? with Option
+
+```rust
+fn get_first_word(text: &str) -> Option<&str> {
+    let first_line = text.lines().next()?;
+    let first_word = first_line.split_whitespace().next()?;
+    Some(first_word)
+}
+
+// Convert Option to Result
+fn get_required_config(key: &str) -> Result<String, Error> {
+    config.get(key)
+        .cloned()
+        .ok_or_else(|| Error::MissingConfig(key.to_string()))
+}
+```
+
+## Error Type Conversion
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum MyError {
+    #[error("io error")]
+    Io(#[from] std::io::Error),  // Auto From impl
+    
+    #[error("parse error")]
+    Parse(#[from] serde_json::Error),  // Auto From impl
+}
+
+fn process() -> Result<(), MyError> {
+    // ? automatically converts io::Error to MyError via From
+    let content = std::fs::read_to_string("file.txt")?;
+    
+    // ? automatically converts serde_json::Error to MyError
+    let data: Data = serde_json::from_str(&content)?;
+    
+    Ok(())
+}
+```
+
+## In main()
+
+```rust
+// Option 1: Return Result from main
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+
+// Option 2: Handle in main, exit on error
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+```
+
+## See Also
+
+- [err-context-chain](err-context-chain.md) - Add context with .context()
+- [err-from-impl](err-from-impl.md) - Use #[from] for automatic conversion
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-result-over-panic.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-result-over-panic.md
@@ -1,0 +1,130 @@
+# err-result-over-panic
+
+> Return `Result<T, E>` instead of panicking for recoverable errors
+
+## Why It Matters
+
+Panics unwind the stack and crash the thread (or program). They're unrecoverable from the caller's perspective. `Result<T, E>` gives callers the ability to decide how to handle errors—retry, fallback, propagate, or log. Libraries should almost never panic; applications should minimize panics to truly unrecoverable situations.
+
+## Bad
+
+```rust
+fn parse_config(path: &str) -> Config {
+    let content = std::fs::read_to_string(path)
+        .expect("Failed to read config");  // Crashes on missing file
+    
+    serde_json::from_str(&content)
+        .expect("Invalid config format")   // Crashes on bad JSON
+}
+
+fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 {
+        panic!("Division by zero!");  // Crashes the program
+    }
+    a / b
+}
+```
+
+Caller has no chance to recover or provide a fallback.
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Invalid config format: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+fn parse_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    let config = serde_json::from_str(&content)?;
+    Ok(config)
+}
+
+fn divide(a: i32, b: i32) -> Result<i32, &'static str> {
+    if b == 0 {
+        return Err("Division by zero");
+    }
+    Ok(a / b)
+}
+
+// Caller decides how to handle
+match parse_config("app.json") {
+    Ok(config) => run_app(config),
+    Err(e) => {
+        eprintln!("Using default config: {}", e);
+        run_app(Config::default())
+    }
+}
+```
+
+## When Panic IS Appropriate
+
+```rust
+// 1. Bug in the program (invariant violation)
+fn get_cached_value(&self, key: &str) -> &Value {
+    self.cache.get(key).expect("BUG: key was verified to exist")
+}
+
+// 2. Setup/initialization that can't reasonably fail
+fn main() {
+    let config = Config::load().expect("Failed to load required config");
+    // Can't run without config, panic is reasonable
+}
+
+// 3. Tests
+#[test]
+fn test_parse() {
+    let result = parse("valid input").unwrap(); // unwrap OK in tests
+    assert_eq!(result, expected);
+}
+
+// 4. Examples and prototypes
+fn main() {
+    // Quick prototype, panic is fine
+    let data = fetch_data().unwrap();
+}
+```
+
+## Panic vs Result Decision Guide
+
+| Situation | Use |
+|-----------|-----|
+| File not found | `Result` |
+| Network error | `Result` |
+| Invalid user input | `Result` |
+| Parse error | `Result` |
+| Index out of bounds (from user data) | `Result` |
+| Index out of bounds (internal bug) | Panic |
+| Violated internal invariant | Panic |
+| Unimplemented code path | Panic (`unimplemented!()`) |
+| Impossible state reached | Panic (`unreachable!()`) |
+
+## Library vs Application
+
+```rust
+// Library: NEVER panic on user input
+pub fn parse(input: &str) -> Result<Ast, ParseError> {
+    // Always return Result
+}
+
+// Application: Can panic at top level for critical failures
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Fatal error: {}", e);
+        std::process::exit(1);
+    }
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Define error types for libraries
+- [err-anyhow-app](./err-anyhow-app.md) - Ergonomic errors for applications
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoid unwrap in production code
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - When unwrap is acceptable

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-source-chain.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-source-chain.md
@@ -1,0 +1,155 @@
+# err-source-chain
+
+> Preserve error chains with `#[source]` or `source()` method
+
+## Why It Matters
+
+Errors often have underlying causes. Preserving the error chain (via `source()` method) allows logging frameworks and error reporters to show the full context: "config parse failed → JSON syntax error at line 5 → unexpected token". Without chaining, you lose valuable debugging information.
+
+## Bad
+
+```rust
+#[derive(Debug)]
+enum ConfigError {
+    ParseFailed(String),  // Lost the original serde_json::Error
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| ConfigError::ParseFailed(e.to_string()))?;  // Chain lost!
+    
+    serde_json::from_str(&content)
+        .map_err(|e| ConfigError::ParseFailed(e.to_string()))?  // No source
+}
+
+// Error output: "Parse failed: invalid type: ..."
+// Missing: which file? what line? what was the parent error?
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file '{path}'")]
+    ReadFailed {
+        path: String,
+        #[source]  // Preserves the error chain
+        source: std::io::Error,
+    },
+    
+    #[error("Failed to parse config file '{path}'")]
+    ParseFailed {
+        path: String,
+        #[source]  // Original parse error preserved
+        source: serde_json::Error,
+    },
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|source| ConfigError::ReadFailed {
+            path: path.to_string(),
+            source,  // Chain preserved
+        })?;
+    
+    serde_json::from_str(&content)
+        .map_err(|source| ConfigError::ParseFailed {
+            path: path.to_string(),
+            source,
+        })
+}
+```
+
+## Manual source() Implementation
+
+```rust
+use std::error::Error;
+
+#[derive(Debug)]
+struct MyError {
+    message: String,
+    source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for MyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as &(dyn Error + 'static))
+    }
+}
+```
+
+## Walking the Error Chain
+
+```rust
+fn print_error_chain(error: &dyn std::error::Error) {
+    eprintln!("Error: {}", error);
+    
+    let mut source = error.source();
+    while let Some(err) = source {
+        eprintln!("Caused by: {}", err);
+        source = err.source();
+    }
+}
+
+// With anyhow, use {:?} for full chain
+let result: anyhow::Result<()> = do_something();
+if let Err(e) = result {
+    eprintln!("{:?}", e);  // Prints full chain with backtraces
+}
+```
+
+## anyhow Context
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_config(path: &str) -> Result<Config> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read '{}'", path))?;
+    
+    let config: Config = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse '{}'", path))?;
+    
+    Ok(config)
+}
+
+// Output:
+// Error: Failed to parse 'config.json'
+// Caused by: expected `:` at line 5 column 10
+```
+
+## #[from] vs #[source]
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum MyError {
+    // #[from] = implements From + sets source
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+    
+    // #[source] = only sets source (no From impl)
+    #[error("Parse error in file '{path}'")]
+    Parse {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - thiserror for error definitions
+- [err-context-chain](./err-context-chain.md) - Adding context to errors
+- [err-from-impl](./err-from-impl.md) - From implementations for ?

--- a/.cursor/skills/rust-skills-leonardomso/rules/err-thiserror-lib.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/err-thiserror-lib.md
@@ -1,0 +1,171 @@
+# err-thiserror-lib
+
+> Use `thiserror` for library error types
+
+## Why It Matters
+
+Libraries should expose typed, matchable errors so users can handle specific error conditions. `thiserror` generates `Error` trait implementations with minimal boilerplate, creating ergonomic error types that are easy to match against.
+
+## Bad
+
+```rust
+// String errors - not matchable
+fn parse(input: &str) -> Result<Data, String> {
+    Err("parse error".to_string())
+}
+
+// Box<dyn Error> - not matchable
+fn load(path: &Path) -> Result<Data, Box<dyn std::error::Error>> {
+    Err(Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "file not found")))
+}
+
+// Manual implementation - verbose
+#[derive(Debug)]
+enum MyError {
+    Io(std::io::Error),
+    Parse(String),
+}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MyError::Io(e) => write!(f, "io error: {}", e),
+            MyError::Parse(s) => write!(f, "parse error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for MyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            MyError::Io(e) => Some(e),
+            MyError::Parse(_) => None,
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("invalid syntax at line {line}: {message}")]
+    Syntax { line: usize, message: String },
+    
+    #[error("unexpected end of file")]
+    UnexpectedEof,
+    
+    #[error("invalid utf-8 encoding")]
+    Utf8(#[from] std::str::Utf8Error),
+    
+    #[error("io error reading input")]
+    Io(#[from] std::io::Error),
+}
+
+// Usage
+fn parse(input: &str) -> Result<Ast, ParseError> {
+    if input.is_empty() {
+        return Err(ParseError::UnexpectedEof);
+    }
+    // ...
+}
+
+// Users can match specific errors
+match parse(input) {
+    Ok(ast) => process(ast),
+    Err(ParseError::Syntax { line, message }) => {
+        eprintln!("Syntax error on line {}: {}", line, message);
+    }
+    Err(ParseError::UnexpectedEof) => {
+        eprintln!("File ended unexpectedly");
+    }
+    Err(e) => eprintln!("Error: {}", e),
+}
+```
+
+## Key Attributes
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MyError {
+    // Simple message
+    #[error("operation failed")]
+    Failed,
+    
+    // Interpolated fields
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
+    
+    // Named fields
+    #[error("connection to {host}:{port} failed")]
+    Connection { host: String, port: u16 },
+    
+    // Automatic From impl with #[from]
+    #[error("database error")]
+    Database(#[from] sqlx::Error),
+    
+    // Source without From (manual conversion needed)
+    #[error("validation failed")]
+    Validation {
+        #[source]
+        cause: ValidationError,
+        field: String,
+    },
+    
+    // Transparent - delegates Display and source to inner
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+```
+
+## Error Chaining
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("failed to read config file")]
+    Read(#[source] std::io::Error),
+    
+    #[error("failed to parse config")]
+    Parse(#[source] toml::de::Error),
+    
+    #[error("invalid config value for '{key}'")]
+    InvalidValue {
+        key: String,
+        #[source]
+        cause: ValueError,
+    },
+}
+
+// Error chain is preserved
+fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(ConfigError::Read)?;
+    
+    let config: Config = toml::from_str(&content)
+        .map_err(ConfigError::Parse)?;
+    
+    Ok(config)
+}
+```
+
+## Library vs Application
+
+| Context | Crate | Why |
+|---------|-------|-----|
+| Library | `thiserror` | Typed errors users can match |
+| Application | `anyhow` | Easy error handling with context |
+| Both | `thiserror` for public API, `anyhow` internally | Best of both |
+
+## See Also
+
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications
+- [err-from-impl](err-from-impl.md) - Use #[from] for automatic conversion
+- [err-source-chain](err-source-chain.md) - Use #[source] to chain errors

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-cargo-metadata.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-cargo-metadata.md
@@ -1,0 +1,138 @@
+# lint-cargo-metadata
+
+> Enable clippy::cargo for published crates
+
+## Why It Matters
+
+The `clippy::cargo` lint group checks Cargo.toml for issues that affect publishing and dependency management. For crates intended for crates.io, these checks help ensure a professional, well-configured package.
+
+## Configuration
+
+```toml
+# Cargo.toml
+[lints.clippy]
+cargo = "warn"
+```
+
+Or in code:
+
+```rust
+#![warn(clippy::cargo)]
+```
+
+## What It Catches
+
+### Missing Metadata
+
+```toml
+# WARN: missing package.description
+# WARN: missing package.license or package.license-file
+# WARN: missing package.repository
+[package]
+name = "my-crate"
+version = "0.1.0"
+```
+
+### Dependency Issues
+
+```toml
+# WARN: feature used but not defined
+# WARN: dependency version not specified
+[dependencies]
+serde = "*"  # Bad: any version
+tokio = { git = "..." }  # WARN for published crates
+```
+
+### Feature Issues
+
+```toml
+# WARN: negative_feature_names
+[features]
+no-std = []  # Should be: std = [] (opt-out vs opt-in)
+
+# WARN: redundant_feature_names
+[features]
+default = ["feature-a"]
+feature-a = []  # Feature name matches crate name
+```
+
+## Notable Lints
+
+| Lint | Issue |
+|------|-------|
+| `cargo_common_metadata` | Missing description/license/repository |
+| `multiple_crate_versions` | Same crate at different versions |
+| `negative_feature_names` | Features like `no-std` instead of `std` |
+| `redundant_feature_names` | Feature same as crate name |
+| `wildcard_dependencies` | Using `*` for version |
+
+## Complete Cargo.toml
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+# Required for cargo lint satisfaction
+description = "A short description of what this crate does"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/user/my-crate"
+
+# Recommended
+documentation = "https://docs.rs/my-crate"
+readme = "README.md"
+keywords = ["keyword1", "keyword2"]
+categories = ["category-slug"]
+
+[dependencies]
+# Specific versions, not wildcards
+serde = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+
+[features]
+default = ["std"]
+std = []  # Opt-out, not no-std opt-in
+
+[lints.clippy]
+cargo = "warn"
+```
+
+## Multiple Crate Versions
+
+```
+# WARN: multiple versions of `syn` in dependency tree
+# syn v1.0.109
+# syn v2.0.48
+```
+
+Fix by updating dependencies or using `[patch]`:
+
+```toml
+[patch.crates-io]
+old-dep = { git = "...", branch = "syn-2" }
+```
+
+## When to Disable
+
+For internal/unpublished crates:
+
+```toml
+[lints.clippy]
+cargo = "allow"  # Not publishing, metadata not needed
+```
+
+Or selectively:
+
+```toml
+[lints.clippy]
+cargo = "warn"
+multiple_crate_versions = "allow"  # Acceptable in this project
+```
+
+## See Also
+
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Cargo.toml metadata
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace dependencies
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-deny-correctness.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-deny-correctness.md
@@ -1,0 +1,107 @@
+# lint-deny-correctness
+
+> `#![deny(clippy::correctness)]`
+
+## Why It Matters
+
+Clippy's correctness lints catch code that is outright wrong - logic errors, undefined behavior, or code that doesn't do what you think. These should always be errors, not warnings.
+
+## Setup
+
+```rust
+// At the top of lib.rs or main.rs
+#![deny(clippy::correctness)]
+
+// Or in Cargo.toml for workspace-wide
+[lints.clippy]
+correctness = "deny"
+```
+
+## What It Catches
+
+```rust
+// Infinite loop (iter::repeat without take)
+for x in std::iter::repeat(1) {  // ERROR: infinite iterator
+    println!("{}", x);
+}
+
+// Comparison to NaN (always false)
+if x == f64::NAN {  // ERROR: NaN != NaN always
+    // This never executes
+}
+
+// Use after free patterns
+let r;
+{
+    let x = 5;
+    r = &x;  // ERROR: x dropped here
+}
+println!("{}", r);
+
+// Wrong equality check
+if x = 5 {  // ERROR: assignment in condition (should be ==)
+}
+
+// Useless comparisons
+if x >= 0 && x < 0 {  // ERROR: impossible condition
+}
+```
+
+## Important Correctness Lints
+
+```rust
+// approx_constant - using imprecise PI, E values
+let pi = 3.14;  // Use std::f64::consts::PI
+
+// invalid_regex - regex that won't compile
+let re = Regex::new("[");  // Invalid regex
+
+// iter_next_loop - using .next() in for loop incorrectly
+for x in iter.next() {  // Should be: for x in iter
+
+// never_loop - loop that never actually loops
+loop {
+    break;  // Always breaks immediately
+}
+
+// nonsensical_open_options - impossible file options
+File::options().read(false).write(false).open("f");
+
+// unit_cmp - comparing unit type ()
+if foo() == bar() { }  // Both return (), always true
+```
+
+## Full Recommended Lints
+
+```rust
+#![deny(clippy::correctness)]
+#![warn(clippy::suspicious)]
+#![warn(clippy::style)]
+#![warn(clippy::complexity)]
+#![warn(clippy::perf)]
+
+// For published crates
+#![warn(missing_docs)]
+#![warn(clippy::cargo)]
+```
+
+## Running Clippy
+
+```bash
+# Basic check
+cargo clippy
+
+# With all warnings as errors
+cargo clippy -- -D warnings
+
+# Check specific lint category
+cargo clippy -- -W clippy::correctness
+
+# In CI (fail on warnings)
+cargo clippy -- -D warnings -D clippy::correctness
+```
+
+## See Also
+
+- [lint-warn-suspicious](lint-warn-suspicious.md) - Warn on suspicious code
+- [lint-warn-perf](lint-warn-perf.md) - Warn on performance issues

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-missing-docs.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-missing-docs.md
@@ -1,0 +1,154 @@
+# lint-missing-docs
+
+> Warn on missing documentation for public items
+
+## Why It Matters
+
+The `missing_docs` lint ensures all public API items are documented. For libraries, documentation IS the user interface. Missing docs mean users can't understand your API without reading source code.
+
+## Configuration
+
+```rust
+// In lib.rs
+#![warn(missing_docs)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.rust]
+missing_docs = "warn"
+```
+
+For strict enforcement:
+
+```rust
+#![deny(missing_docs)]
+```
+
+## What It Catches
+
+```rust
+#![warn(missing_docs)]
+
+pub struct User {  // WARN: missing documentation for a struct
+    pub name: String,  // WARN: missing documentation for a field
+    pub age: u32,      // WARN: missing documentation for a field
+}
+
+pub fn process() { }  // WARN: missing documentation for a function
+
+pub trait Handler {  // WARN: missing documentation for a trait
+    fn handle(&self);  // WARN: missing documentation for a method
+}
+```
+
+## Good
+
+```rust
+#![warn(missing_docs)]
+
+//! User management module.
+
+/// Represents a registered user in the system.
+pub struct User {
+    /// The user's display name.
+    pub name: String,
+    /// The user's age in years.
+    pub age: u32,
+}
+
+/// Processes pending user requests.
+///
+/// # Examples
+///
+/// ```
+/// process();
+/// ```
+pub fn process() { }
+
+/// Handler trait for request processing.
+pub trait Handler {
+    /// Handle an incoming request.
+    fn handle(&self);
+}
+```
+
+## Private Items
+
+`missing_docs` only applies to `pub` items. Private items don't trigger warnings:
+
+```rust
+#![warn(missing_docs)]
+
+struct Internal { }  // No warning - private
+
+pub struct Public { }  // WARN - public, needs docs
+```
+
+## Allow for Specific Items
+
+```rust
+#![warn(missing_docs)]
+
+/// Documented module.
+pub mod api {
+    /// Documented struct.
+    pub struct Config { }
+    
+    #[allow(missing_docs)]
+    pub mod internal {
+        // Internal API, docs not required
+        pub struct Helper { }
+    }
+}
+```
+
+## Gradual Adoption
+
+For existing codebases, start with `warn` and fix incrementally:
+
+```rust
+// Phase 1: Warn, fix critical items
+#![warn(missing_docs)]
+
+// Phase 2: After cleanup, deny
+#![deny(missing_docs)]
+```
+
+## Combining with doc Attributes
+
+```rust
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::private_intra_doc_links)]
+```
+
+## Workspace Configuration
+
+```toml
+# In workspace Cargo.toml
+[workspace.lints.rust]
+missing_docs = "warn"
+
+# Member crates inherit
+[lints]
+workspace = true
+```
+
+## What to Document
+
+| Item | Doc Focus |
+|------|-----------|
+| Structs | Purpose, usage example |
+| Struct fields | What it represents |
+| Enums | When to use each variant |
+| Functions | What it does, params, return |
+| Traits | Contract and expectations |
+| Modules | What the module provides |
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documentation patterns
+- [lint-unsafe-doc](./lint-unsafe-doc.md) - Unsafe documentation
+- [doc-examples-section](./doc-examples-section.md) - Adding examples

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-pedantic-selective.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-pedantic-selective.md
@@ -1,0 +1,118 @@
+# lint-pedantic-selective
+
+> Enable clippy::pedantic selectively
+
+## Why It Matters
+
+The `clippy::pedantic` group contains opinionated lints that aren't universally applicable. Enabling it wholesale produces noise; selectively enabling useful pedantic lints improves code quality without false positives.
+
+## Bad
+
+```rust
+// Too noisy - will fight you constantly
+#![warn(clippy::pedantic)]
+```
+
+## Good
+
+```toml
+# Cargo.toml - cherry-pick useful pedantic lints
+[lints.clippy]
+# Enable pedantic as baseline
+pedantic = "warn"
+
+# Disable noisy ones
+missing_errors_doc = "allow"      # Document errors separately
+missing_panics_doc = "allow"      # Document panics separately
+module_name_repetitions = "allow" # Allow Foo::FooError pattern
+too_many_lines = "allow"          # Function length varies
+must_use_candidate = "allow"      # Too many suggestions
+```
+
+## Recommended Pedantic Lints
+
+| Lint | Why Enable |
+|------|-----------|
+| `doc_markdown` | Catch unmarked code in docs |
+| `match_wildcard_for_single_variants` | Explicit variant matching |
+| `semicolon_if_nothing_returned` | Consistent semicolons |
+| `string_add_assign` | Use `+=` for string concatenation |
+| `unnested_or_patterns` | Simplify match patterns |
+| `unused_self` | Catch methods that should be functions |
+| `used_underscore_binding` | Warn on using `_var` |
+| `wildcard_imports` | Avoid glob imports |
+
+## Often Disabled
+
+| Lint | Why Disable |
+|------|-------------|
+| `missing_errors_doc` | Handle with `#[doc]` policy |
+| `missing_panics_doc` | Handle with `#[doc]` policy |
+| `module_name_repetitions` | Sometimes intentional |
+| `must_use_candidate` | Too aggressive |
+| `too_many_lines` | Arbitrary threshold |
+| `struct_excessive_bools` | Valid for config structs |
+
+## Full Configuration
+
+```toml
+# Cargo.toml
+[lints.clippy]
+# Start with pedantic
+pedantic = "warn"
+
+# Keep these
+doc_markdown = "warn"
+match_wildcard_for_single_variants = "warn"
+semicolon_if_nothing_returned = "warn"
+unused_self = "warn"
+wildcard_imports = "warn"
+
+# Disable these
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+too_many_lines = "allow"
+similar_names = "allow"
+struct_excessive_bools = "allow"
+```
+
+## Alternative: Explicit Opt-in
+
+```toml
+# Only enable specific lints, not the group
+[lints.clippy]
+# From pedantic, only these:
+doc_markdown = "warn"
+semicolon_if_nothing_returned = "warn"
+unused_self = "warn"
+wildcard_imports = "warn"
+```
+
+## Module-Level Overrides
+
+```rust
+// Allow specific lint for a module
+#![allow(clippy::module_name_repetitions)]
+
+// Or for specific items
+#[allow(clippy::too_many_arguments)]
+fn complex_function(/* many args */) { }
+```
+
+## Team Consensus
+
+Pedantic lints are style choices. Agree as a team:
+
+1. Enable `pedantic` as baseline
+2. Run `cargo clippy` on codebase
+3. Discuss each warning category
+4. Disable ones that don't fit your style
+5. Document decisions in `clippy.toml`
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-rustfmt-check.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-rustfmt-check.md
@@ -1,0 +1,157 @@
+# lint-rustfmt-check
+
+> Run cargo fmt --check in CI
+
+## Why It Matters
+
+Consistent formatting eliminates style debates and makes diffs cleaner. Running `cargo fmt --check` in CI ensures all code follows the same format. This catches formatting issues before merge, not after.
+
+## CI Configuration
+
+### GitHub Actions
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+```
+
+### GitLab CI
+
+```yaml
+fmt:
+  image: rust:latest
+  script:
+    - rustup component add rustfmt
+    - cargo fmt --all --check
+```
+
+### Pre-commit Hook
+
+```bash
+#!/bin/sh
+# .git/hooks/pre-commit
+cargo fmt --all --check
+```
+
+## Configuration
+
+Create `rustfmt.toml` for custom settings:
+
+```toml
+# rustfmt.toml
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Max"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+```
+
+## Common Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_width` | 100 | Maximum line width |
+| `tab_spaces` | 4 | Spaces per indent |
+| `edition` | "2015" | Rust edition |
+| `use_small_heuristics` | "Default" | Layout heuristics |
+| `imports_granularity` | "Preserve" | Import grouping |
+| `group_imports` | "Preserve" | Import ordering |
+
+## Running Locally
+
+```bash
+# Check formatting (doesn't modify files)
+cargo fmt --all --check
+
+# Apply formatting
+cargo fmt --all
+
+# Format specific file
+cargo fmt -- src/main.rs
+
+# Check with verbose output
+cargo fmt --all --check -- --verbose
+```
+
+## Workspace Formatting
+
+```bash
+# Format all workspace members
+cargo fmt --all
+
+# Format specific package
+cargo fmt -p my-package
+```
+
+## Ignoring Files
+
+In `rustfmt.toml`:
+
+```toml
+# Skip generated files
+ignore = [
+    "src/generated/*",
+    "build.rs",
+]
+```
+
+Or in code:
+
+```rust
+#[rustfmt::skip]
+mod generated_code;
+
+#[rustfmt::skip]
+const MATRIX: [[i32; 4]; 4] = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+];
+```
+
+## Nightly Features
+
+Some options require nightly:
+
+```toml
+# rustfmt.toml (nightly only)
+unstable_features = true
+imports_granularity = "Crate"
+wrap_comments = true
+format_code_in_doc_comments = true
+```
+
+```bash
+# Use nightly rustfmt
+cargo +nightly fmt
+```
+
+## IDE Integration
+
+Most IDEs format on save. Configure to use project `rustfmt.toml`:
+
+```json
+// VS Code settings.json
+{
+  "rust-analyzer.rustfmt.extraArgs": ["--config-path", "./rustfmt.toml"]
+}
+```
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style lints
+- [lint-pedantic-selective](./lint-pedantic-selective.md) - Pedantic lints
+- [name-funcs-snake](./name-funcs-snake.md) - Naming conventions

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-unsafe-doc.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-unsafe-doc.md
@@ -1,0 +1,133 @@
+# lint-unsafe-doc
+
+> Require documentation for unsafe blocks
+
+## Why It Matters
+
+The `undocumented_unsafe_blocks` lint ensures every unsafe block has a `// SAFETY:` comment explaining why the operation is sound. Unsafe code is the source of most memory safety bugs—documenting invariants catches mistakes and helps reviewers.
+
+## Configuration
+
+```rust
+#![warn(clippy::undocumented_unsafe_blocks)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"
+```
+
+For strict enforcement:
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+```
+
+## Bad
+
+```rust
+pub fn read_data(ptr: *const u8, len: usize) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(ptr, len)  // WARN: undocumented
+    }
+}
+
+impl Buffer {
+    pub fn get_unchecked(&self, index: usize) -> &u8 {
+        unsafe { self.data.get_unchecked(index) }  // WARN
+    }
+}
+```
+
+## Good
+
+```rust
+pub fn read_data(ptr: *const u8, len: usize) -> &[u8] {
+    // SAFETY: Caller guarantees:
+    // - ptr is valid for reads of len bytes
+    // - ptr is properly aligned for u8
+    // - the memory is initialized
+    // - no mutable references exist to this memory
+    unsafe {
+        std::slice::from_raw_parts(ptr, len)
+    }
+}
+
+impl Buffer {
+    pub fn get_unchecked(&self, index: usize) -> &u8 {
+        debug_assert!(index < self.len(), "index out of bounds");
+        // SAFETY: We verified index < len in debug builds.
+        // Callers must ensure index is within bounds.
+        unsafe { self.data.get_unchecked(index) }
+    }
+}
+```
+
+## SAFETY Comment Format
+
+```rust
+// SAFETY: <explanation of why this is sound>
+unsafe {
+    // ...
+}
+```
+
+The comment should explain:
+1. **What invariants are upheld** - preconditions that make this safe
+2. **Why the invariants hold** - how you know they're satisfied
+3. **What could go wrong** - if invariants are violated
+
+## Examples by Category
+
+### Pointer Operations
+
+```rust
+// SAFETY: ptr was obtained from Box::into_raw, so it's valid
+// and properly aligned. We're taking back ownership.
+let boxed = unsafe { Box::from_raw(ptr) };
+```
+
+### Unchecked Operations
+
+```rust
+// SAFETY: We just checked that i < self.len() above.
+// The bounds check cannot be elided by the optimizer
+// because len() is not inlined.
+unsafe { self.data.get_unchecked(i) }
+```
+
+### FFI Calls
+
+```rust
+// SAFETY: libc::getenv is safe to call with a null-terminated
+// string. We ensure null termination with CString::new.
+// The returned pointer is valid for the lifetime of the environment.
+let value = unsafe { libc::getenv(key.as_ptr()) };
+```
+
+### Trait Implementations
+
+```rust
+// SAFETY: MyType contains no pointers or interior mutability,
+// and all bit patterns are valid MyType values.
+unsafe impl Send for MyType {}
+unsafe impl Sync for MyType {}
+```
+
+## Related Lints
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"
+# Also consider:
+multiple_unsafe_ops_per_block = "warn"  # One operation per block
+```
+
+## See Also
+
+- [doc-safety-section](./doc-safety-section.md) - `# Safety` in docs
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints
+- [type-repr-transparent](./type-repr-transparent.md) - FFI safety

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-complexity.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-complexity.md
@@ -1,0 +1,131 @@
+# lint-warn-complexity
+
+> Enable clippy::complexity for simpler code
+
+## Why It Matters
+
+The `clippy::complexity` lint group identifies unnecessarily complex code that can be simplified. Complex code is harder to read, maintain, and often hides bugs. Clippy suggests cleaner alternatives.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::complexity)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+complexity = "warn"
+```
+
+## What It Catches
+
+### Unnecessary Complexity
+
+```rust
+// WARN: Overly complex boolean expression
+if !(x == 0) { }  // Use: if x != 0 { }
+
+// WARN: Manual implementation of Option::map
+match option {
+    Some(x) => Some(x + 1),
+    None => None,
+}  // Use: option.map(|x| x + 1)
+
+// WARN: Unnecessary filter before count
+iter.filter(|x| predicate(x)).count()  // Could simplify if only counting
+```
+
+### Redundant Operations
+
+```rust
+// WARN: Redundant allocation
+let s = format!("literal");  // Use: "literal".to_string() or just "literal"
+
+// WARN: Unnecessarily complicated match
+match result {
+    Ok(ok) => Ok(ok),
+    Err(err) => Err(err),
+}  // Just use: result
+
+// WARN: Box::new in return position
+fn make_error() -> Box<dyn Error> {
+    Box::new(MyError)  // Could use: MyError.into()
+}
+```
+
+### Overly Verbose Code
+
+```rust
+// WARN: bind_instead_of_map
+option.and_then(|x| Some(x + 1))  // Use: option.map(|x| x + 1)
+
+// WARN: clone_on_copy
+let y = x.clone();  // Where x is Copy type, just use: let y = x;
+
+// WARN: useless_let_if_seq
+let result;
+if condition {
+    result = 1;
+} else {
+    result = 2;
+}
+// Use: let result = if condition { 1 } else { 2 };
+```
+
+## Notable Lints in This Group
+
+| Lint | Simplification |
+|------|---------------|
+| `bind_instead_of_map` | Use `map` instead of `and_then(Some(...))` |
+| `bool_comparison` | `if x == true` → `if x` |
+| `clone_on_copy` | Remove `.clone()` for Copy types |
+| `filter_next` | Use `.find()` instead |
+| `option_map_unit_fn` | Use `if let` instead |
+| `search_is_some` | Use `.any()` or `.contains()` |
+| `unnecessary_cast` | Remove redundant casts |
+| `useless_conversion` | Remove `.into()` when types match |
+
+## Examples
+
+```rust
+// Before (complexity warnings)
+fn find_positive(nums: &[i32]) -> Option<i32> {
+    let filtered: Vec<_> = nums.iter()
+        .cloned()
+        .filter(|x| *x > 0)
+        .collect();
+    if filtered.len() == 0 {
+        None
+    } else {
+        Some(filtered[0])
+    }
+}
+
+// After (simplified)
+fn find_positive(nums: &[i32]) -> Option<i32> {
+    nums.iter()
+        .copied()
+        .find(|&x| x > 0)
+}
+```
+
+## Cognitive Load
+
+Complex code isn't just longer—it's harder to understand:
+
+```rust
+// High cognitive load
+let value = if x.is_some() { x.unwrap() } else { y.unwrap_or(z) };
+
+// Lower cognitive load
+let value = x.unwrap_or_else(|| y.unwrap_or(z));
+```
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-perf](./lint-warn-perf.md) - Performance warnings
+- [lint-pedantic-selective](./lint-pedantic-selective.md) - Pedantic lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-perf.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-perf.md
@@ -1,0 +1,136 @@
+# lint-warn-perf
+
+> Enable clippy::perf for performance improvements
+
+## Why It Matters
+
+The `clippy::perf` lint group catches performance anti-patterns—inefficient allocations, unnecessary copies, suboptimal API usage. While not all performance issues are critical, avoiding obvious inefficiencies is good practice.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::perf)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+perf = "warn"
+```
+
+## What It Catches
+
+### Unnecessary Allocations
+
+```rust
+// WARN: Unnecessary to_string before into
+fn take_string(s: impl Into<String>) { }
+take_string("hello".to_string());  // Just use: "hello"
+
+// WARN: Box::new in return with deref coercion
+fn make_trait() -> Box<dyn Trait> {
+    Box::new(concrete)  // Could use Into
+}
+
+// WARN: Unnecessary vec! for iteration
+for x in vec![1, 2, 3] { }  // Use array: [1, 2, 3]
+```
+
+### Inefficient Operations
+
+```rust
+// WARN: Single-character string patterns
+s.starts_with("x")  // Use char: 'x'
+s.contains("a")     // Use char: 'a'
+
+// WARN: iter().nth(0) instead of first()
+iter.nth(0)  // Use: iter.first() or iter.next()
+
+// WARN: Manual saturating arithmetic
+if x > i32::MAX - y { i32::MAX } else { x + y }
+// Use: x.saturating_add(y)
+```
+
+### Collection Inefficiencies
+
+```rust
+// WARN: extend with a single element
+vec.extend(std::iter::once(item));  // Use: vec.push(item)
+
+// WARN: Inefficient to_vec
+slice.iter().cloned().collect::<Vec<_>>()  // Use: slice.to_vec()
+
+// WARN: Manual string concatenation
+let s = format!("{}{}", a, b);  // When both are &str, use: a.to_owned() + b
+```
+
+## Notable Lints in This Group
+
+| Lint | Improvement |
+|------|-------------|
+| `box_collection` | Use `Vec<T>` not `Box<Vec<T>>` |
+| `iter_nth` | Use `.get(n)` or `.next()` |
+| `large_enum_variant` | Box large variants |
+| `manual_memcpy` | Use slice copy methods |
+| `redundant_allocation` | Remove double boxing |
+| `single_char_pattern` | Use `char` not `&str` |
+| `slow_vector_initialization` | Use `vec![0; n]` |
+| `unnecessary_to_owned` | Remove redundant `.to_owned()` |
+
+## Examples
+
+```rust
+// Before (perf warnings)
+fn process(input: &str) -> String {
+    let parts: Vec<_> = input.split(",").collect();
+    let mut result = String::new();
+    for part in parts.iter() {
+        if part.starts_with(" ") {
+            result = result + &part.trim().to_string();
+        }
+    }
+    result
+}
+
+// After (optimized)
+fn process(input: &str) -> String {
+    input.split(',')
+        .filter(|part| part.starts_with(' '))
+        .map(str::trim)
+        .collect()
+}
+```
+
+## Allocation Patterns
+
+```rust
+// Unnecessary allocation
+let vec: Vec<i32> = vec![];  // Creates capacity
+let vec: Vec<i32> = Vec::new();  // No allocation
+
+// Pre-allocation
+let mut vec = Vec::with_capacity(100);  // One allocation
+for i in 0..100 {
+    vec.push(i);  // No reallocation
+}
+```
+
+## String Patterns
+
+```rust
+// Slow: str pattern
+s.contains("x");
+s.find("y");
+
+// Fast: char pattern
+s.contains('x');
+s.find('y');
+```
+
+## See Also
+
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimizing

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-style.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-style.md
@@ -1,0 +1,135 @@
+# lint-warn-style
+
+> Enable clippy::style for idiomatic code
+
+## Why It Matters
+
+The `clippy::style` lint group enforces idiomatic Rust patterns. While not bugs, style violations make code harder to read and maintain. Consistent style helps teams work together and makes code easier to review.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::style)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+style = "warn"
+```
+
+## What It Catches
+
+### Redundant Code
+
+```rust
+// WARN: Redundant clone on Copy type
+let x = 5;
+let y = x.clone();  // Just use: let y = x;
+
+// WARN: Redundant closure
+iter.map(|x| foo(x))  // Just use: iter.map(foo)
+
+// WARN: Redundant pattern matching
+match result {
+    Ok(x) => Ok(x),
+    Err(e) => Err(e),
+}  // Just return result
+```
+
+### Non-Idiomatic Patterns
+
+```rust
+// WARN: Should use if let
+match option {
+    Some(x) => do_something(x),
+    None => {},
+}
+// Better: if let Some(x) = option { do_something(x) }
+
+// WARN: Should use or_else
+let value = if option.is_some() {
+    option.unwrap()
+} else {
+    default()
+};
+// Better: option.unwrap_or_else(default)
+
+// WARN: Collapsible if statements
+if condition1 {
+    if condition2 {
+        do_something();
+    }
+}
+// Better: if condition1 && condition2 { do_something() }
+```
+
+### Naming Issues
+
+```rust
+// WARN: Function should not start with 'is_' returning non-bool
+fn is_valid() -> i32 { 0 }  // Misleading name
+
+// WARN: Method should not be named 'new' without returning Self
+impl Foo {
+    fn new() -> Bar { Bar }  // Confusing
+}
+```
+
+## Notable Lints in This Group
+
+| Lint | Better Pattern |
+|------|---------------|
+| `len_zero` | Use `is_empty()` instead of `len() == 0` |
+| `redundant_field_names` | Use shorthand `{ x }` not `{ x: x }` |
+| `unused_unit` | Remove `-> ()` and trailing `()` |
+| `collapsible_if` | Combine nested ifs with `&&` |
+| `single_match` | Use `if let` instead |
+| `match_like_matches_macro` | Use `matches!()` macro |
+| `needless_return` | Remove explicit `return` at end |
+| `question_mark` | Use `?` instead of `match` |
+
+## Examples
+
+```rust
+// Before (style warnings)
+fn process(data: Vec<i32>) -> Option<i32> {
+    if data.len() == 0 {
+        return None;
+    }
+    let first = match data.first() {
+        Some(x) => x,
+        None => return None,
+    };
+    return Some(*first);
+}
+
+// After (idiomatic)
+fn process(data: Vec<i32>) -> Option<i32> {
+    if data.is_empty() {
+        return None;
+    }
+    let first = data.first()?;
+    Some(*first)
+}
+```
+
+## Selective Allowance
+
+Some style lints may conflict with team preferences:
+
+```rust
+// If your team prefers explicit returns
+#[allow(clippy::needless_return)]
+fn explicit_return() -> i32 {
+    return 42;
+}
+```
+
+## See Also
+
+- [lint-warn-suspicious](./lint-warn-suspicious.md) - Suspicious patterns
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [lint-rustfmt-check](./lint-rustfmt-check.md) - Formatting checks

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-suspicious.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-warn-suspicious.md
@@ -1,0 +1,122 @@
+# lint-warn-suspicious
+
+> Enable clippy::suspicious for likely bugs
+
+## Why It Matters
+
+The `clippy::suspicious` lint group catches code patterns that are syntactically valid but almost always wrong. These are potential bugs that deserve investigation. Enabling this group as a warning helps catch mistakes early.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::suspicious)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+suspicious = "warn"
+```
+
+Or in `clippy.toml`:
+
+```toml
+warn = ["clippy::suspicious"]
+```
+
+## What It Catches
+
+### Suspicious Arithmetic
+
+```rust
+// WARN: Suspicious use of + in a << expression
+let bits = 1 << 4 + 1;  // Probably meant (1 << 4) + 1 or 1 << (4 + 1)
+
+// WARN: Suspicious use of | in a + expression
+let value = x | 1 + y;  // Probably meant (x | 1) + y or x | (1 + y)
+```
+
+### Suspicious Comparisons
+
+```rust
+// WARN: Almost swapped operands in a comparison
+if 5 < x && x < 3 { }  // Impossible condition
+
+// WARN: Suspicious assignment in a condition
+if (x = 5) { }  // Probably meant x == 5
+```
+
+### Suspicious Method Calls
+
+```rust
+// WARN: Suspicious map usage
+let _: Vec<_> = vec.iter().map(|x| { 
+    println!("{}", x);  // Side effect in map
+    x
+}).collect();  // Use for_each instead
+
+// WARN: Suspicious string formatting
+let s = format!("{}", format!("{}", x));  // Redundant nested format
+```
+
+### Suspicious Casts
+
+```rust
+// WARN: Suspicious use of not on a bool
+let inverted = !x as i32;  // Did you mean (!x) as i32 or !(x as i32)?
+
+// WARN: Cast of float to int may lose precision
+let n = 3.14_f64 as i32;  // May want .round() first
+```
+
+## Notable Lints in This Group
+
+| Lint | Description |
+|------|-------------|
+| `suspicious_arithmetic_impl` | Unusual operator in arithmetic trait |
+| `suspicious_assignment_formatting` | Looks like typo in assignment |
+| `suspicious_else_formatting` | Else on wrong line |
+| `suspicious_map` | Map with side effects |
+| `suspicious_op_assign_impl` | Unusual op-assign implementation |
+| `suspicious_splitn` | splitn that can't produce n parts |
+| `suspicious_unary_op_formatting` | Confusing unary operator spacing |
+
+## Example Catches
+
+```rust
+// Caught: Suspicious double negation
+let value = --x;  // In Rust, this is -(-x), not pre-decrement
+
+// Caught: Suspicious modulo
+let remainder = x % 1;  // Always 0 for integers
+
+// Caught: Suspicious else formatting
+if condition {
+    do_something();
+}
+else {  // Weird formatting, might be a mistake
+    do_other();
+}
+```
+
+## When to Allow
+
+Rarely. If you need to suppress, document why:
+
+```rust
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Mul for Matrix {
+    // Custom matrix multiplication using + for reduction step
+    fn mul(self, rhs: Self) -> Self::Output {
+        // ...
+    }
+}
+```
+
+## See Also
+
+- [lint-deny-correctness](./lint-deny-correctness.md) - Deny definite bugs
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings

--- a/.cursor/skills/rust-skills-leonardomso/rules/lint-workspace-lints.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/lint-workspace-lints.md
@@ -1,0 +1,172 @@
+# lint-workspace-lints
+
+> Configure lints at workspace level for consistent enforcement
+
+## Why It Matters
+
+Without centralized lint configuration, each crate develops its own standards (or none). Workspace-level lints (Rust 1.74+) ensure consistent code quality across all crates. Denied lints catch issues in CI before they reach production.
+
+## Bad
+
+```toml
+# crate-a/Cargo.toml - strict
+[lints.clippy]
+unwrap_used = "deny"
+
+# crate-b/Cargo.toml - lenient
+# No lint config
+
+# crate-c/Cargo.toml - different
+[lints.clippy]
+unwrap_used = "warn"
+
+# Inconsistent enforcement, some issues slip through
+```
+
+## Good
+
+```toml
+# Root Cargo.toml
+[workspace.lints.rust]
+unsafe_code = "deny"
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+# Correctness
+unwrap_used = "deny"
+expect_used = "warn"
+panic = "deny"
+
+# Style
+needless_pass_by_value = "warn"
+redundant_clone = "warn"
+
+# Complexity
+cognitive_complexity = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+
+# crate-a/Cargo.toml
+[lints]
+workspace = true
+
+# crate-b/Cargo.toml
+[lints]
+workspace = true
+```
+
+## Recommended Lint Configuration
+
+```toml
+# Root Cargo.toml
+[workspace.lints.rust]
+# Safety
+unsafe_code = "deny"
+missing_debug_implementations = "warn"
+
+# Quality
+unused_results = "warn"
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# === Correctness (deny) ===
+correctness = { level = "deny", priority = -1 }
+
+# === Suspicious (deny) ===
+suspicious = { level = "deny", priority = -1 }
+
+# === Style (warn) ===
+style = { level = "warn", priority = -1 }
+
+# === Complexity (warn) ===
+complexity = { level = "warn", priority = -1 }
+
+# === Perf (warn) ===
+perf = { level = "warn", priority = -1 }
+
+# === Pedantic (selective) ===
+# Not all pedantic lints are useful
+doc_markdown = "warn"
+needless_pass_by_value = "warn"
+redundant_closure_for_method_calls = "warn"
+semicolon_if_nothing_returned = "warn"
+
+# === Nursery (selective) ===
+cognitive_complexity = "warn"
+useless_let_if_seq = "warn"
+
+# === Restriction (selective) ===
+unwrap_used = "deny"
+expect_used = "warn"
+dbg_macro = "warn"
+print_stdout = "warn"  # Use logging instead
+todo = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "warn"
+```
+
+## Per-Crate Overrides
+
+```toml
+# crate-with-binary/Cargo.toml
+[lints]
+workspace = true
+
+# Binary entry point can use unwrap
+[lints.clippy]
+unwrap_used = "allow"
+
+# test-utils/Cargo.toml
+[lints]
+workspace = true
+
+# Test utilities can print
+[lints.clippy]
+print_stdout = "allow"
+```
+
+## CI Integration
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      
+      - name: Rustdoc
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+```
+
+## Lint Categories
+
+```toml
+# Category-level configuration
+[workspace.lints.clippy]
+# All lints in category at once
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+style = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Then override specific lints (higher priority)
+missing_errors_doc = "allow"  # Override pedantic
+```
+
+## See Also
+
+- [lint-deny-correctness](./lint-deny-correctness.md) - Critical lints
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace configuration
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - unwrap lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-arena-allocator.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-arena-allocator.md
@@ -1,0 +1,168 @@
+# mem-arena-allocator
+
+> Use arena allocators for batch allocations
+
+## Why It Matters
+
+Arena allocators (bump allocators) allocate memory from a contiguous region, making allocation extremely fast (just bump a pointer). All allocations are freed at once when the arena is dropped. Perfect for request-scoped or parse-tree allocations.
+
+## Bad
+
+```rust
+// Many small allocations during parsing
+fn parse(input: &str) -> Vec<Node> {
+    let mut nodes = Vec::new();
+    for token in tokenize(input) {
+        nodes.push(Box::new(Node::new(token)));  // Heap alloc per node!
+    }
+    nodes
+}
+
+// Per-request allocations add up
+fn handle_request(req: Request) -> Response {
+    let headers = parse_headers(&req);      // Allocates
+    let body = parse_body(&req);            // Allocates
+    let response = generate_response();     // Allocates
+    // All freed individually at end
+    response
+}
+```
+
+## Good
+
+```rust
+use bumpalo::Bump;
+
+// All nodes allocated from same arena
+fn parse<'a>(input: &str, arena: &'a Bump) -> Vec<&'a Node> {
+    let mut nodes = Vec::new();
+    for token in tokenize(input) {
+        let node = arena.alloc(Node::new(token));  // Fast bump!
+        nodes.push(node);
+    }
+    nodes
+}  // Arena freed all at once
+
+// Per-request arena
+fn handle_request(req: Request) -> Response {
+    let arena = Bump::new();
+    
+    let headers = parse_headers(&req, &arena);
+    let body = parse_body(&req, &arena);
+    let response = generate_response(&arena);
+    
+    // Convert to owned response before arena drops
+    response.to_owned()
+}  // All request memory freed instantly
+```
+
+## Thread-Local Scratch Arena Pattern
+
+```rust
+use bumpalo::Bump;
+use std::cell::RefCell;
+
+thread_local! {
+    static SCRATCH: RefCell<Bump> = RefCell::new(Bump::with_capacity(4 * 1024));
+}
+
+fn with_scratch<T>(f: impl FnOnce(&Bump) -> T) -> T {
+    SCRATCH.with(|scratch| {
+        let arena = scratch.borrow();
+        let result = f(&arena);
+        result
+    })
+}
+
+fn reset_scratch() {
+    SCRATCH.with(|scratch| {
+        scratch.borrow_mut().reset();
+    });
+}
+
+// Usage
+fn process_batch(items: &[Item]) -> Vec<Output> {
+    with_scratch(|arena| {
+        let temp_data: Vec<&TempData> = items
+            .iter()
+            .map(|item| arena.alloc(compute_temp(item)))
+            .collect();
+        
+        // Use temp_data...
+        let result = finalize(&temp_data);
+        
+        reset_scratch();  // Reuse arena memory
+        result
+    })
+}
+```
+
+## Evidence from ROC Compiler
+
+```rust
+// https://github.com/roc-lang/roc/blob/main/crates/compiler/solve/src/to_var.rs
+std::thread_local! {
+    static SCRATCHPAD: RefCell<Option<bumpalo::Bump>> = 
+        RefCell::new(Some(bumpalo::Bump::with_capacity(4 * 1024)));
+}
+
+fn take_scratchpad() -> bumpalo::Bump {
+    SCRATCHPAD.with(|f| f.take().unwrap())
+}
+
+fn put_scratchpad(scratchpad: bumpalo::Bump) {
+    SCRATCHPAD.with(|f| {
+        f.replace(Some(scratchpad));
+    });
+}
+```
+
+## Bumpalo Collections
+
+```rust
+use bumpalo::Bump;
+use bumpalo::collections::{Vec, String};
+
+fn process<'a>(arena: &'a Bump, input: &str) -> Vec<'a, String<'a>> {
+    let mut results = Vec::new_in(arena);
+    
+    for word in input.split_whitespace() {
+        let mut s = String::new_in(arena);
+        s.push_str(word);
+        s.push_str("_processed");
+        results.push(s);
+    }
+    
+    results  // All allocated in arena
+}
+```
+
+## When to Use Arenas
+
+| Situation | Use Arena? |
+|-----------|-----------|
+| Parsing (AST nodes) | Yes |
+| Request handling | Yes |
+| Batch processing | Yes |
+| Long-lived data | No |
+| Data escaping scope | No (or copy out) |
+| Simple programs | Overkill |
+
+## Performance Impact
+
+```rust
+// Benchmarks from production systems:
+// - Individual allocations: ~25-50ns each
+// - Arena bump: ~1-2ns each (20-50x faster)
+// - Arena reset: O(1) regardless of allocation count
+
+// Memory overhead:
+// - Arena wastes some memory (unused capacity)
+// - But eliminates per-allocation metadata overhead
+```
+
+## See Also
+
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate when size is known
+- [mem-reuse-collections](mem-reuse-collections.md) - Reuse collections with clear()
+- [opt-profile-first](perf-profile-first.md) - Profile to verify benefit

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-arrayvec.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-arrayvec.md
@@ -1,0 +1,142 @@
+# mem-arrayvec
+
+> Use `ArrayVec<T, N>` for fixed-capacity collections that never heap-allocate
+
+## Why It Matters
+
+`ArrayVec` from the `arrayvec` crate provides Vec-like API with a compile-time maximum capacity, storing all elements inline on the stack. Unlike `SmallVec` which can spill to heap, `ArrayVec` guarantees no heap allocation—if you exceed capacity, it returns an error or panics. This is ideal for embedded systems, real-time code, or when you have a hard upper bound.
+
+## Bad
+
+```rust
+// Vec always heap-allocates, even for small collections
+fn parse_options(input: &str) -> Vec<Option> {
+    let mut options = Vec::new();  // Heap allocation
+    for part in input.split(',').take(8) {  // Know we never exceed 8
+        options.push(parse_option(part));
+    }
+    options
+}
+
+// Or SmallVec when you truly can't exceed capacity
+use smallvec::SmallVec;
+fn get_flags() -> SmallVec<[Flag; 4]> {
+    // SmallVec CAN heap-allocate if pushed beyond 4
+    // That might be unexpected in no-alloc contexts
+}
+```
+
+## Good
+
+```rust
+use arrayvec::ArrayVec;
+
+// Guaranteed no heap allocation
+fn parse_options(input: &str) -> ArrayVec<Option, 8> {
+    let mut options = ArrayVec::new();
+    for part in input.split(',') {
+        if options.try_push(parse_option(part)).is_err() {
+            break;  // Capacity reached, stop
+        }
+    }
+    options
+}
+
+// For embedded/no_std contexts
+#[no_std]
+fn collect_readings() -> ArrayVec<SensorReading, 16> {
+    let mut readings = ArrayVec::new();
+    for sensor in SENSORS.iter() {
+        readings.push(sensor.read());  // Panics if > 16
+    }
+    readings
+}
+```
+
+## ArrayVec vs SmallVec vs Vec
+
+| Type | Stack | Heap | Use When |
+|------|-------|------|----------|
+| `Vec<T>` | Never | Always | Unknown size, may grow indefinitely |
+| `SmallVec<[T; N]>` | Up to N | Beyond N | Usually small, occasionally large |
+| `ArrayVec<T, N>` | Always | Never | Hard limit, no heap allowed |
+
+## API Patterns
+
+```rust
+use arrayvec::ArrayVec;
+
+let mut arr: ArrayVec<i32, 4> = ArrayVec::new();
+
+// Push with potential panic (like Vec)
+arr.push(1);
+arr.push(2);
+
+// Safe push - returns Err if full
+match arr.try_push(3) {
+    Ok(()) => println!("Added"),
+    Err(err) => println!("Full, couldn't add {}", err.element()),
+}
+
+// Check capacity
+assert!(arr.len() < arr.capacity());
+
+// Remaining capacity
+let remaining = arr.remaining_capacity();
+
+// Is it full?
+if arr.is_full() {
+    arr.pop();
+}
+
+// From iterator with limit
+let arr: ArrayVec<_, 10> = (0..100)
+    .filter(|x| x % 2 == 0)
+    .take(10)  // Important: don't exceed capacity
+    .collect();
+```
+
+## ArrayString for Stack Strings
+
+```rust
+use arrayvec::ArrayString;
+
+// Stack-allocated string with max capacity
+let mut s: ArrayString<64> = ArrayString::new();
+s.push_str("Hello, ");
+s.push_str("world!");
+
+// No heap allocation for small strings
+fn format_code(code: u32) -> ArrayString<16> {
+    let mut s = ArrayString::new();
+    write!(&mut s, "CODE-{:04}", code).unwrap();
+    s
+}
+```
+
+## When NOT to Use ArrayVec
+
+```rust
+// ❌ When size varies widely
+fn parse_json_array(json: &str) -> ArrayVec<Value, ???> {
+    // What capacity? JSON arrays can be any size
+}
+
+// ❌ When capacity is very large
+let big: ArrayVec<u8, 1_000_000> = ArrayVec::new();  // 1MB on stack = bad
+
+// ✅ Use SmallVec or Vec instead for these cases
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+arrayvec = "0.7"
+```
+
+## See Also
+
+- [mem-smallvec](./mem-smallvec.md) - When heap fallback is acceptable
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating Vec capacity
+- [own-move-large](./own-move-large.md) - Large stack types considerations

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-assert-type-size.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-assert-type-size.md
@@ -1,0 +1,168 @@
+# mem-assert-type-size
+
+> Use static assertions to guard against accidental type size growth
+
+## Why It Matters
+
+Adding a field to a frequently-instantiated struct can silently bloat memory usage. Static size assertions catch this at compile time, making size changes intentional rather than accidental. This is especially important for types stored in large collections or passed frequently by value.
+
+## Bad
+
+```rust
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+}
+
+// Later, someone adds a field without realizing the impact
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+    metadata: String,  // Silently adds 24 bytes!
+}
+
+// 10 million events now use 240MB more memory
+// No warning, no review trigger
+```
+
+## Good
+
+```rust
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+}
+
+// Static assertion - breaks compile if size changes
+const _: () = assert!(std::mem::size_of::<Event>() == 48);
+
+// Or with static_assertions crate
+use static_assertions::assert_eq_size;
+assert_eq_size!(Event, [u8; 48]);
+
+// Now adding metadata triggers compile error:
+// error: assertion failed: std::mem::size_of::<Event>() == 48
+```
+
+## static_assertions Crate
+
+```rust
+use static_assertions::{assert_eq_size, const_assert};
+
+struct Critical {
+    id: u64,
+    flags: u32,
+    data: [u8; 16],
+}
+
+// Exact size assertion
+assert_eq_size!(Critical, [u8; 32]);
+
+// Maximum size assertion
+const_assert!(std::mem::size_of::<Critical>() <= 64);
+
+// Alignment assertion
+const_assert!(std::mem::align_of::<Critical>() == 8);
+
+// Compare sizes
+assert_eq_size!(Critical, [u64; 4]);
+```
+
+## Built-in Const Assertions
+
+```rust
+// No external crate needed (Rust 1.57+)
+struct Packet {
+    header: u32,
+    payload: [u8; 60],
+}
+
+const _: () = assert!(
+    std::mem::size_of::<Packet>() == 64,
+    "Packet must be exactly 64 bytes for protocol compliance"
+);
+
+// Compile error shows custom message if assertion fails
+```
+
+## Documenting Size Constraints
+
+```rust
+/// Network protocol packet header.
+/// 
+/// # Size
+/// 
+/// This struct is guaranteed to be exactly 32 bytes to match
+/// the network protocol specification. Any changes to fields
+/// must maintain this size constraint.
+#[repr(C)]  // Predictable layout for FFI
+struct Header {
+    version: u16,
+    flags: u16,
+    length: u32,
+    checksum: u64,
+    reserved: [u8; 16],
+}
+
+const _: () = assert!(std::mem::size_of::<Header>() == 32);
+```
+
+## Testing Size Stability
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn critical_types_have_expected_sizes() {
+        // Document expected sizes in tests too
+        assert_eq!(std::mem::size_of::<Event>(), 48);
+        assert_eq!(std::mem::size_of::<Message>(), 64);
+        assert_eq!(std::mem::size_of::<Header>(), 32);
+    }
+    
+    #[test]
+    fn cache_line_aligned() {
+        // Verify cache-friendly sizing
+        assert!(std::mem::size_of::<HotData>() <= 64);
+    }
+}
+```
+
+## When to Assert
+
+```rust
+// ✅ Types stored in large collections
+struct Node { /* ... */ }
+const _: () = assert!(std::mem::size_of::<Node>() <= 64);
+
+// ✅ Types used in FFI / binary protocols
+#[repr(C)]
+struct WireFormat { /* ... */ }
+const _: () = assert!(std::mem::size_of::<WireFormat>() == 256);
+
+// ✅ Performance-critical types
+struct HotPath { /* ... */ }
+const _: () = assert!(std::mem::size_of::<HotPath>() <= 128);
+
+// ❌ Skip for rarely-instantiated types
+struct AppConfig { /* many fields */ }
+// Size doesn't matter, only one instance
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+static_assertions = "1.1"
+```
+
+## See Also
+
+- [mem-smaller-integers](./mem-smaller-integers.md) - Choosing appropriate integer sizes
+- [mem-box-large-variant](./mem-box-large-variant.md) - Managing enum variant sizes
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache line considerations

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-avoid-format.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-avoid-format.md
@@ -1,0 +1,147 @@
+# mem-avoid-format
+
+> Avoid `format!()` when string literals work
+
+## Why It Matters
+
+`format!()` always allocates a new String, even for constant text. In hot paths, these allocations add up. Use string literals, `write!()`, or pre-allocated buffers instead.
+
+## Bad
+
+```rust
+// Allocates every time, even for static text
+fn get_error_message() -> String {
+    format!("An error occurred")  // Unnecessary allocation!
+}
+
+// Allocates in a loop
+for item in items {
+    log::info!("{}", format!("Processing item: {}", item));  // Double work!
+}
+
+// format! in hot path
+fn classify(n: i32) -> String {
+    if n > 0 {
+        format!("positive")  // Allocates!
+    } else if n < 0 {
+        format!("negative")  // Allocates!
+    } else {
+        format!("zero")      // Allocates!
+    }
+}
+```
+
+## Good
+
+```rust
+// Return &'static str for constants
+fn get_error_message() -> &'static str {
+    "An error occurred"  // No allocation
+}
+
+// Use format args directly
+for item in items {
+    log::info!("Processing item: {}", item);  // No intermediate String
+}
+
+// Return Cow for mixed static/dynamic
+use std::borrow::Cow;
+
+fn classify(n: i32) -> Cow<'static, str> {
+    if n > 0 {
+        Cow::Borrowed("positive")  // No allocation
+    } else if n < 0 {
+        Cow::Borrowed("negative")  // No allocation
+    } else {
+        Cow::Borrowed("zero")      // No allocation
+    }
+}
+
+// Or just &'static str if always static
+fn classify_str(n: i32) -> &'static str {
+    if n > 0 { "positive" }
+    else if n < 0 { "negative" }
+    else { "zero" }
+}
+```
+
+## Use write!() for Output
+
+```rust
+use std::io::Write;
+
+// Bad: Allocate then write
+fn bad_log(writer: &mut impl Write, msg: &str, code: u32) {
+    let formatted = format!("[ERROR {}] {}", code, msg);  // Allocation!
+    writer.write_all(formatted.as_bytes()).unwrap();
+}
+
+// Good: Write directly
+fn good_log(writer: &mut impl Write, msg: &str, code: u32) {
+    write!(writer, "[ERROR {}] {}", code, msg).unwrap();  // No allocation!
+}
+```
+
+## Pre-allocate for Multiple Appends
+
+```rust
+// Bad: Multiple allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result = format!("{}{}\n", result, part);  // Allocates each iteration!
+    }
+    result
+}
+
+// Good: Pre-allocate
+fn build_message(parts: &[&str]) -> String {
+    let total_len: usize = parts.iter().map(|p| p.len() + 1).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(part);
+        result.push('\n');
+    }
+    result
+}
+
+// Good: Use join
+fn build_message(parts: &[&str]) -> String {
+    parts.join("\n")
+}
+```
+
+## CompactString for Small Strings
+
+```rust
+use compact_str::CompactString;
+
+// Stack-allocated for strings <= 24 bytes
+fn format_code(code: u32) -> CompactString {
+    compact_str::format_compact!("ERR-{:04}", code)
+    // Stack-allocated if result is small enough
+}
+```
+
+## When format!() Is Fine
+
+```rust
+// Rare/cold paths - clarity over micro-optimization
+fn log_startup_message() {
+    println!("{}", format!("Starting {} v{}", APP_NAME, VERSION));
+}
+
+// When you need an owned String anyway
+fn create_user_greeting(name: &str) -> String {
+    format!("Hello, {}!", name)  // Need owned String
+}
+
+// Error messages (already on error path)
+return Err(format!("Invalid value: {}", value).into());
+```
+
+## See Also
+
+- [mem-write-over-format](mem-write-over-format.md) - Use write!() instead of format!()
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate strings
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for mixed static/dynamic

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-box-large-variant.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-box-large-variant.md
@@ -1,0 +1,158 @@
+# mem-box-large-variant
+
+> Box large enum variants to reduce overall enum size
+
+## Why It Matters
+
+An enum's size is determined by its largest variant. If one variant contains a large struct while others are small, every instance of the enum pays for the largest variant's size. Boxing the large variant puts that data on the heap, keeping the enum itself small. This can significantly reduce memory usage and improve cache performance.
+
+## Bad
+
+```rust
+enum Message {
+    Quit,                              // 0 bytes of data
+    Move { x: i32, y: i32 },          // 8 bytes
+    Text(String),                      // 24 bytes
+    Image { 
+        data: [u8; 1024],             // 1024 bytes - forces entire enum to ~1032 bytes!
+        width: u32, 
+        height: u32 
+    },
+}
+
+// Every Message is ~1032 bytes, even Quit and Move
+let messages: Vec<Message> = vec![
+    Message::Quit,  // Wastes ~1032 bytes
+    Message::Quit,  // Wastes ~1032 bytes
+    Message::Move { x: 0, y: 0 },  // Wastes ~1024 bytes
+];
+```
+
+## Good
+
+```rust
+struct ImageData {
+    data: [u8; 1024],
+    width: u32,
+    height: u32,
+}
+
+enum Message {
+    Quit,
+    Move { x: i32, y: i32 },
+    Text(String),
+    Image(Box<ImageData>),  // Now just 8 bytes (pointer)
+}
+
+// Message is now ~32 bytes (String variant is largest)
+let messages: Vec<Message> = vec![
+    Message::Quit,  // Uses ~32 bytes
+    Message::Quit,  // Uses ~32 bytes  
+    Message::Move { x: 0, y: 0 },  // Uses ~32 bytes
+];
+```
+
+## Check Enum Sizes
+
+```rust
+use std::mem::size_of;
+
+// Before boxing
+enum BadEvent {
+    Click { x: u32, y: u32 },           // 8 bytes
+    KeyPress(char),                      // 4 bytes
+    LargeData([u8; 256]),               // 256 bytes
+}
+println!("BadEvent: {} bytes", size_of::<BadEvent>());  // ~264 bytes
+
+// After boxing
+enum GoodEvent {
+    Click { x: u32, y: u32 },
+    KeyPress(char),
+    LargeData(Box<[u8; 256]>),          // 8 bytes (pointer)
+}
+println!("GoodEvent: {} bytes", size_of::<GoodEvent>());  // ~16 bytes
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+large_enum_variant = "warn"  # Warns when variants differ significantly
+```
+
+```rust
+// Clippy will suggest:
+// warning: large size difference between variants
+// help: consider boxing the large fields to reduce the total size
+```
+
+## When to Box
+
+| Largest Variant | Other Variants | Action |
+|-----------------|----------------|--------|
+| < 64 bytes | Similar size | Don't box |
+| > 128 bytes | Much smaller | Box the large variant |
+| > 256 bytes | Any | Definitely box |
+
+## Recursive Types Require Boxing
+
+```rust
+// Won't compile - infinite size
+enum List {
+    Cons(i32, List),
+    Nil,
+}
+
+// Must box recursive variant
+enum List {
+    Cons(i32, Box<List>),  // Now finite size
+    Nil,
+}
+
+// Same for ASTs
+enum Expr {
+    Number(i64),
+    BinOp {
+        op: Op,
+        left: Box<Expr>,   // Recursive - must box
+        right: Box<Expr>,
+    },
+}
+```
+
+## Pattern Matching with Boxed Variants
+
+```rust
+enum Event {
+    Small(u32),
+    Large(Box<LargeData>),
+}
+
+fn handle(event: Event) {
+    match event {
+        Event::Small(n) => println!("Small: {}", n),
+        Event::Large(data) => {
+            // data is Box<LargeData>, dereference to access
+            println!("Large: {} bytes", data.size);
+        }
+    }
+}
+
+// Or match on reference
+fn handle_ref(event: &Event) {
+    match event {
+        Event::Small(n) => println!("Small: {}", n),
+        Event::Large(data) => {
+            // data is &Box<LargeData>, auto-derefs
+            println!("Large: {} bytes", data.size);
+        }
+    }
+}
+```
+
+## See Also
+
+- [own-move-large](./own-move-large.md) - Boxing large types for cheap moves
+- [mem-smallvec](./mem-smallvec.md) - Alternative for inline small collections
+- [lint-deny-correctness](./lint-deny-correctness.md) - Enabling clippy lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-boxed-slice.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-boxed-slice.md
@@ -1,0 +1,139 @@
+# mem-boxed-slice
+
+> Use `Box<[T]>` instead of `Vec<T>` for fixed-size heap data
+
+## Why It Matters
+
+`Vec<T>` stores three words: pointer, length, and capacity. When you know a collection won't grow, `Box<[T]>` stores only pointer and length (2 words), saving 8 bytes per instance. More importantly, it communicates intent: "this data is fixed-size." For large numbers of fixed collections, this adds up.
+
+## Bad
+
+```rust
+struct Document {
+    // Vec signals "might grow" but we never push after creation
+    paragraphs: Vec<Paragraph>,  // 24 bytes: ptr + len + capacity
+}
+
+fn load_document(data: &[u8]) -> Document {
+    let paragraphs: Vec<Paragraph> = parse_paragraphs(data);
+    // paragraphs has capacity >= len, wasting the capacity field
+    Document { paragraphs }
+}
+```
+
+## Good
+
+```rust
+struct Document {
+    // Box<[T]> signals "fixed size" - clear intent
+    paragraphs: Box<[Paragraph]>,  // 16 bytes: ptr + len (as fat pointer)
+}
+
+fn load_document(data: &[u8]) -> Document {
+    let paragraphs: Vec<Paragraph> = parse_paragraphs(data);
+    Document { 
+        paragraphs: paragraphs.into_boxed_slice()  // Shrinks + converts
+    }
+}
+```
+
+## Memory Layout
+
+```rust
+use std::mem::size_of;
+
+// Vec: 24 bytes on 64-bit
+assert_eq!(size_of::<Vec<u8>>(), 24);  // ptr(8) + len(8) + cap(8)
+
+// Box<[T]>: 16 bytes (fat pointer)
+assert_eq!(size_of::<Box<[u8]>>(), 16);  // ptr(8) + len(8)
+
+// Savings per instance: 8 bytes
+// For 1 million instances: 8 MB saved
+```
+
+## Conversion Patterns
+
+```rust
+// Vec to Box<[T]>
+let vec: Vec<i32> = vec![1, 2, 3, 4, 5];
+let boxed: Box<[i32]> = vec.into_boxed_slice();
+
+// Box<[T]> back to Vec (if you need to grow)
+let vec_again: Vec<i32> = boxed.into_vec();
+
+// From iterator
+let boxed: Box<[i32]> = (0..100).collect::<Vec<_>>().into_boxed_slice();
+
+// Shrink Vec first if it has excess capacity
+let mut vec = Vec::with_capacity(1000);
+vec.extend(0..10);
+vec.shrink_to_fit();  // Reduce capacity to length
+let boxed = vec.into_boxed_slice();  // Now no wasted allocation
+```
+
+## When to Use What
+
+| Type | Use When |
+|------|----------|
+| `Vec<T>` | Collection may grow/shrink |
+| `Box<[T]>` | Fixed-size, heap-allocated, many instances |
+| `[T; N]` | Fixed-size, stack-allocated, size known at compile time |
+| `&[T]` | Borrowed view, don't need ownership |
+
+## Box<str> for Immutable Strings
+
+Same principle applies to strings:
+
+```rust
+use std::mem::size_of;
+
+// String: 24 bytes (like Vec<u8>)
+assert_eq!(size_of::<String>(), 24);
+
+// Box<str>: 16 bytes
+assert_eq!(size_of::<Box<str>>(), 16);
+
+// For immutable strings
+struct Name {
+    value: Box<str>,  // Saves 8 bytes vs String
+}
+
+impl Name {
+    fn new(s: &str) -> Self {
+        Name { value: s.into() }  // &str -> Box<str>
+    }
+}
+
+// Or from String
+let s = String::from("hello");
+let boxed: Box<str> = s.into_boxed_str();
+```
+
+## Real-World Example
+
+```rust
+// Cache with millions of entries
+struct Cache {
+    // 8 bytes saved per entry adds up
+    entries: HashMap<Key, Box<[u8]>>,
+}
+
+impl Cache {
+    fn insert(&mut self, key: Key, data: Vec<u8>) {
+        // Convert to boxed slice for storage
+        self.entries.insert(key, data.into_boxed_slice());
+    }
+    
+    fn get(&self, key: &Key) -> Option<&[u8]> {
+        // Returns regular slice reference
+        self.entries.get(key).map(|b| b.as_ref())
+    }
+}
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating when size is known
+- [own-slice-over-vec](./own-slice-over-vec.md) - Using slices in function parameters
+- [mem-compact-string](./mem-compact-string.md) - Compact string alternatives

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-clone-from.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-clone-from.md
@@ -1,0 +1,147 @@
+# mem-clone-from
+
+> Use `clone_from()` to reuse allocations when repeatedly cloning
+
+## Why It Matters
+
+`x = y.clone()` drops x's allocation and creates a new one from y. `x.clone_from(&y)` reuses x's existing allocation if possible, avoiding the allocation overhead. For repeatedly cloning into the same variable (loops, buffers), this can significantly reduce allocator pressure.
+
+## Bad
+
+```rust
+let mut buffer = String::with_capacity(1024);
+
+for source in sources {
+    buffer = source.clone();  // Drops old allocation, allocates new
+    process(&buffer);
+}
+
+// Each iteration:
+// 1. Drops buffer's 1024-byte allocation
+// 2. Allocates new memory for source.clone()
+// Allocator thrashing!
+```
+
+## Good
+
+```rust
+let mut buffer = String::with_capacity(1024);
+
+for source in sources {
+    buffer.clone_from(source);  // Reuses allocation if capacity sufficient
+    process(&buffer);
+}
+
+// If source.len() <= 1024, no allocation happens
+// Just copies bytes into existing buffer
+```
+
+## How clone_from Works
+
+```rust
+impl Clone for String {
+    fn clone(&self) -> Self {
+        // Always allocates new memory
+        String::from(self.as_str())
+    }
+    
+    fn clone_from(&mut self, source: &Self) {
+        // Reuse existing capacity if possible
+        self.clear();
+        self.push_str(source);  // Only reallocates if capacity insufficient
+    }
+}
+```
+
+## Types That Benefit
+
+```rust
+// String - reuses capacity
+let mut s = String::with_capacity(100);
+s.clone_from(&other_string);
+
+// Vec<T> - reuses capacity
+let mut v: Vec<u8> = Vec::with_capacity(1000);
+v.clone_from(&other_vec);
+
+// HashMap - reuses buckets
+let mut map = HashMap::with_capacity(100);
+map.clone_from(&other_map);
+
+// PathBuf - reuses capacity
+let mut path = PathBuf::with_capacity(256);
+path.clone_from(&other_path);
+```
+
+## Benchmarking the Difference
+
+```rust
+use criterion::{black_box, criterion_group, Criterion};
+
+fn bench_clone_patterns(c: &mut Criterion) {
+    let source = "x".repeat(1000);
+    
+    c.bench_function("clone assignment", |b| {
+        let mut buffer = String::new();
+        b.iter(|| {
+            buffer = black_box(&source).clone();
+        });
+    });
+    
+    c.bench_function("clone_from", |b| {
+        let mut buffer = String::with_capacity(1000);
+        b.iter(|| {
+            buffer.clone_from(black_box(&source));
+        });
+    });
+}
+// clone_from is typically 2-3x faster for this pattern
+```
+
+## Custom Implementations
+
+When implementing Clone for your types:
+
+```rust
+#[derive(Debug)]
+struct Buffer {
+    data: Vec<u8>,
+    metadata: Metadata,
+}
+
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Buffer {
+            data: self.data.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+    
+    // Optimize clone_from to reuse vec capacity
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);  // Reuses allocation
+        self.metadata = source.metadata.clone();
+    }
+}
+```
+
+## When NOT Needed
+
+```rust
+// Single clone - no benefit
+let copy = original.clone();  // Can't reuse, no prior allocation
+
+// Small Copy types - no allocation anyway
+let x: i32 = y;  // Not even Clone, just Copy
+
+// Immutable context
+fn process(data: &String) {
+    // Can't use clone_from - would need &mut self
+}
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating capacity
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing collection allocations
+- [own-clone-explicit](./own-clone-explicit.md) - When Clone is appropriate

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-compact-string.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-compact-string.md
@@ -1,0 +1,149 @@
+# mem-compact-string
+
+> Use compact string types for memory-constrained string storage
+
+## Why It Matters
+
+Standard `String` is 24 bytes (pointer + length + capacity). For applications storing millions of short strings, this overhead dominates. Compact string libraries like `compact_str`, `smartstring`, or `ecow` store small strings inline (no heap allocation) and use optimized layouts for larger strings.
+
+## Bad
+
+```rust
+struct User {
+    id: u64,
+    // Most usernames are < 24 chars, but String is always 24 bytes + heap
+    username: String,
+    email: String,
+}
+
+// 1 million users = 24 bytes * 2 * 1M = 48MB just for String metadata
+// Plus all the heap allocations for actual content
+```
+
+## Good
+
+```rust
+use compact_str::CompactString;
+
+struct User {
+    id: u64,
+    // CompactString: 24 bytes, but strings ≤ 24 chars are inline (no heap)
+    username: CompactString,
+    email: CompactString,
+}
+
+// Most usernames fit inline = zero heap allocations
+// Same memory footprint as String but way fewer allocations
+```
+
+## Compact String Libraries
+
+### compact_str
+
+```rust
+use compact_str::CompactString;
+
+// Inline storage for strings ≤ 24 bytes
+let small: CompactString = "hello".into();  // No heap allocation
+
+// Automatic heap fallback for larger strings
+let large: CompactString = "x".repeat(100).into();
+
+// String-like API
+let mut s = CompactString::new("hello");
+s.push_str(" world");
+assert_eq!(s.as_str(), "hello world");
+
+// Format macro
+use compact_str::format_compact;
+let s = format_compact!("value: {}", 42);
+```
+
+### smartstring
+
+```rust
+use smartstring::{SmartString, LazyCompact};
+
+// Default is LazyCompact: 24 bytes inline capacity
+let s: SmartString<LazyCompact> = "short string".into();
+
+// Compact mode: 23 bytes inline on 64-bit
+use smartstring::Compact;
+let s: SmartString<Compact> = "hello".into();
+```
+
+### ecow (copy-on-write)
+
+```rust
+use ecow::EcoString;
+
+// Clone is O(1) - shares underlying data
+let s1: EcoString = "shared data".into();
+let s2 = s1.clone();  // Cheap, shares allocation
+
+// Copy-on-write: only allocates on mutation
+let mut s3 = s1.clone();
+s3.push_str(" modified");  // Now allocates
+```
+
+## Memory Comparison
+
+```rust
+use std::mem::size_of;
+
+// All 24 bytes, but different inline capacities
+assert_eq!(size_of::<String>(), 24);
+assert_eq!(size_of::<compact_str::CompactString>(), 24);
+assert_eq!(size_of::<smartstring::SmartString>(), 24);
+assert_eq!(size_of::<ecow::EcoString>(), 16);  // Even smaller!
+```
+
+## Inline Capacity
+
+| Type | Size | Inline Capacity |
+|------|------|-----------------|
+| `String` | 24 | 0 (always heap) |
+| `CompactString` | 24 | 24 bytes |
+| `SmartString<LazyCompact>` | 24 | 23 bytes |
+| `EcoString` | 16 | 15 bytes |
+
+## When to Use
+
+```rust
+// ✅ Good: Many short strings in memory
+struct Dictionary {
+    words: Vec<CompactString>,  // Millions of short words
+}
+
+// ✅ Good: Frequently cloned strings
+struct Template {
+    parts: Vec<EcoString>,  // O(1) clone
+}
+
+// ❌ Don't: Hot path string manipulation
+fn transform(s: &str) -> String {
+    // Standard String is optimized for manipulation
+    s.to_uppercase()
+}
+
+// ❌ Don't: API boundaries (prefer &str or String for interop)
+pub fn public_api(input: CompactString) { }  // Forces dependency
+pub fn public_api(input: impl Into<String>) { }  // Better
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+compact_str = "0.7"
+# or
+smartstring = "1.0"
+# or
+ecow = "0.2"
+```
+
+## See Also
+
+- [mem-boxed-slice](./mem-boxed-slice.md) - Box<str> for immutable strings
+- [own-cow-conditional](./own-cow-conditional.md) - Cow<str> for borrow-or-own
+- [mem-smallvec](./mem-smallvec.md) - Similar concept for Vec

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-reuse-collections.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-reuse-collections.md
@@ -1,0 +1,174 @@
+# mem-reuse-collections
+
+> Clear and reuse collections instead of creating new ones in loops
+
+## Why It Matters
+
+Creating new `Vec`, `String`, or `HashMap` instances in hot loops generates significant allocator pressure. Clearing a collection and reusing it keeps the existing capacity, avoiding repeated allocation/deallocation cycles. This is especially impactful for frequently-executed code paths.
+
+## Bad
+
+```rust
+fn process_batches(batches: &[Batch]) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for batch in batches {
+        let mut temp = Vec::new();  // Allocates every iteration
+        
+        for item in &batch.items {
+            temp.push(transform(item));
+        }
+        
+        results.push(aggregate(&temp));
+        // temp dropped here, deallocation
+    }
+    
+    results
+}
+
+fn format_lines(items: &[Item]) -> String {
+    let mut output = String::new();
+    
+    for item in items {
+        let line = format!("{}: {}", item.name, item.value);  // Allocates
+        output.push_str(&line);
+        output.push('\n');
+    }
+    
+    output
+}
+```
+
+## Good
+
+```rust
+fn process_batches(batches: &[Batch]) -> Vec<Result> {
+    let mut results = Vec::with_capacity(batches.len());
+    let mut temp = Vec::new();  // Allocate once outside loop
+    
+    for batch in batches {
+        temp.clear();  // Reuse allocation, just reset length
+        
+        for item in &batch.items {
+            temp.push(transform(item));
+        }
+        
+        results.push(aggregate(&temp));
+        // temp keeps its capacity for next iteration
+    }
+    
+    results
+}
+
+fn format_lines(items: &[Item]) -> String {
+    use std::fmt::Write;
+    
+    let mut output = String::new();
+    let mut line = String::new();  // Reusable buffer
+    
+    for item in items {
+        line.clear();
+        write!(&mut line, "{}: {}", item.name, item.value).unwrap();
+        output.push_str(&line);
+        output.push('\n');
+    }
+    
+    output
+}
+```
+
+## Clear vs Drain vs New
+
+```rust
+let mut vec = vec![1, 2, 3, 4, 5];
+
+// clear(): keeps capacity, O(n) for Drop types
+vec.clear();
+assert_eq!(vec.len(), 0);
+assert!(vec.capacity() >= 5);
+
+// drain(): returns iterator, clears after iteration
+let drained: Vec<_> = vec.drain(..).collect();
+
+// truncate(): keeps first n elements
+vec.truncate(2);
+
+// Creating new: loses all capacity
+vec = Vec::new();  // Capacity gone
+```
+
+## HashMap Reuse
+
+```rust
+use std::collections::HashMap;
+
+fn count_words_per_line(lines: &[&str]) -> Vec<HashMap<String, usize>> {
+    let mut results = Vec::with_capacity(lines.len());
+    let mut counts = HashMap::new();  // Reuse across iterations
+    
+    for line in lines {
+        counts.clear();  // Keeps bucket allocation
+        
+        for word in line.split_whitespace() {
+            *counts.entry(word.to_string()).or_insert(0) += 1;
+        }
+        
+        results.push(counts.clone());
+    }
+    
+    results
+}
+```
+
+## BufWriter Pattern
+
+```rust
+use std::io::{BufWriter, Write};
+
+fn write_many_records(records: &[Record], mut output: impl Write) -> std::io::Result<()> {
+    // BufWriter reuses its internal buffer
+    let mut writer = BufWriter::with_capacity(8192, &mut output);
+    let mut line = String::with_capacity(256);  // Reusable formatting buffer
+    
+    for record in records {
+        line.clear();
+        format_record(record, &mut line);
+        writer.write_all(line.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
+    
+    writer.flush()
+}
+```
+
+## When to Create Fresh
+
+```rust
+// When ownership transfer is needed
+fn produce_results() -> Vec<Vec<Item>> {
+    let mut results = Vec::new();
+    
+    for batch in batches {
+        let processed: Vec<Item> = batch.process();  // Ownership transferred
+        results.push(processed);  // Moved into results
+    }
+    
+    results  // Each inner Vec is independent
+}
+
+// When thread safety requires it
+std::thread::scope(|s| {
+    for _ in 0..4 {
+        s.spawn(|| {
+            let local_buffer = Vec::new();  // Thread-local, can't share
+            // ...
+        });
+    }
+});
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating capacity
+- [mem-clone-from](./mem-clone-from.md) - Reusing allocations when cloning
+- [mem-write-over-format](./mem-write-over-format.md) - Avoiding format! allocations

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-smaller-integers.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-smaller-integers.md
@@ -1,0 +1,159 @@
+# mem-smaller-integers
+
+> Use appropriately-sized integers to reduce memory footprint
+
+## Why It Matters
+
+Using `i64` when `i16` suffices wastes 6 bytes per value. In arrays, vectors, and structs with millions of instances, this waste compounds dramatically. Choosing the smallest integer type that fits your domain reduces memory usage and improves cache utilization.
+
+## Bad
+
+```rust
+struct Pixel {
+    r: u64,  // Color channels 0-255 = 8 bits needed
+    g: u64,  // Using 64 bits = 8x waste
+    b: u64,
+    a: u64,
+}
+// Size: 32 bytes per pixel
+
+struct HttpStatus {
+    code: i32,      // HTTP codes 100-599 = 10 bits needed
+    version: i32,   // HTTP 1.0, 1.1, 2, 3 = 2 bits needed
+}
+// Size: 8 bytes per status
+
+struct GeoPoint {
+    lat: f64,   // -90 to 90
+    lon: f64,   // -180 to 180
+}
+// Often f32 precision is sufficient for display
+```
+
+## Good
+
+```rust
+struct Pixel {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+// Size: 4 bytes per pixel (8x smaller!)
+
+struct HttpStatus {
+    code: u16,      // 100-599 fits in u16
+    version: u8,    // 1, 2, 3 fits in u8
+}
+// Size: 3 bytes (+ 1 padding = 4 bytes)
+
+struct GeoPoint {
+    lat: f32,   // ~7 decimal digits precision
+    lon: f32,   // Sufficient for most geo applications
+}
+// Size: 8 bytes vs 16 bytes
+```
+
+## Integer Size Reference
+
+| Type | Range | Use For |
+|------|-------|---------|
+| `u8` | 0 to 255 | Bytes, small counts, flags |
+| `i8` | -128 to 127 | Small signed values |
+| `u16` | 0 to 65,535 | Port numbers, small indices |
+| `i16` | -32,768 to 32,767 | Audio samples |
+| `u32` | 0 to 4 billion | Array indices, timestamps (seconds) |
+| `i32` | ±2 billion | General integers, file offsets |
+| `u64` | 0 to 18 quintillion | Large counts, nanosecond timestamps |
+| `usize` | Platform-dependent | Array indexing (required by Rust) |
+
+## Struct Packing
+
+```rust
+use std::mem::size_of;
+
+// Poor ordering - 24 bytes due to padding
+struct Wasteful {
+    a: u8,    // 1 byte + 7 padding
+    b: u64,   // 8 bytes
+    c: u8,    // 1 byte + 7 padding
+}
+assert_eq!(size_of::<Wasteful>(), 24);
+
+// Better ordering - 16 bytes
+struct Efficient {
+    b: u64,   // 8 bytes (aligned)
+    a: u8,    // 1 byte
+    c: u8,    // 1 byte + 6 padding
+}
+assert_eq!(size_of::<Efficient>(), 16);
+
+// Even better with smaller types - 10 bytes
+struct Compact {
+    b: u32,   // 4 bytes (if u32 suffices)
+    a: u8,    // 1 byte
+    c: u8,    // 1 byte
+}
+assert_eq!(size_of::<Compact>(), 8);  // With padding
+```
+
+## Conversion Safety
+
+```rust
+// Safe: always succeeds (widening)
+let small: u8 = 42;
+let big: u32 = small.into();
+
+// Fallible: may overflow (narrowing)
+let big: u32 = 1000;
+let small: u8 = big.try_into().expect("value out of range");
+
+// Or use checked conversion
+if let Ok(small) = u8::try_from(big) {
+    use_small(small);
+} else {
+    handle_overflow();
+}
+```
+
+## Bitflags for Boolean Sets
+
+```rust
+use bitflags::bitflags;
+
+// Instead of 8 separate bool fields (8 bytes minimum)
+bitflags! {
+    struct Permissions: u8 {
+        const READ    = 0b0000_0001;
+        const WRITE   = 0b0000_0010;
+        const EXECUTE = 0b0000_0100;
+        const DELETE  = 0b0000_1000;
+    }
+}
+// All 8 flags in 1 byte!
+
+let perms = Permissions::READ | Permissions::WRITE;
+if perms.contains(Permissions::READ) {
+    // ...
+}
+```
+
+## NonZero Types for Option Optimization
+
+```rust
+use std::num::NonZeroU64;
+
+// Option<u64> = 16 bytes (no null pointer optimization)
+assert_eq!(size_of::<Option<u64>>(), 16);
+
+// Option<NonZeroU64> = 8 bytes (0 represents None)
+assert_eq!(size_of::<Option<NonZeroU64>>(), 8);
+
+let id: Option<NonZeroU64> = NonZeroU64::new(42);
+```
+
+## See Also
+
+- [mem-box-large-variant](./mem-box-large-variant.md) - Optimizing enum sizes
+- [mem-assert-type-size](./mem-assert-type-size.md) - Compile-time size checks
+- [type-newtype-ids](./type-newtype-ids.md) - Type safety for integer IDs

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-smallvec.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-smallvec.md
@@ -1,0 +1,138 @@
+# mem-smallvec
+
+> Use `SmallVec` for usually-small collections
+
+## Why It Matters
+
+`SmallVec<[T; N]>` stores up to N elements inline (on the stack), only allocating on the heap when the size exceeds N. This eliminates heap allocations for the common case while still allowing growth when needed.
+
+## Bad
+
+```rust
+// Always heap-allocates, even for 1-2 elements
+fn get_path_components(path: &str) -> Vec<&str> {
+    path.split('/').collect()  // Usually 2-4 components
+}
+
+// Always heap-allocates for error list
+fn validate(input: &Input) -> Vec<ValidationError> {
+    let mut errors = Vec::new();  // Usually 0-3 errors
+    // validation logic...
+    errors
+}
+```
+
+## Good
+
+```rust
+use smallvec::{smallvec, SmallVec};
+
+// Stack-allocated for typical paths (1-8 components)
+fn get_path_components(path: &str) -> SmallVec<[&str; 8]> {
+    path.split('/').collect()
+}
+
+// Stack-allocated for typical error counts
+fn validate(input: &Input) -> SmallVec<[ValidationError; 4]> {
+    let mut errors = SmallVec::new();
+    // validation logic...
+    errors
+}
+
+// Using smallvec! macro
+let v: SmallVec<[i32; 4]> = smallvec![1, 2, 3];
+```
+
+## Choosing Capacity N
+
+```rust
+// Measure your actual data distribution!
+// Guidelines:
+
+// Path components: 4-8 (most paths are shallow)
+type PathParts<'a> = SmallVec<[&'a str; 8]>;
+
+// Function arguments: 4-8 (most functions have few args)  
+type Args = SmallVec<[Arg; 8]>;
+
+// AST children: 2-4 (binary ops, if/else, etc.)
+type Children = SmallVec<[Node; 4]>;
+
+// Error accumulation: 2-4 (most inputs have few errors)
+type Errors = SmallVec<[Error; 4]>;
+
+// Attribute lists: 4-8 (most items have few attributes)
+type Attrs = SmallVec<[Attribute; 8]>;
+```
+
+## Evidence from rust-analyzer
+
+```rust
+// https://github.com/rust-lang/rust/blob/main/compiler/rustc_expand/src/base.rs
+macro_rules! make_stmts_default {
+    ($me:expr) => {
+        $me.make_expr().map(|e| {
+            smallvec![ast::Stmt {
+                id: ast::DUMMY_NODE_ID,
+                span: e.span,
+                kind: ast::StmtKind::Expr(e),
+            }]
+        })
+    }
+}
+```
+
+## Trade-offs
+
+```rust
+// SmallVec is slightly larger than Vec
+use std::mem::size_of;
+// Vec<i32>: 24 bytes (ptr + len + cap)
+// SmallVec<[i32; 4]>: 32 bytes (inline storage + len + discriminant)
+
+// SmallVec has branching overhead on every operation
+// (must check if inline or heap)
+
+// Profile to verify benefit!
+```
+
+## When to Use SmallVec vs Alternatives
+
+| Situation | Use |
+|-----------|-----|
+| Usually small, sometimes large | `SmallVec<[T; N]>` |
+| Always small, fixed max | `ArrayVec<T, N>` |
+| Rarely grows past initial | `Vec::with_capacity` |
+| No `unsafe` allowed | `TinyVec` |
+| Often empty | `ThinVec` |
+
+## ArrayVec Alternative
+
+```rust
+use arrayvec::ArrayVec;
+
+// Fixed maximum capacity, never heap allocates
+// Panics if you exceed capacity
+fn parse_rgb(s: &str) -> ArrayVec<u8, 3> {
+    let mut components = ArrayVec::new();
+    for part in s.split(',').take(3) {
+        components.push(part.parse().unwrap());
+    }
+    components
+}
+```
+
+## TinyVec (No Unsafe)
+
+```rust
+use tinyvec::{tiny_vec, TinyVec};
+
+// Same concept as SmallVec but 100% safe code
+let v: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3];
+```
+
+## See Also
+
+- [mem-arrayvec](mem-arrayvec.md) - Use ArrayVec for fixed-max collections
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate when size is known
+- [mem-thinvec](mem-thinvec.md) - Use ThinVec for often-empty vectors

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-thinvec.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-thinvec.md
@@ -1,0 +1,142 @@
+# mem-thinvec
+
+> Use `ThinVec<T>` for nullable collections with minimal overhead
+
+## Why It Matters
+
+Standard `Vec<T>` is 24 bytes even when empty. `ThinVec` from Mozilla's `thin_vec` crate uses a single pointer (8 bytes), storing length and capacity inline with the heap allocation. For Option<Vec<T>> patterns or structs with many optional vecs, this significantly reduces memory overhead.
+
+## Bad
+
+```rust
+struct TreeNode {
+    value: i32,
+    // Each node pays 24 bytes for children, even leaves
+    children: Vec<TreeNode>,  // Most nodes are leaves with empty Vec
+}
+
+// Or using Option<Vec<T>>
+struct SparseData {
+    // Option<Vec> = 24 bytes (Vec is never null-pointer optimized)
+    tags: Option<Vec<String>>,
+    metadata: Option<Vec<Metadata>>,
+    // 48 bytes for usually-None fields
+}
+```
+
+## Good
+
+```rust
+use thin_vec::ThinVec;
+
+struct TreeNode {
+    value: i32,
+    // Empty ThinVec is just a null pointer - 8 bytes
+    children: ThinVec<TreeNode>,
+}
+
+struct SparseData {
+    // ThinVec empty = 8 bytes each
+    tags: ThinVec<String>,
+    metadata: ThinVec<Metadata>,
+    // 16 bytes vs 48 bytes
+}
+```
+
+## Memory Layout
+
+```rust
+use std::mem::size_of;
+
+// Standard Vec: always 24 bytes
+assert_eq!(size_of::<Vec<u8>>(), 24);
+assert_eq!(size_of::<Option<Vec<u8>>>(), 24);  // No NPO benefit
+
+// ThinVec: 8 bytes (one pointer)
+use thin_vec::ThinVec;
+assert_eq!(size_of::<ThinVec<u8>>(), 8);
+assert_eq!(size_of::<Option<ThinVec<u8>>>(), 8);  // Option is free!
+```
+
+## ThinVec vs Vec
+
+| Feature | `Vec<T>` | `ThinVec<T>` |
+|---------|----------|--------------|
+| Size (empty) | 24 bytes | 8 bytes |
+| Size (non-empty) | 24 bytes | 8 bytes (header on heap) |
+| Option<T> optimization | No | Yes |
+| Cache locality | Better (len/cap on stack) | Worse (len/cap on heap) |
+| Iteration speed | Faster | Slightly slower |
+| API compatibility | Full | Vec-like |
+
+## When to Use ThinVec
+
+```rust
+// ✅ Good: Many instances, often empty
+struct SparseGraph {
+    nodes: Vec<Node>,
+    // Most edges lists are empty or small
+    edges: Vec<ThinVec<EdgeId>>,  // Saves 16 bytes per node
+}
+
+// ✅ Good: Nullable collection field
+struct Document {
+    content: String,
+    attachments: ThinVec<Attachment>,  // Often empty
+}
+
+// ❌ Avoid: Hot loops, performance-critical iteration
+fn process_hot_path(data: &ThinVec<Item>) {
+    // Every length check goes through pointer indirection
+    for item in data {  // Vec would be faster here
+        process(item);
+    }
+}
+
+// ❌ Avoid: Few instances
+fn main() {
+    let single_vec: ThinVec<i32> = ThinVec::new();
+    // Saving 16 bytes once is meaningless
+}
+```
+
+## API Compatibility
+
+```rust
+use thin_vec::{ThinVec, thin_vec};
+
+// Constructor macro
+let v: ThinVec<i32> = thin_vec![1, 2, 3];
+
+// Familiar Vec-like API
+let mut v = ThinVec::new();
+v.push(1);
+v.push(2);
+v.extend([3, 4, 5]);
+v.pop();
+
+// Iteration
+for item in &v {
+    println!("{}", item);
+}
+
+// Slicing
+let slice: &[i32] = &v[..];
+
+// Conversion
+let vec: Vec<i32> = v.into();
+let thin: ThinVec<i32> = vec.into();
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+thin-vec = "0.2"
+```
+
+## See Also
+
+- [mem-smallvec](./mem-smallvec.md) - Stack-allocated small vecs
+- [mem-boxed-slice](./mem-boxed-slice.md) - Fixed-size heap slices
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation strategies

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-with-capacity.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-with-capacity.md
@@ -1,0 +1,156 @@
+# mem-with-capacity
+
+> Use `with_capacity()` when size is known
+
+## Why It Matters
+
+When you know (or can estimate) the final size of a collection, pre-allocating avoids multiple reallocations as it grows. Each reallocation copies all existing elements, so avoiding them can dramatically improve performance.
+
+## Bad
+
+```rust
+// Vec starts at capacity 0, reallocates at 4, 8, 16, 32...
+let mut results = Vec::new();
+for i in 0..1000 {
+    results.push(process(i));  // ~10 reallocations!
+}
+
+// String grows similarly
+let mut output = String::new();
+for word in words {
+    output.push_str(word);
+    output.push(' ');
+}
+
+// HashMap default capacity is small
+let mut map = HashMap::new();
+for (k, v) in pairs {  // Many reallocations
+    map.insert(k, v);
+}
+```
+
+## Good
+
+```rust
+// Pre-allocate exact size
+let mut results = Vec::with_capacity(1000);
+for i in 0..1000 {
+    results.push(process(i));  // Zero reallocations!
+}
+
+// Or use collect with size hint (iterator provides capacity)
+let results: Vec<_> = (0..1000).map(process).collect();
+
+// Pre-allocate string
+let estimated_len = words.iter().map(|w| w.len() + 1).sum();
+let mut output = String::with_capacity(estimated_len);
+for word in words {
+    output.push_str(word);
+    output.push(' ');
+}
+
+// Pre-allocate HashMap
+let mut map = HashMap::with_capacity(pairs.len());
+for (k, v) in pairs {
+    map.insert(k, v);
+}
+```
+
+## Collection Capacity Methods
+
+```rust
+// Vec
+let mut v = Vec::with_capacity(100);
+v.reserve(50);        // Ensure at least 50 more slots
+v.reserve_exact(50);  // Ensure exactly 50 more (no extra)
+v.shrink_to_fit();    // Release unused capacity
+
+// String
+let mut s = String::with_capacity(100);
+s.reserve(50);
+
+// HashMap / HashSet
+let mut m = HashMap::with_capacity(100);
+m.reserve(50);
+
+// VecDeque
+let mut d = VecDeque::with_capacity(100);
+```
+
+## Estimating Capacity
+
+```rust
+// From iterator length
+fn collect_results(items: &[Item]) -> Vec<Output> {
+    let mut results = Vec::with_capacity(items.len());
+    for item in items {
+        results.push(process(item));
+    }
+    results
+}
+
+// From filter estimate (if ~10% pass filter)
+fn filter_valid(items: &[Item]) -> Vec<&Item> {
+    let mut valid = Vec::with_capacity(items.len() / 10);
+    for item in items {
+        if item.is_valid() {
+            valid.push(item);
+        }
+    }
+    valid
+}
+
+// String from parts
+fn join_with_sep(parts: &[&str], sep: &str) -> String {
+    let total_len: usize = parts.iter().map(|p| p.len()).sum();
+    let sep_len = if parts.is_empty() { 0 } else { sep.len() * (parts.len() - 1) };
+    
+    let mut result = String::with_capacity(total_len + sep_len);
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            result.push_str(sep);
+        }
+        result.push_str(part);
+    }
+    result
+}
+```
+
+## Evidence from Production Code
+
+From fd (file finder):
+```rust
+// https://github.com/sharkdp/fd/blob/master/src/walk.rs
+struct ReceiverBuffer<'a, W> {
+    buffer: Vec<DirEntry>,
+    // ...
+}
+
+impl<'a, W: Write> ReceiverBuffer<'a, W> {
+    fn new(...) -> Self {
+        Self {
+            buffer: Vec::with_capacity(MAX_BUFFER_LENGTH),
+            // ...
+        }
+    }
+}
+```
+
+## When to Skip
+
+```rust
+// Unknown size, small expected
+let mut small: Vec<i32> = Vec::new();  // OK for small collections
+
+// Using collect() with good size_hint
+let v: Vec<_> = iter.collect();  // collect() uses size_hint
+
+// Capacity overhead exceeds benefit
+let mut rarely_used = Vec::new();  // OK if rarely grown
+```
+
+## See Also
+
+- [mem-reuse-collections](mem-reuse-collections.md) - Reuse collections with clear()
+- [mem-smallvec](mem-smallvec.md) - Use SmallVec for usually-small collections
+- [perf-extend-batch](perf-extend-batch.md) - Use extend() for batch insertions

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-write-over-format.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-write-over-format.md
@@ -1,0 +1,172 @@
+# mem-write-over-format
+
+> Use `write!()` into existing buffers instead of `format!()` allocations
+
+## Why It Matters
+
+`format!()` always allocates a new `String`. In hot paths or loops, these allocations add up. `write!()` writes directly into an existing buffer, reusing its capacity. For high-frequency formatting operations, this can eliminate significant allocator overhead.
+
+## Bad
+
+```rust
+fn log_event(event: &Event, output: &mut Vec<u8>) {
+    // format! allocates a new String every call
+    let line = format!(
+        "[{}] {}: {}\n",
+        event.timestamp,
+        event.level,
+        event.message
+    );
+    output.extend_from_slice(line.as_bytes());
+}
+
+fn build_response(items: &[Item]) -> String {
+    let mut result = String::new();
+    
+    for item in items {
+        // format! allocates for each item
+        result.push_str(&format!("{}: {}\n", item.name, item.value));
+    }
+    
+    result
+}
+```
+
+## Good
+
+```rust
+use std::fmt::Write;
+
+fn log_event(event: &Event, output: &mut Vec<u8>) {
+    use std::io::Write;
+    // write! to Vec<u8> directly, no intermediate allocation
+    write!(
+        output,
+        "[{}] {}: {}\n",
+        event.timestamp,
+        event.level,
+        event.message
+    ).unwrap();
+}
+
+fn build_response(items: &[Item]) -> String {
+    use std::fmt::Write;
+    
+    let mut result = String::with_capacity(items.len() * 64);
+    
+    for item in items {
+        // write! into existing String, reuses capacity
+        write!(&mut result, "{}: {}\n", item.name, item.value).unwrap();
+    }
+    
+    result
+}
+```
+
+## Write Trait Varieties
+
+```rust
+// std::fmt::Write - for String, &mut String
+use std::fmt::Write as FmtWrite;
+let mut s = String::new();
+write!(&mut s, "Hello {}", 42).unwrap();
+
+// std::io::Write - for Vec<u8>, File, TcpStream, etc.
+use std::io::Write as IoWrite;
+let mut v: Vec<u8> = Vec::new();
+write!(&mut v, "Hello {}", 42).unwrap();
+
+// Both can fail in principle, but String/Vec never fail
+// Still need .unwrap() due to Result return type
+```
+
+## Reusable Formatting Buffer
+
+```rust
+use std::fmt::Write;
+
+struct Formatter {
+    buffer: String,
+}
+
+impl Formatter {
+    fn new() -> Self {
+        Self { buffer: String::with_capacity(1024) }
+    }
+    
+    fn format_event(&mut self, event: &Event) -> &str {
+        self.buffer.clear();  // Reuse allocation
+        write!(
+            &mut self.buffer, 
+            "[{}] {}",
+            event.timestamp, 
+            event.message
+        ).unwrap();
+        &self.buffer
+    }
+}
+
+// Usage
+let mut formatter = Formatter::new();
+for event in events {
+    let formatted = formatter.format_event(event);
+    send_log(formatted);
+}
+```
+
+## writeln! for Lines
+
+```rust
+use std::fmt::Write;
+
+let mut output = String::new();
+
+// writeln! adds newline automatically
+writeln!(&mut output, "Line 1: {}", value1).unwrap();
+writeln!(&mut output, "Line 2: {}", value2).unwrap();
+
+// Equivalent to
+write!(&mut output, "Line 1: {}\n", value1).unwrap();
+```
+
+## When format! Is Fine
+
+```rust
+// One-time formatting, not in loop
+let message = format!("Starting server on port {}", port);
+log::info!("{}", message);
+
+// Return value (can't return reference to local buffer)
+fn describe(item: &Item) -> String {
+    format!("{}: {}", item.name, item.value)  // Must allocate
+}
+
+// Debug/error paths (not hot)
+if condition {
+    panic!("Unexpected: {}", format!("details: {:?}", debug_info));
+}
+```
+
+## Benchmark Difference
+
+```rust
+// format! in loop: ~500ns per iteration (allocation heavy)
+for i in 0..1000 {
+    let s = format!("item-{}", i);
+    process(&s);
+}
+
+// write! with reuse: ~50ns per iteration (no allocation)
+let mut buf = String::with_capacity(32);
+for i in 0..1000 {
+    buf.clear();
+    write!(&mut buf, "item-{}", i).unwrap();
+    process(&buf);
+}
+```
+
+## See Also
+
+- [mem-avoid-format](./mem-avoid-format.md) - General format! avoidance patterns
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing buffers in loops
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating string capacity

--- a/.cursor/skills/rust-skills-leonardomso/rules/mem-zero-copy.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/mem-zero-copy.md
@@ -1,0 +1,164 @@
+# mem-zero-copy
+
+> Use zero-copy patterns with slices and `Bytes`
+
+## Why It Matters
+
+Zero-copy means working with data without copying it. Instead of allocating new memory and copying bytes, you work with references to the original data. This dramatically reduces memory usage and improves performance, especially for large data.
+
+## Bad
+
+```rust
+// Copies every line into a new String
+fn get_lines(data: &str) -> Vec<String> {
+    data.lines()
+        .map(|line| line.to_string())  // Allocates!
+        .collect()
+}
+
+// Copies the entire buffer
+fn process_packet(buffer: &[u8]) -> Vec<u8> {
+    let header = buffer[0..16].to_vec();  // Copy!
+    let body = buffer[16..].to_vec();      // Copy!
+    // Process...
+    [header, body].concat()  // Another copy!
+}
+```
+
+## Good
+
+```rust
+// Zero-copy: returns references to original data
+fn get_lines(data: &str) -> Vec<&str> {
+    data.lines().collect()  // Just pointers!
+}
+
+// Zero-copy with slices
+fn process_packet(buffer: &[u8]) -> (&[u8], &[u8]) {
+    let header = &buffer[0..16];  // Just a pointer + length
+    let body = &buffer[16..];     // Just a pointer + length
+    (header, body)
+}
+```
+
+## Using bytes::Bytes
+
+```rust
+use bytes::Bytes;
+
+// Bytes provides zero-copy slicing with reference counting
+let data = Bytes::from("hello world");
+
+// Slicing doesn't copy - just increments refcount
+let hello = data.slice(0..5);   // Zero-copy!
+let world = data.slice(6..11); // Zero-copy!
+
+// Both hello and world share the underlying allocation
+// Memory is freed when all references are dropped
+```
+
+## Real-World Pattern from Deno
+
+```rust
+// https://github.com/denoland/deno/blob/main/ext/http/lib.rs
+fn method_to_cow(method: &http::Method) -> Cow<'static, str> {
+    match *method {
+        Method::GET => Cow::Borrowed("GET"),      // Zero-copy
+        Method::POST => Cow::Borrowed("POST"),    // Zero-copy
+        Method::PUT => Cow::Borrowed("PUT"),      // Zero-copy
+        _ => Cow::Owned(method.to_string()),      // Only copies for rare methods
+    }
+}
+```
+
+## Zero-Copy Parsing
+
+```rust
+// Bad: Copies each parsed field
+struct ParsedBad {
+    name: String,
+    value: String,
+}
+
+fn parse_bad(input: &str) -> ParsedBad {
+    let (name, value) = input.split_once('=').unwrap();
+    ParsedBad {
+        name: name.to_string(),   // Copy!
+        value: value.to_string(), // Copy!
+    }
+}
+
+// Good: References into original string
+struct Parsed<'a> {
+    name: &'a str,
+    value: &'a str,
+}
+
+fn parse_good(input: &str) -> Parsed<'_> {
+    let (name, value) = input.split_once('=').unwrap();
+    Parsed { name, value }  // Zero-copy!
+}
+```
+
+## Combining with Cow
+
+```rust
+use std::borrow::Cow;
+
+// Zero-copy when possible, copy when needed
+fn normalize<'a>(input: &'a str) -> Cow<'a, str> {
+    if input.contains('\t') {
+        // Must copy to modify
+        Cow::Owned(input.replace('\t', "    "))
+    } else {
+        // Zero-copy reference
+        Cow::Borrowed(input)
+    }
+}
+```
+
+## memchr for Fast Searching
+
+```rust
+use memchr::memchr;
+
+// Fast byte search using SIMD
+fn find_newline(data: &[u8]) -> Option<usize> {
+    memchr(b'\n', data)  // SIMD-accelerated, no allocation
+}
+
+// Find all occurrences
+use memchr::memchr_iter;
+
+fn count_newlines(data: &[u8]) -> usize {
+    memchr_iter(b'\n', data).count()
+}
+```
+
+## When Zero-Copy Isn't Possible
+
+```rust
+// Need to modify data - must copy
+fn uppercase(s: &str) -> String {
+    s.to_uppercase()  // Creates new String
+}
+
+// Need data to outlive source
+fn store_for_later(s: &str) -> String {
+    s.to_string()  // Must copy for ownership
+}
+
+// Cross-thread transfer (without Arc)
+fn send_to_thread(data: &[u8]) {
+    let owned = data.to_vec();  // Must copy
+    std::thread::spawn(move || {
+        process(&owned);
+    });
+}
+```
+
+## See Also
+
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for conditional ownership
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning
+- [mem-arena-allocator](mem-arena-allocator.md) - Arena allocators for batch operations

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-acronym-word.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-acronym-word.md
@@ -1,0 +1,99 @@
+# name-acronym-word
+
+> Treat acronyms as words in identifiers: `HttpServer`, not `HTTPServer`
+
+## Why It Matters
+
+When acronyms are written in ALL CAPS within identifiers, word boundaries become unclear: is `HTTPSHandler` "HTTPS Handler" or "HTTP SHandler"? Treating acronyms as words (`HttpsHandler`) maintains clear word boundaries and follows Rust convention. The standard library uses this consistently.
+
+## Bad
+
+```rust
+// ALL CAPS acronyms - unclear word boundaries
+struct HTTPServer { ... }      // HTTP + Server or H + TTP + Server?
+struct TCPIPConnection { ... } // TCP + IP? Or other splits?
+struct JSONParser { ... }
+struct XMLHTTPRequest { ... }  // Very confusing
+
+fn parseJSON(input: &str) { ... }
+fn connectTCP(addr: &str) { ... }
+```
+
+## Good
+
+```rust
+// Acronyms as words - clear boundaries
+struct HttpServer { ... }      // Http + Server
+struct TcpIpConnection { ... } // Tcp + Ip + Connection
+struct JsonParser { ... }
+struct XmlHttpRequest { ... }
+
+fn parse_json(input: &str) { ... }
+fn connect_tcp(addr: &str) { ... }
+
+// More examples
+struct Uuid { ... }            // Not UUID
+struct Uri { ... }             // Not URI
+struct Url { ... }             // Not URL
+struct Html { ... }            // Not HTML
+struct Css { ... }             // Not CSS
+struct Api { ... }             // Not API
+```
+
+## Standard Library Examples
+
+```rust
+// std uses acronyms as words
+std::net::TcpStream            // Not TCPStream
+std::net::TcpListener          // Not TCPListener
+std::net::UdpSocket            // Not UDPSocket
+std::net::IpAddr               // Not IPAddr
+std::io::IoError               // Not IOError (though Io is acceptable too)
+```
+
+## Two-Letter Acronyms
+
+```rust
+// Two-letter acronyms can go either way
+struct Io { ... }    // or IO - both acceptable
+struct Id { ... }    // or ID - both acceptable
+
+// Preference: treat as word for consistency
+struct IoHandler { ... }     // Preferred
+struct IdGenerator { ... }   // Preferred
+```
+
+## In snake_case
+
+```rust
+// Acronyms become lowercase in snake_case
+fn parse_json() { ... }
+fn connect_tcp() { ... }
+fn generate_uuid() { ... }
+fn fetch_http() { ... }
+fn encode_url() { ... }
+
+// Variables
+let json_response = fetch_json();
+let tcp_connection = connect_tcp();
+let user_id = generate_uuid();
+```
+
+## Mixed Cases
+
+```rust
+// When acronym is part of compound
+struct HttpsConnection { ... }   // Https (not HTTPS)
+struct Utf8String { ... }        // Utf8 (not UTF8)
+struct Base64Encoder { ... }     // Base64 as word
+
+// Multiple acronyms
+struct JsonApiClient { ... }     // Json + Api + Client
+struct RestApiHandler { ... }    // Rest + Api + Handler
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming conventions
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming conventions
+- [name-consts-screaming](./name-consts-screaming.md) - Constant naming

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-as-free.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-as-free.md
@@ -1,0 +1,104 @@
+# name-as-free
+
+> `as_` prefix: free reference conversion
+
+## Why It Matters
+
+Consistent naming helps users understand API cost. `as_` prefix signals a free (O(1), no allocation) conversion that returns a reference. This convention is used throughout the standard library.
+
+## The Convention
+
+| Prefix | Cost | Ownership | Example |
+|--------|------|-----------|---------|
+| `as_` | Free | `&T -> &U` | `str::as_bytes()` |
+| `to_` | Expensive | `&T -> U` | `str::to_lowercase()` |
+| `into_` | Variable | `T -> U` | `String::into_bytes()` |
+
+## Examples
+
+```rust
+impl MyString {
+    // as_ - free reference conversion
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+    
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl Wrapper<T> {
+    // as_ - returns reference to inner
+    pub fn as_inner(&self) -> &T {
+        &self.inner
+    }
+    
+    pub fn as_inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// String
+let s = String::from("hello");
+let bytes: &[u8] = s.as_bytes();    // Free, returns &[u8]
+let str_ref: &str = s.as_str();     // Free, returns &str
+
+// Vec
+let v = vec![1, 2, 3];
+let slice: &[i32] = v.as_slice();   // Free, returns &[i32]
+
+// Path
+let p = PathBuf::from("/home");
+let path: &Path = p.as_path();      // Free, returns &Path
+
+// OsString
+let os = OsString::from("hello");
+let os_str: &OsStr = os.as_os_str(); // Free, returns &OsStr
+```
+
+## Bad
+
+```rust
+impl MyType {
+    // BAD: as_ but allocates
+    pub fn as_string(&self) -> String {
+        format!("{}", self.value)  // Allocates! Should be to_string()
+    }
+    
+    // BAD: as_ but expensive
+    pub fn as_processed(&self) -> &ProcessedData {
+        // Actually does expensive computation
+    }
+}
+```
+
+## Good
+
+```rust
+impl MyType {
+    // GOOD: Free reference
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+    
+    // GOOD: to_ signals allocation
+    pub fn to_string(&self) -> String {
+        format!("{}", self.value)
+    }
+    
+    // GOOD: into_ signals ownership transfer
+    pub fn into_inner(self) -> Inner {
+        self.inner
+    }
+}
+```
+
+## See Also
+
+- [name-to-expensive](name-to-expensive.md) - `to_` prefix for expensive conversions
+- [name-into-ownership](name-into-ownership.md) - `into_` prefix for ownership transfer

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-consts-screaming.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-consts-screaming.md
@@ -1,0 +1,94 @@
+# name-consts-screaming
+
+> Use `SCREAMING_SNAKE_CASE` for constants and statics
+
+## Why It Matters
+
+Constants and statics are special—they're known at compile time and have program-wide lifetime. `SCREAMING_SNAKE_CASE` makes them visually distinct from runtime variables. This convention is enforced by the compiler and universally expected.
+
+## Bad
+
+```rust
+// lowercase/camelCase constants - compiler warns
+const maxConnections: u32 = 100;  // warning
+const default_timeout: u64 = 30;  // warning
+static globalCounter: AtomicU64 = AtomicU64::new(0);  // warning
+```
+
+## Good
+
+```rust
+// SCREAMING_SNAKE_CASE for constants
+const MAX_CONNECTIONS: u32 = 100;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const BUFFER_SIZE: usize = 4096;
+
+// SCREAMING_SNAKE_CASE for statics
+static GLOBAL_COUNTER: AtomicU64 = AtomicU64::new(0);
+static CONFIG: OnceLock<Config> = OnceLock::new();
+
+// Type-level constants in impl blocks
+impl Buffer {
+    const INITIAL_CAPACITY: usize = 1024;
+    const MAX_CAPACITY: usize = 1024 * 1024;
+}
+```
+
+## Associated Constants
+
+```rust
+trait Limit {
+    const MAX: usize;
+    const MIN: usize;
+}
+
+impl Limit for SmallBuffer {
+    const MAX: usize = 256;
+    const MIN: usize = 16;
+}
+
+// Generic associated constants
+struct Container<T> {
+    data: Vec<T>,
+}
+
+impl<T> Container<T> {
+    const EMPTY: Self = Self { data: Vec::new() };
+}
+```
+
+## Environment and Config
+
+```rust
+// Environment variable names
+const ENV_DATABASE_URL: &str = "DATABASE_URL";
+const ENV_LOG_LEVEL: &str = "LOG_LEVEL";
+
+// Configuration keys
+const CONFIG_TIMEOUT_SECONDS: &str = "timeout_seconds";
+const CONFIG_MAX_RETRIES: &str = "max_retries";
+```
+
+## Lazy Static / OnceLock
+
+```rust
+use std::sync::OnceLock;
+
+// Global configuration
+static CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+// Compiled regex
+static EMAIL_REGEX: OnceLock<Regex> = OnceLock::new();
+
+fn get_email_regex() -> &'static Regex {
+    EMAIL_REGEX.get_or_init(|| {
+        Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap()
+    })
+}
+```
+
+## See Also
+
+- [name-funcs-snake](./name-funcs-snake.md) - Function/variable naming
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [type-newtype-ids](./type-newtype-ids.md) - Type-safe constants

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-crate-no-rs.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-crate-no-rs.md
@@ -1,0 +1,78 @@
+# name-crate-no-rs
+
+> Don't suffix crate names with `-rs` or `-rust`
+
+## Why It Matters
+
+Adding `-rs` or `-rust` to crate names is redundant—you're already on crates.io, it's obviously Rust. These suffixes waste characters, clutter the namespace, and can make crate names harder to type. The Rust community discourages this pattern.
+
+## Bad
+
+```toml
+# Cargo.toml
+[package]
+name = "json-parser-rs"    # Redundant -rs
+name = "my-lib-rust"       # Redundant -rust
+name = "http-client-rs"    # We know it's Rust
+name = "rust-sqlite"       # rust- prefix equally bad
+```
+
+## Good
+
+```toml
+# Cargo.toml
+[package]
+name = "json-parser"
+name = "my-lib"
+name = "http-client"
+name = "sqlite-wrapper"
+
+# Real crate examples (no -rs):
+# serde (not serde-rs)
+# tokio (not tokio-rs)
+# reqwest (not reqwest-rs)
+# clap (not clap-rs)
+```
+
+## When Context Is Needed
+
+```toml
+# If you're porting a library from another language:
+name = "python-ast"        # Describes what it's for, not what it's written in
+
+# If you're providing bindings:
+name = "openssl"           # The Rust crate IS the Rust interface
+
+# Platform-specific:
+name = "windows-sys"       # Platform, not language
+```
+
+## Repository Naming
+
+```
+# GitHub repos don't need -rs either
+github.com/user/my-library      # Good
+github.com/user/my-library-rs   # Unnecessary
+
+# Though some do for disambiguation from other language versions
+github.com/rust-lang/rust       # The rust repo itself uses "rust"
+```
+
+## Exceptions
+
+```toml
+# Rare cases where disambiguation matters:
+# - If there's a widely-known non-Rust project with the same name
+# - Official Rust project repositories (rust-lang org)
+
+# But even then, consider alternatives:
+name = "fancy-lib"           # Instead of fancy-rs
+name = "better-json"         # Instead of json-rust
+name = "my-serde-impl"       # Instead of serde-rs-fork
+```
+
+## See Also
+
+- [proj-workspace-deps](./proj-workspace-deps.md) - Cargo configuration
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Package metadata
+- [name-funcs-snake](./name-funcs-snake.md) - Naming conventions

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-funcs-snake.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-funcs-snake.md
@@ -1,0 +1,76 @@
+# name-funcs-snake
+
+> Use `snake_case` for functions, methods, variables, and modules
+
+## Why It Matters
+
+Rust uses `snake_case` for "value-level" names—functions, methods, variables, modules. This convention is enforced by the compiler and distinguishes runtime entities from types. Consistent naming makes code scannable and predictable.
+
+## Bad
+
+```rust
+// CamelCase functions - compiler warns
+fn calculateTotal() -> f64 { ... }  // warning: function `calculateTotal` should have a snake case name
+fn getUserName() -> String { ... }  // warning
+
+// Inconsistent naming
+fn get_user() -> User { ... }
+fn fetchOrder() -> Order { ... }  // Mixed conventions
+```
+
+## Good
+
+```rust
+// snake_case for functions
+fn calculate_total() -> f64 { ... }
+fn get_user_name() -> String { ... }
+fn fetch_order() -> Order { ... }
+
+// snake_case for methods
+impl User {
+    fn full_name(&self) -> String { ... }
+    fn is_active(&self) -> bool { ... }
+    fn set_email(&mut self, email: &str) { ... }
+}
+
+// snake_case for variables
+let user_count = 42;
+let max_connections = 100;
+let is_valid = true;
+
+// snake_case for modules
+mod user_service;
+mod http_client;
+mod json_parser;
+```
+
+## Acronyms in snake_case
+
+```rust
+// Lowercase acronyms in snake_case
+fn parse_json() -> Json { ... }   // Not parse_JSON
+fn connect_tcp() -> TcpStream { ... }   // Not connect_TCP
+fn generate_uuid() -> Uuid { ... }      // Not generate_UUID
+
+let http_response = fetch();
+let json_data = parse();
+```
+
+## Local Variables
+
+```rust
+fn process_data(input_data: &[u8]) -> Result<Output, Error> {
+    let raw_bytes = input_data;
+    let decoded_string = decode(raw_bytes)?;
+    let parsed_value = parse(&decoded_string)?;
+    let final_result = transform(parsed_value)?;
+    
+    Ok(final_result)
+}
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [name-consts-screaming](./name-consts-screaming.md) - Constant naming
+- [name-lifetime-short](./name-lifetime-short.md) - Lifetime naming

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-into-ownership.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-into-ownership.md
@@ -1,0 +1,123 @@
+# name-into-ownership
+
+> Use `into_` prefix for ownership-consuming conversions
+
+## Why It Matters
+
+The `into_` prefix signals "this method consumes self and returns something else." The original value is moved and no longer usable. This ownership transfer is usually cheap (no allocation), but the caller loses access to the original. Clear naming prevents "use after move" confusion.
+
+## Bad
+
+```rust
+impl Wrapper {
+    // Misleading: doesn't indicate ownership transfer
+    fn get_inner(self) -> Inner {  
+        self.inner
+    }
+    
+    // Misleading: suggests borrowing
+    fn as_inner(self) -> Inner {  // Takes self by value!
+        self.inner
+    }
+}
+```
+
+## Good
+
+```rust
+impl Wrapper {
+    // into_ clearly shows ownership transfer
+    fn into_inner(self) -> Inner {
+        self.inner
+    }
+}
+
+// Usage is clear
+let wrapper = Wrapper::new(inner);
+let inner = wrapper.into_inner();  // wrapper is consumed
+// wrapper.foo();  // Error: use of moved value
+```
+
+## Standard Library Examples
+
+```rust
+// All consume self and return owned data
+let string: String = "hello".to_string();
+let bytes: Vec<u8> = string.into_bytes();  // String consumed
+
+let path = PathBuf::from("/foo");
+let os_string: OsString = path.into_os_string();  // PathBuf consumed
+
+let boxed: Box<[i32]> = vec![1, 2, 3].into_boxed_slice();  // Vec consumed
+
+let vec: Vec<u8> = boxed.into_vec();  // Box consumed
+```
+
+## into_iter() Pattern
+
+```rust
+let vec = vec![1, 2, 3];
+
+// into_iter consumes the collection
+for item in vec.into_iter() {  // or just: for item in vec
+    // item is i32, not &i32
+}
+// vec is consumed, can't use anymore
+
+// Contrast with iter() which borrows
+let vec = vec![1, 2, 3];
+for item in vec.iter() {
+    // item is &i32
+}
+// vec still usable
+```
+
+## IntoIterator Trait
+
+```rust
+impl IntoIterator for MyCollection {
+    type Item = Element;
+    type IntoIter = std::vec::IntoIter<Element>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()  // Consumes self
+    }
+}
+```
+
+## Conversion Prefix Summary
+
+```rust
+struct Buffer {
+    data: Vec<u8>,
+    name: String,
+}
+
+impl Buffer {
+    // as_ : free borrow, returns reference
+    fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+    
+    // to_ : allocates, creates new value
+    fn to_vec(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+    
+    // into_ : consumes self, usually cheap
+    fn into_inner(self) -> Vec<u8> {
+        self.data
+    }
+    
+    // into_ : can destructure into parts
+    fn into_parts(self) -> (Vec<u8>, String) {
+        (self.data, self.name)
+    }
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Borrowing conversions
+- [name-to-expensive](./name-to-expensive.md) - Allocating conversions
+- [api-from-not-into](./api-from-not-into.md) - From trait implementation

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-is-has-bool.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-is-has-bool.md
@@ -1,0 +1,127 @@
+# name-is-has-bool
+
+> Use `is_`, `has_`, `can_`, `should_` prefixes for boolean-returning methods
+
+## Why It Matters
+
+Boolean methods answer yes/no questions. Prefixes like `is_`, `has_`, `can_` make the question explicit, so code reads naturally: `if user.is_active()`, `if buffer.has_remaining()`. Without prefixes, boolean methods are ambiguous and require reading documentation.
+
+## Bad
+
+```rust
+impl User {
+    // Unclear: does this check or set?
+    fn active(&self) -> bool { ... }
+    
+    // Unclear: does this delete or check?
+    fn deleted(&self) -> bool { ... }
+    
+    // Unclear return type
+    fn admin(&self) -> bool { ... }
+}
+
+// Reading code is confusing
+if user.active() { ... }  // Is this checking or activating?
+```
+
+## Good
+
+```rust
+impl User {
+    // Clear: answers "is the user active?"
+    fn is_active(&self) -> bool { ... }
+    
+    // Clear: answers "is the user deleted?"
+    fn is_deleted(&self) -> bool { ... }
+    
+    // Clear: answers "is the user an admin?"
+    fn is_admin(&self) -> bool { ... }
+    
+    // Clear: answers "does the user have permission X?"
+    fn has_permission(&self, perm: Permission) -> bool { ... }
+    
+    // Clear: answers "can the user edit?"
+    fn can_edit(&self) -> bool { ... }
+}
+
+// Reads naturally
+if user.is_active() && user.has_permission(Permission::Write) {
+    // ...
+}
+```
+
+## Common Prefixes
+
+| Prefix | Use For | Example |
+|--------|---------|---------|
+| `is_` | State/property check | `is_empty()`, `is_valid()`, `is_some()` |
+| `has_` | Possession/containment | `has_key()`, `has_children()`, `has_remaining()` |
+| `can_` | Capability/permission | `can_read()`, `can_write()`, `can_execute()` |
+| `should_` | Recommendation/policy | `should_retry()`, `should_cache()` |
+| `needs_` | Requirement | `needs_update()`, `needs_auth()` |
+| `will_` | Future action | `will_block()`, `will_overflow()` |
+
+## Standard Library Examples
+
+```rust
+// is_ prefix
+vec.is_empty()
+option.is_some()
+option.is_none()
+result.is_ok()
+result.is_err()
+char.is_alphabetic()
+str.is_ascii()
+path.is_file()
+path.is_dir()
+
+// has_ prefix (less common in std)
+iterator.has_next()  // conceptual
+
+// Checking methods
+str.contains("foo")      // Not is_ because takes argument
+str.starts_with("bar")   // Descriptive verb phrase
+str.ends_with("baz")
+```
+
+## Negation
+
+```rust
+// Prefer positive form with caller negation
+if !user.is_active() { ... }
+
+// Rather than negative method
+if user.is_inactive() { ... }  // Avoid double negatives: !is_inactive()
+
+// Exception: when negative is the common case
+fn is_empty(&self) -> bool { ... }     // Checking for empty is common
+fn is_not_empty(&self) -> bool { ... } // Rarely needed, use !is_empty()
+```
+
+## Boolean Fields
+
+```rust
+struct Config {
+    // Field names can omit prefix
+    enabled: bool,
+    verbose: bool,
+    debug: bool,
+}
+
+impl Config {
+    // But methods should have prefix
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+    
+    fn is_verbose(&self) -> bool {
+        self.verbose
+    }
+}
+```
+
+## See Also
+
+- [name-no-get-prefix](./name-no-get-prefix.md) - Getter naming
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming
+- [api-must-use](./api-must-use.md) - Boolean functions should be checked

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-iter-convention.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-iter-convention.md
@@ -1,0 +1,129 @@
+# name-iter-convention
+
+> Use iter/iter_mut/into_iter for iterator methods
+
+## Why It Matters
+
+Rust has a standard convention for iterator method names that signals ownership semantics. Following this convention makes APIs predictable and enables the `for item in collection` syntax to work correctly.
+
+## The Three Iterator Methods
+
+| Method | Returns | Ownership |
+|--------|---------|-----------|
+| `iter()` | `impl Iterator<Item = &T>` | Borrows collection |
+| `iter_mut()` | `impl Iterator<Item = &mut T>` | Mutably borrows |
+| `into_iter()` | `impl Iterator<Item = T>` | Consumes collection |
+
+## Implementation
+
+```rust
+struct MyCollection<T> {
+    items: Vec<T>,
+}
+
+impl<T> MyCollection<T> {
+    /// Returns an iterator over references.
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    /// Returns an iterator over mutable references.
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.items.iter_mut()
+    }
+}
+
+// IntoIterator trait for into_iter()
+impl<T> IntoIterator for MyCollection<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+// Also implement for references
+impl<'a, T> IntoIterator for &'a MyCollection<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MyCollection<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter_mut()
+    }
+}
+```
+
+## Usage
+
+```rust
+let collection = MyCollection { items: vec![1, 2, 3] };
+
+// Explicit methods
+for x in collection.iter() { }     // Borrows
+for x in collection.iter_mut() { } // Mutably borrows
+
+// IntoIterator enables for loop syntax
+for x in &collection { }      // Calls (&collection).into_iter()
+for x in &mut collection { }  // Calls (&mut collection).into_iter()
+for x in collection { }       // Consumes, calls collection.into_iter()
+```
+
+## Bad
+
+```rust
+impl MyCollection<T> {
+    // Non-standard names
+    fn elements(&self) -> impl Iterator<Item = &T> { }      // Should be iter()
+    fn get_items(&self) -> impl Iterator<Item = &T> { }     // Should be iter()
+    fn iterate(&self) -> impl Iterator<Item = &T> { }       // Should be iter()
+    fn as_iter(&self) -> impl Iterator<Item = &T> { }       // Should be iter()
+}
+```
+
+## Additional Iterator Methods
+
+```rust
+impl MyCollection<T> {
+    // Filter by predicate
+    fn iter_valid(&self) -> impl Iterator<Item = &T> {
+        self.iter().filter(|x| x.is_valid())
+    }
+    
+    // Specific slice
+    fn iter_range(&self, start: usize, end: usize) -> impl Iterator<Item = &T> {
+        self.items[start..end].iter()
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// Vec, slice, arrays
+vec.iter()      // &T
+vec.iter_mut()  // &mut T
+vec.into_iter() // T
+
+// HashMap
+map.iter()      // (&K, &V)
+map.iter_mut()  // (&K, &mut V)
+map.into_iter() // (K, V)
+map.keys()      // &K
+map.values()    // &V
+```
+
+## See Also
+
+- [name-iter-type-match](./name-iter-type-match.md) - Iterator type naming
+- [name-iter-method](./name-iter-method.md) - Iterator method names
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-iter-method.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-iter-method.md
@@ -1,0 +1,131 @@
+# name-iter-method
+
+> Name iterator methods `iter()`, `iter_mut()`, and `into_iter()` consistently
+
+## Why It Matters
+
+Rust has a strong convention for iterator method names. Following these conventions makes your types work predictably with `for` loops and iterator adapters. Users expect `iter()` for shared references, `iter_mut()` for mutable references, and `into_iter()` for owned iteration.
+
+## Bad
+
+```rust
+struct Collection<T> {
+    items: Vec<T>,
+}
+
+impl<T> Collection<T> {
+    // Non-standard names - confusing
+    fn elements(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    fn get_iterator(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    fn to_iter(self) -> impl Iterator<Item = T> {
+        self.items.into_iter()
+    }
+}
+```
+
+## Good
+
+```rust
+struct Collection<T> {
+    items: Vec<T>,
+}
+
+impl<T> Collection<T> {
+    /// Returns an iterator over references.
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    /// Returns an iterator over mutable references.
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.items.iter_mut()
+    }
+}
+
+// Implement IntoIterator for for-loop support
+impl<T> IntoIterator for Collection<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Collection<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Collection<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter_mut()
+    }
+}
+```
+
+## Iterator Convention Summary
+
+| Method | Receiver | Yields | Use Case |
+|--------|----------|--------|----------|
+| `iter()` | `&self` | `&T` | Read-only iteration |
+| `iter_mut()` | `&mut self` | `&mut T` | In-place modification |
+| `into_iter()` | `self` | `T` | Consuming iteration |
+
+## For Loop Integration
+
+```rust
+let col = Collection { items: vec![1, 2, 3] };
+
+// These all work with proper IntoIterator impls
+for item in &col {           // Calls (&col).into_iter() -> iter()
+    println!("{}", item);    // &i32
+}
+
+for item in &mut col {       // Calls (&mut col).into_iter() -> iter_mut()
+    *item += 1;              // &mut i32
+}
+
+for item in col {            // Calls col.into_iter()
+    process(item);           // i32, consumes col
+}
+```
+
+## Additional Iterator Methods
+
+```rust
+impl<T> Collection<T> {
+    // Domain-specific iterators follow similar patterns
+    
+    /// Iterates over keys (for map-like structures).
+    fn keys(&self) -> impl Iterator<Item = &K> { ... }
+    
+    /// Iterates over values.
+    fn values(&self) -> impl Iterator<Item = &V> { ... }
+    
+    /// Iterates over mutable values.
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut V> { ... }
+    
+    /// Drains elements, leaving container empty.
+    fn drain(&mut self) -> impl Iterator<Item = T> { ... }
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Conversion naming conventions
+- [api-extension-trait](./api-extension-trait.md) - Iterator extensions
+- [api-common-traits](./api-common-traits.md) - Standard trait implementations

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-iter-type-match.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-iter-type-match.md
@@ -1,0 +1,142 @@
+# name-iter-type-match
+
+> Name iterator types after their source method
+
+## Why It Matters
+
+Iterator types should match the method that creates them. `iter()` returns `Iter`, `into_iter()` returns `IntoIter`, `keys()` returns `Keys`. This naming pattern is established by the standard library and makes types predictable.
+
+## Standard Library Pattern
+
+```rust
+// Vec
+impl<T> Vec<T> {
+    fn iter(&self) -> Iter<'_, T> { }       // Returns Iter
+    fn iter_mut(&mut self) -> IterMut<'_, T> { }  // Returns IterMut
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type IntoIter = IntoIter<T>;  // Returns IntoIter
+}
+
+// HashMap
+impl<K, V> HashMap<K, V> {
+    fn iter(&self) -> Iter<'_, K, V> { }
+    fn keys(&self) -> Keys<'_, K, V> { }    // Returns Keys
+    fn values(&self) -> Values<'_, K, V> { }  // Returns Values
+    fn drain(&mut self) -> Drain<'_, K, V> { }  // Returns Drain
+}
+```
+
+## Implementation
+
+```rust
+mod my_collection {
+    pub struct MyCollection<T> {
+        items: Vec<T>,
+    }
+    
+    // Iterator types in same module
+    pub struct Iter<'a, T> {
+        inner: std::slice::Iter<'a, T>,
+    }
+    
+    pub struct IterMut<'a, T> {
+        inner: std::slice::IterMut<'a, T>,
+    }
+    
+    pub struct IntoIter<T> {
+        inner: std::vec::IntoIter<T>,
+    }
+    
+    impl<T> MyCollection<T> {
+        pub fn iter(&self) -> Iter<'_, T> {
+            Iter { inner: self.items.iter() }
+        }
+        
+        pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+            IterMut { inner: self.items.iter_mut() }
+        }
+    }
+    
+    impl<T> IntoIterator for MyCollection<T> {
+        type Item = T;
+        type IntoIter = IntoIter<T>;
+        
+        fn into_iter(self) -> IntoIter<T> {
+            IntoIter { inner: self.items.into_iter() }
+        }
+    }
+    
+    // Implement Iterator for each type
+    impl<'a, T> Iterator for Iter<'a, T> {
+        type Item = &'a T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+    
+    impl<'a, T> Iterator for IterMut<'a, T> {
+        type Item = &'a mut T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+    
+    impl<T> Iterator for IntoIter<T> {
+        type Item = T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+}
+```
+
+## Naming Convention
+
+| Method | Iterator Type |
+|--------|---------------|
+| `iter()` | `Iter` |
+| `iter_mut()` | `IterMut` |
+| `into_iter()` | `IntoIter` |
+| `keys()` | `Keys` |
+| `values()` | `Values` |
+| `values_mut()` | `ValuesMut` |
+| `drain()` | `Drain` |
+| `chunks()` | `Chunks` |
+| `windows()` | `Windows` |
+
+## Custom Iterator Methods
+
+```rust
+impl Graph {
+    // Method name -> Type name
+    fn nodes(&self) -> Nodes<'_> { }        // Custom: Nodes
+    fn edges(&self) -> Edges<'_> { }        // Custom: Edges
+    fn neighbors(&self, node: NodeId) -> Neighbors<'_> { }  // Custom: Neighbors
+}
+
+pub struct Nodes<'a> { /* ... */ }
+pub struct Edges<'a> { /* ... */ }
+pub struct Neighbors<'a> { /* ... */ }
+```
+
+## Bad
+
+```rust
+// Mismatched names
+impl MyCollection<T> {
+    fn iter(&self) -> MyCollectionIterator<'_, T> { }  // Should be Iter
+    fn keys(&self) -> KeyIterator<'_, K> { }           // Should be Keys
+}
+
+// Generic names that don't match method
+pub struct Iterator<T>;  // Conflicts with std::iter::Iterator
+pub struct I<T>;         // Too cryptic
+```
+
+## See Also
+
+- [name-iter-convention](./name-iter-convention.md) - iter/iter_mut/into_iter
+- [name-iter-method](./name-iter-method.md) - Iterator method names
+- [api-common-traits](./api-common-traits.md) - Implementing common traits

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-lifetime-short.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-lifetime-short.md
@@ -1,0 +1,86 @@
+# name-lifetime-short
+
+> Use short, conventional lifetime names: `'a`, `'b`, `'de`, `'src`
+
+## Why It Matters
+
+Lifetime parameters are ubiquitous in Rust signatures. Short names like `'a` keep signatures readable. For domain-specific lifetimes, descriptive but short names like `'src` or `'de` communicate intent without clutter. The Rust community has established conventions that aid recognition.
+
+## Bad
+
+```rust
+// Overly verbose lifetimes
+fn parse<'input_lifetime, 'output_lifetime>(
+    input: &'input_lifetime str
+) -> Result<&'output_lifetime str, Error> { ... }
+
+// Meaningless long names
+struct Parser<'parser_instance_lifetime> {
+    source: &'parser_instance_lifetime str,
+}
+```
+
+## Good
+
+```rust
+// Standard short lifetimes
+fn parse<'a>(input: &'a str) -> Result<&'a str, Error> { ... }
+
+struct Parser<'a> {
+    source: &'a str,
+}
+
+// Multiple lifetimes: 'a, 'b, 'c
+fn merge<'a, 'b>(first: &'a str, second: &'b str) -> String { ... }
+
+// Descriptive when clarity helps
+fn deserialize<'de>(input: &'de [u8]) -> Result<Value<'de>, Error> { ... }
+```
+
+## Common Lifetime Conventions
+
+| Lifetime | Convention | Example |
+|----------|------------|---------|
+| `'a` | Generic, first lifetime | `fn foo<'a>(x: &'a str)` |
+| `'b` | Generic, second lifetime | `fn bar<'a, 'b>(x: &'a T, y: &'b U)` |
+| `'de` | Deserialization | serde's `Deserialize<'de>` |
+| `'src` | Source code/input | `struct Lexer<'src>` |
+| `'ctx` | Context | `struct Query<'ctx>` |
+| `'input` | Input data | `struct Parser<'input>` |
+| `'static` | Static lifetime | `&'static str` |
+
+## Elision Preferred
+
+```rust
+// Let elision work when possible
+fn first_word(s: &str) -> &str {  // Not fn first_word<'a>(s: &'a str) -> &'a str
+    s.split_whitespace().next().unwrap_or("")
+}
+
+impl User {
+    fn name(&self) -> &str {  // Elision handles this
+        &self.name
+    }
+}
+```
+
+## Serde Convention
+
+```rust
+use serde::{Deserialize, Serialize};
+
+// 'de is the standard serde lifetime for borrowed data
+#[derive(Deserialize)]
+struct Request<'de> {
+    #[serde(borrow)]
+    name: &'de str,
+    #[serde(borrow)]
+    tags: Vec<&'de str>,
+}
+```
+
+## See Also
+
+- [own-lifetime-elision](./own-lifetime-elision.md) - When to omit lifetimes
+- [name-type-param-single](./name-type-param-single.md) - Type parameter naming
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Borrowing patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-no-get-prefix.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-no-get-prefix.md
@@ -1,0 +1,154 @@
+# name-no-get-prefix
+
+> Omit get_ prefix for simple getters
+
+## Why It Matters
+
+Rust convention omits the `get_` prefix for simple field access. Methods like `len()`, `name()`, `value()` are cleaner than `get_len()`, `get_name()`, `get_value()`. This follows the principle of making the common case concise.
+
+The `get` prefix is reserved for methods that DO something beyond simple field access.
+
+## Bad
+
+```rust
+struct User {
+    name: String,
+    age: u32,
+}
+
+impl User {
+    fn get_name(&self) -> &str {      // Verbose
+        &self.name
+    }
+    
+    fn get_age(&self) -> u32 {         // Verbose
+        self.age
+    }
+    
+    fn get_is_adult(&self) -> bool {   // Doubly verbose
+        self.age >= 18
+    }
+}
+
+let name = user.get_name();
+let age = user.get_age();
+```
+
+## Good
+
+```rust
+struct User {
+    name: String,
+    age: u32,
+}
+
+impl User {
+    fn name(&self) -> &str {           // Clean
+        &self.name
+    }
+    
+    fn age(&self) -> u32 {             // Clean
+        self.age
+    }
+    
+    fn is_adult(&self) -> bool {       // Boolean uses is_ prefix
+        self.age >= 18
+    }
+}
+
+let name = user.name();
+let age = user.age();
+```
+
+## When get_ IS Appropriate
+
+Use `get` when the method does more than simple access:
+
+```rust
+impl HashMap<K, V> {
+    // Returns Option - not just field access
+    fn get(&self, key: &K) -> Option<&V> { }
+    
+    // Mutable variant
+    fn get_mut(&mut self, key: &K) -> Option<&mut V> { }
+}
+
+impl Vec<T> {
+    // Returns Option - bounds checked
+    fn get(&self, index: usize) -> Option<&T> { }
+}
+
+impl Context {
+    // Does computation/lookup, not just field access
+    fn get_config(&self) -> Config {
+        self.configs.get(&self.current_env).cloned().unwrap_or_default()
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// No get_ prefix
+String::len()
+Vec::len()
+Vec::capacity()
+Vec::is_empty()
+Path::file_name()
+Option::is_some()
+Result::is_ok()
+
+// With get - returns Option or does lookup
+Vec::get(index)
+HashMap::get(key)
+BTreeMap::get(key)
+```
+
+## Pattern: Getter/Setter Pairs
+
+```rust
+impl Config {
+    // Getter: no prefix
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    
+    // Setter: use set_ prefix
+    fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+}
+```
+
+## Pattern: Builder Methods
+
+```rust
+impl ConfigBuilder {
+    // Builder methods: no get_, no set_
+    fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+    
+    fn retries(mut self, retries: u32) -> Self {
+        self.retries = retries;
+        self
+    }
+}
+```
+
+## Decision Guide
+
+| Pattern | Naming |
+|---------|--------|
+| Simple field access | `name()`, `value()`, `len()` |
+| Boolean property | `is_valid()`, `has_items()` |
+| Fallible access | `get()`, `get_mut()` |
+| Setter | `set_name()`, `set_value()` |
+| Builder | `name()`, `value()` (consuming self) |
+
+## See Also
+
+- [name-is-has-bool](./name-is-has-bool.md) - Boolean naming
+- [name-is-has-bool](./name-is-has-bool.md) - Boolean naming
+- [api-builder-pattern](./api-builder-pattern.md) - Builder pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-to-expensive.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-to-expensive.md
@@ -1,0 +1,118 @@
+# name-to-expensive
+
+> Use `to_` prefix for expensive conversions that allocate or compute
+
+## Why It Matters
+
+The `to_` prefix signals "this conversion has a cost"—typically allocation, cloning, or computation. Callers know to consider caching the result or avoiding repeated calls. This contrasts with `as_` (free reference conversion) and `into_` (ownership transfer).
+
+## Bad
+
+```rust
+impl Name {
+    // Misleading: suggests expensive operation
+    fn as_uppercase(&self) -> String {
+        self.0.to_uppercase()  // Allocates!
+    }
+    
+    // Misleading: suggests cheap reference
+    fn get_string(&self) -> String {
+        self.0.clone()  // Allocates!
+    }
+}
+```
+
+## Good
+
+```rust
+impl Name {
+    // to_ = allocates/computes
+    fn to_uppercase(&self) -> String {
+        self.0.to_uppercase()
+    }
+    
+    // to_ = creates new value
+    fn to_string(&self) -> String {
+        self.0.clone()
+    }
+    
+    // as_ = free reference (cheap)
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// to_ methods - all allocate or compute
+let s: String = slice.to_vec();           // Allocates Vec
+let s: String = "hello".to_string();      // Allocates String
+let s: String = "HELLO".to_lowercase();   // Allocates new String
+let s: String = path.to_string_lossy().into_owned();  // May allocate
+
+// Contrast with as_ methods - all are free
+let slice: &[u8] = s.as_bytes();          // Just reinterpret
+let str_ref: &str = string.as_str();      // Just reference
+let path: &Path = Path::new("foo");       // Just reference
+```
+
+## Conversion Method Prefixes
+
+| Prefix | Cost | Ownership | Example |
+|--------|------|-----------|---------|
+| `as_` | Free (O(1)) | Borrows `&T` | `as_str()`, `as_bytes()` |
+| `to_` | Allocates/Computes | Creates new | `to_string()`, `to_vec()` |
+| `into_` | Usually free | Takes ownership | `into_inner()`, `into_vec()` |
+
+## Custom Types
+
+```rust
+struct Email(String);
+
+impl Email {
+    // Cheap: just returns reference
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+    
+    // Expensive: allocates
+    fn to_lowercase(&self) -> Email {
+        Email(self.0.to_lowercase())
+    }
+    
+    // Expensive: allocates
+    fn to_display_format(&self) -> String {
+        format!("<{}>", self.0)
+    }
+    
+    // Ownership transfer: usually cheap
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+```
+
+## to_owned() Pattern
+
+```rust
+// to_owned() for getting owned version of borrowed data
+let borrowed: &str = "hello";
+let owned: String = borrowed.to_owned();  // Allocates
+
+let borrowed: &[i32] = &[1, 2, 3];
+let owned: Vec<i32> = borrowed.to_owned();  // Allocates
+
+// ToOwned trait
+trait ToOwned {
+    type Owned;
+    fn to_owned(&self) -> Self::Owned;
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Free reference conversions
+- [name-into-ownership](./name-into-ownership.md) - Ownership transfer
+- [own-cow-conditional](./own-cow-conditional.md) - Avoiding unnecessary allocations

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-type-param-single.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-type-param-single.md
@@ -1,0 +1,92 @@
+# name-type-param-single
+
+> Use single uppercase letters for type parameters: `T`, `E`, `K`, `V`
+
+## Why It Matters
+
+Generic type parameters conventionally use single uppercase letters. This keeps signatures concise and follows established conventions that readers instantly recognize. `T` for "type", `E` for "error", `K` for "key", `V` for "value" are universal in Rust.
+
+## Bad
+
+```rust
+// Verbose type parameters
+struct Container<ElementType> {
+    items: Vec<ElementType>,
+}
+
+fn process<InputType, OutputType>(input: InputType) -> OutputType { ... }
+
+// Lowercase - looks like lifetime
+struct Wrapper<t> { ... }  // Confusing
+```
+
+## Good
+
+```rust
+// Single uppercase letters
+struct Container<T> {
+    items: Vec<T>,
+}
+
+fn process<I, O>(input: I) -> O { ... }
+
+// Standard conventions
+struct HashMap<K, V> { ... }     // K=Key, V=Value
+enum Result<T, E> { ... }         // T=Type, E=Error
+enum Option<T> { ... }            // T=Type
+struct Ref<'a, T> { ... }        // Lifetime + Type
+```
+
+## Standard Type Parameter Names
+
+| Parameter | Meaning | Example |
+|-----------|---------|---------|
+| `T` | Type (generic) | `Vec<T>` |
+| `E` | Error | `Result<T, E>` |
+| `K` | Key | `HashMap<K, V>` |
+| `V` | Value | `HashMap<K, V>` |
+| `I` | Input / Item | `Iterator<Item = I>` |
+| `O` | Output | `Fn(I) -> O` |
+| `R` | Return / Result | `fn() -> R` |
+| `S` | State | `StateMachine<S>` |
+| `A` | Allocator | `Vec<T, A>` |
+| `F` | Function | `map<F>(f: F)` |
+
+## Multiple Type Parameters
+
+```rust
+// Use related letters
+fn transform<I, O, E>(input: I) -> Result<O, E>
+where
+    I: Input,
+    O: Output,
+    E: Error,
+{ ... }
+
+// Or sequential: T, U, V
+fn combine<T, U, V>(a: T, b: U) -> V { ... }
+
+// Descriptive only when many parameters need clarity
+struct Query<Db, Row, Err> { ... }
+```
+
+## Trait Bounds
+
+```rust
+// Keep type params short, move complexity to where clause
+fn process<T, E>(value: T) -> Result<T, E>
+where
+    T: Clone + Debug + Send + Sync,
+    E: Error + From<IoError>,
+{ ... }
+
+// Not inline
+fn process<T: Clone + Debug + Send + Sync, E: Error + From<IoError>>(value: T) -> Result<T, E>
+// Too long!
+```
+
+## See Also
+
+- [name-lifetime-short](./name-lifetime-short.md) - Lifetime parameter naming
+- [name-types-camel](./name-types-camel.md) - Concrete type naming
+- [type-generic-bounds](./type-generic-bounds.md) - Trait bounds

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-types-camel.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-types-camel.md
@@ -1,0 +1,65 @@
+# name-types-camel
+
+> Use `UpperCamelCase` for types, traits, and enum names
+
+## Why It Matters
+
+Rust's naming conventions are enforced by the compiler and linter. Consistent naming makes code immediately recognizable—you know `HttpClient` is a type, `send_request` is a function. Violating conventions triggers warnings and makes code harder to read.
+
+## Bad
+
+```rust
+// Lowercase types - compiler warns
+struct http_client { ... }  // warning: type `http_client` should have an upper camel case name
+trait serializable { ... }  // warning
+enum response_type { ... }  // warning
+
+// Screaming case for types
+struct HTTP_CLIENT { ... }  // Not idiomatic
+```
+
+## Good
+
+```rust
+// UpperCamelCase for all types
+struct HttpClient { ... }
+trait Serializable { ... }
+enum ResponseType { ... }
+
+// Compound words
+struct TcpConnection { ... }
+struct IoError { ... }
+struct FileReader { ... }
+
+// Generic types
+struct HashMap<K, V> { ... }
+struct Result<T, E> { ... }
+```
+
+## Acronyms
+
+```rust
+// Treat acronyms as words (capitalize first letter only)
+struct HttpServer { ... }      // Not HTTPServer
+struct JsonParser { ... }      // Not JSONParser
+struct Uuid { ... }            // Not UUID
+struct TcpStream { ... }       // Not TCPStream
+
+// Exception: Two-letter acronyms can be all caps
+struct IOError { ... }         // Acceptable
+struct IoError { ... }         // Also acceptable (preferred)
+```
+
+## Type Aliases
+
+```rust
+// Type aliases also use UpperCamelCase
+type Result<T> = std::result::Result<T, Error>;
+type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+```
+
+## See Also
+
+- [name-variants-camel](./name-variants-camel.md) - Enum variant naming
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming
+- [name-acronym-word](./name-acronym-word.md) - Acronym handling

--- a/.cursor/skills/rust-skills-leonardomso/rules/name-variants-camel.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/name-variants-camel.md
@@ -1,0 +1,101 @@
+# name-variants-camel
+
+> Use `UpperCamelCase` for enum variants
+
+## Why It Matters
+
+Enum variants follow the same naming convention as types—`UpperCamelCase`. This distinguishes them from fields, variables, and functions. The compiler warns on violations, and consistent naming helps readers instantly recognize variant names.
+
+## Bad
+
+```rust
+enum Status {
+    pending,       // warning: variant `pending` should have an upper camel case name
+    in_progress,   // warning
+    COMPLETED,     // Not idiomatic
+}
+
+enum Color {
+    RED,           // Screaming case - not Rust style
+    GREEN,
+    BLUE,
+}
+```
+
+## Good
+
+```rust
+enum Status {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+    Custom(u8, u8, u8),
+}
+
+enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+}
+```
+
+## Variants with Data
+
+```rust
+enum Message {
+    // Unit variant
+    Quit,
+    
+    // Tuple variant
+    Move(i32, i32),
+    
+    // Struct variant
+    Write { text: String },
+    
+    // Named fields
+    ChangeColor {
+        red: u8,
+        green: u8,
+        blue: u8,
+    },
+}
+```
+
+## Variant Naming Tips
+
+```rust
+// Be specific
+enum Error {
+    NotFound,           // Good: specific
+    PermissionDenied,   // Good: specific
+    Error,              // Bad: vague
+}
+
+// Avoid redundant type name in variant
+enum ConnectionState {
+    Connected,          // Good
+    Disconnected,       // Good
+    ConnectionError,    // Bad: redundant "Connection"
+}
+
+// Use None/Some pattern for Option-like enums
+enum MaybeValue<T> {
+    Some(T),
+    None,
+}
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums
+- [type-enum-states](./type-enum-states.md) - State machine enums

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-bounds-check.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-bounds-check.md
@@ -1,0 +1,161 @@
+# opt-bounds-check
+
+> Use iterators and patterns that eliminate bounds checks in hot paths
+
+## Why It Matters
+
+Rust's safety guarantees require bounds checking on array/slice indexing. In tight loops, these checks can cause measurable overhead (branch mispredictions, preventing vectorization). Patterns like iterators, `get_unchecked`, and index splitting can eliminate these checks while maintaining safety.
+
+## Bad
+
+```rust
+fn sum_products(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len() {
+        sum += a[i] * b[i];  // Two bounds checks per iteration
+    }
+    sum
+}
+
+fn apply_filter(data: &mut [u8], kernel: &[u8; 3]) {
+    for i in 1..data.len() - 1 {
+        // Three bounds checks per iteration
+        data[i] = (data[i - 1] + data[i] + data[i + 1]) / 3;
+    }
+}
+```
+
+## Good
+
+```rust
+fn sum_products(a: &[f64], b: &[f64]) -> f64 {
+    // Iterator zips - no bounds checks, vectorizes well
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+fn apply_filter(data: &mut [u8]) {
+    // Windows pattern - no bounds checks
+    for window in data.windows(3) {
+        // window[0], window[1], window[2] are all valid
+    }
+    
+    // Or use chunks
+    for chunk in data.chunks_exact(4) {
+        process_simd(chunk);
+    }
+}
+```
+
+## Iterator Patterns
+
+```rust
+// All of these avoid bounds checks:
+
+// zip - parallel iteration
+for (a, b) in xs.iter().zip(ys.iter()) { ... }
+
+// enumerate - index + value  
+for (i, x) in data.iter().enumerate() { ... }
+
+// windows - sliding window
+for window in data.windows(3) { ... }
+
+// chunks - fixed-size groups
+for chunk in data.chunks(4) { ... }
+for chunk in data.chunks_exact(4) { ... }  // Guarantees exact size
+
+// split_at - divide slice
+let (left, right) = data.split_at(mid);
+```
+
+## Split for Parallel Access
+
+```rust
+fn parallel_sum(data: &[i32]) -> i32 {
+    // Split into independent chunks
+    let (left, right) = data.split_at(data.len() / 2);
+    
+    // Process chunks without bounds checks
+    let sum_left: i32 = left.iter().sum();
+    let sum_right: i32 = right.iter().sum();
+    
+    sum_left + sum_right
+}
+```
+
+## get_unchecked for Proven Safety
+
+```rust
+fn matrix_multiply(a: &[f64], b: &[f64], c: &mut [f64], n: usize) {
+    assert!(a.len() >= n * n);
+    assert!(b.len() >= n * n);
+    assert!(c.len() >= n * n);
+    
+    for i in 0..n {
+        for j in 0..n {
+            let mut sum = 0.0;
+            for k in 0..n {
+                // SAFETY: bounds verified by asserts above
+                unsafe {
+                    sum += a.get_unchecked(i * n + k) 
+                         * b.get_unchecked(k * n + j);
+                }
+            }
+            // SAFETY: bounds verified by asserts above
+            unsafe {
+                *c.get_unchecked_mut(i * n + j) = sum;
+            }
+        }
+    }
+}
+```
+
+## Slice Patterns
+
+```rust
+fn process_header(data: &[u8]) -> Option<Header> {
+    // Slice pattern - single length check, no per-field checks
+    let [a, b, c, d, rest @ ..] = data else {
+        return None;
+    };
+    
+    Some(Header {
+        magic: *a,
+        version: *b,
+        flags: u16::from_le_bytes([*c, *d]),
+        payload: rest,
+    })
+}
+```
+
+## Verify Bounds Check Elimination
+
+```bash
+# Check generated assembly
+cargo asm --release my_crate::hot_function
+
+# Look for 'cmp' and 'ja'/'jbe' instructions near array access
+# If eliminated, you'll see direct memory access
+```
+
+## When to Accept Bounds Checks
+
+```rust
+// Random access patterns - checks unavoidable
+fn random_lookup(data: &[u8], indices: &[usize]) -> Vec<u8> {
+    indices.iter()
+        .filter_map(|&i| data.get(i).copied())  // Checked, but necessary
+        .collect()
+}
+
+// Infrequent access - overhead negligible
+fn get_config(&self, key: &str) -> Option<&Value> {
+    self.config.get(key)  // Fine, not hot path
+}
+```
+
+## See Also
+
+- [opt-simd-portable](./opt-simd-portable.md) - SIMD requires unchecked access
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache-efficient patterns
+- [perf-profile-first](./perf-profile-first.md) - Identify actual hot paths

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-cache-friendly.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-cache-friendly.md
@@ -1,0 +1,187 @@
+# opt-cache-friendly
+
+> Organize data for cache-efficient access patterns
+
+## Why It Matters
+
+Cache misses are expensive—a L3 cache miss costs ~100+ cycles vs ~4 cycles for L1 hit. Data layout and access patterns determine cache efficiency. Arrays of structs (AoS) vs structs of arrays (SoA), memory locality, and access patterns can make order-of-magnitude performance differences.
+
+## Bad
+
+```rust
+// Array of Structs (AoS) - poor cache use when accessing one field
+struct Particle {
+    position: [f32; 3],  // 12 bytes
+    velocity: [f32; 3],  // 12 bytes
+    mass: f32,           // 4 bytes
+    id: u64,             // 8 bytes
+    flags: u8,           // 1 byte + padding
+    // Total: 40 bytes per particle
+}
+
+fn update_positions(particles: &mut [Particle], dt: f32) {
+    for p in particles {
+        // Access position and velocity - 24 bytes
+        // But loads 40-byte struct per particle
+        // 16 bytes wasted per cache line load
+        p.position[0] += p.velocity[0] * dt;
+        p.position[1] += p.velocity[1] * dt;
+        p.position[2] += p.velocity[2] * dt;
+    }
+}
+```
+
+## Good
+
+```rust
+// Struct of Arrays (SoA) - cache-efficient for field access
+struct Particles {
+    positions_x: Vec<f32>,
+    positions_y: Vec<f32>,
+    positions_z: Vec<f32>,
+    velocities_x: Vec<f32>,
+    velocities_y: Vec<f32>,
+    velocities_z: Vec<f32>,
+    masses: Vec<f32>,
+    ids: Vec<u64>,
+    flags: Vec<u8>,
+}
+
+fn update_positions(p: &mut Particles, dt: f32) {
+    // Access contiguous memory - perfect cache utilization
+    for (px, vx) in p.positions_x.iter_mut().zip(&p.velocities_x) {
+        *px += vx * dt;
+    }
+    for (py, vy) in p.positions_y.iter_mut().zip(&p.velocities_y) {
+        *py += vy * dt;
+    }
+    for (pz, vz) in p.positions_z.iter_mut().zip(&p.velocities_z) {
+        *pz += vz * dt;
+    }
+}
+```
+
+## Hot/Cold Splitting
+
+```rust
+// Separate frequently and rarely accessed fields
+struct EntityHot {
+    position: [f32; 3],
+    velocity: [f32; 3],
+    // Hot data - accessed every frame
+}
+
+struct EntityCold {
+    name: String,
+    creation_time: Instant,
+    metadata: HashMap<String, Value>,
+    // Cold data - rarely accessed
+}
+
+struct Entities {
+    hot: Vec<EntityHot>,
+    cold: Vec<EntityCold>,
+}
+
+// Hot loop touches only hot data
+fn update(entities: &mut Entities, dt: f32) {
+    for e in &mut entities.hot {
+        e.position[0] += e.velocity[0] * dt;
+        // Cold data stays out of cache
+    }
+}
+```
+
+## Prefetching
+
+```rust
+// Process in cache-line-sized chunks
+const CACHE_LINE: usize = 64;
+
+fn process_with_prefetch(data: &mut [u8]) {
+    for chunk in data.chunks_mut(CACHE_LINE) {
+        // Prefetch next chunk while processing current
+        // (automatic in many cases, manual for complex patterns)
+        process_chunk(chunk);
+    }
+}
+
+// Matrix multiplication - block for cache
+fn matmul_blocked(a: &[f64], b: &[f64], c: &mut [f64], n: usize) {
+    const BLOCK: usize = 32;  // Fits in L1 cache
+    
+    for i0 in (0..n).step_by(BLOCK) {
+        for j0 in (0..n).step_by(BLOCK) {
+            for k0 in (0..n).step_by(BLOCK) {
+                // Process BLOCK x BLOCK tile
+                for i in i0..min(i0 + BLOCK, n) {
+                    for j in j0..min(j0 + BLOCK, n) {
+                        // Inner loop operates on cached data
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Avoid Pointer Chasing
+
+```rust
+// Bad: linked list - random memory access
+struct Node {
+    value: i32,
+    next: Option<Box<Node>>,
+}
+
+fn sum_linked(head: &Node) -> i32 {
+    // Each node is a cache miss
+}
+
+// Good: contiguous vector
+fn sum_vector(data: &[i32]) -> i32 {
+    data.iter().sum()  // Sequential access, prefetcher happy
+}
+
+// Good: if graph needed, use indices
+struct Graph {
+    values: Vec<i32>,
+    edges: Vec<usize>,  // Indices into values
+}
+```
+
+## Memory Layout Attributes
+
+```rust
+// Ensure cache-line alignment
+#[repr(C, align(64))]
+struct CacheAligned {
+    data: [u8; 64],
+}
+
+// Prevent false sharing in concurrent code
+#[repr(C, align(64))]
+struct PaddedCounter {
+    value: AtomicU64,
+    _pad: [u8; 56],
+}
+```
+
+## Measuring Cache Performance
+
+```bash
+# Linux perf
+perf stat -e cache-references,cache-misses ./my_program
+
+# Detailed cache analysis
+perf stat -e L1-dcache-loads,L1-dcache-load-misses,LLC-loads,LLC-load-misses ./my_program
+
+# Cachegrind
+valgrind --tool=cachegrind ./my_program
+```
+
+## See Also
+
+- [mem-smaller-integers](./mem-smaller-integers.md) - Smaller data fits more in cache
+- [mem-box-large-variant](./mem-box-large-variant.md) - Keep enum sizes small
+- [opt-bounds-check](./opt-bounds-check.md) - Sequential access patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-codegen-units.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-codegen-units.md
@@ -1,0 +1,142 @@
+# opt-codegen-units
+
+> Set `codegen-units = 1` for maximum optimization in release builds
+
+## Why It Matters
+
+By default, Cargo splits code into multiple codegen units for parallel compilation. This speeds up builds but prevents some cross-unit optimizations. Setting `codegen-units = 1` allows LLVM to optimize across the entire crate, potentially improving runtime performance by 5-20% at the cost of slower builds.
+
+## Bad
+
+```toml
+# Cargo.toml - default settings
+[profile.release]
+# codegen-units defaults to 16
+# Fast to compile, but misses optimization opportunities
+```
+
+## Good
+
+```toml
+# Cargo.toml - optimized for runtime performance
+[profile.release]
+codegen-units = 1  # Single unit = better optimization
+lto = true         # Link-time optimization
+opt-level = 3      # Maximum optimization
+```
+
+## What codegen-units Affects
+
+| Codegen Units | Compile Time | Runtime Performance | Memory Use |
+|---------------|--------------|---------------------|------------|
+| 16 (default)  | Faster       | Baseline            | Lower      |
+| 4-8           | Moderate     | Slightly better     | Moderate   |
+| 1             | Slower       | Best                | Higher     |
+
+## How It Works
+
+```rust
+// With codegen-units = 16:
+// - Crate split into 16 independent compilation units
+// - Compiled in parallel
+// - Limited visibility between units for optimization
+
+// With codegen-units = 1:
+// - Entire crate in single unit
+// - LLVM sees all code at once
+// - Can inline across module boundaries
+// - Better dead code elimination
+// - Better constant propagation
+```
+
+## Full Release Profile
+
+```toml
+[profile.release]
+# Maximum runtime performance
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"      # Smaller binary, slight perf gain
+strip = true         # Smaller binary
+
+[profile.release-with-debug]
+# Performance with debugging ability
+inherits = "release"
+debug = true         # Keep debug symbols
+strip = false
+
+[profile.bench]
+# For benchmarking
+inherits = "release"
+```
+
+## Build Time Trade-offs
+
+```bash
+# Default release build (fast compile)
+cargo build --release
+# Time: ~30s
+
+# Optimized release build (slow compile, fast runtime)
+# With codegen-units = 1, lto = "fat"
+cargo build --release
+# Time: ~2-5min, but potentially 10-20% faster binary
+```
+
+## Per-Profile Configuration
+
+```toml
+# Fast debug builds
+[profile.dev]
+codegen-units = 256  # Maximum parallelism
+
+# Fast CI builds
+[profile.ci]
+inherits = "release"
+codegen-units = 16   # Balance compile time vs runtime
+lto = "thin"         # Faster than "fat"
+
+# Production release
+[profile.production]
+inherits = "release"
+codegen-units = 1
+lto = "fat"
+```
+
+## When to Use What
+
+```rust
+// codegen-units = 16 (default)
+// - Development builds
+// - CI where compile time matters
+// - When runtime performance isn't critical
+
+// codegen-units = 1
+// - Production deployments
+// - Performance-critical applications
+// - Final releases
+// - Benchmarking
+```
+
+## Measuring Impact
+
+```bash
+# Build with different settings
+cargo build --release
+
+# Benchmark
+cargo bench
+
+# Compare binary sizes
+ls -lh target/release/my_binary
+
+# Profile runtime
+perf stat ./target/release/my_binary
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - Link-time optimization
+- [opt-pgo-profile](./opt-pgo-profile.md) - Profile-guided optimization
+- [opt-target-cpu](./opt-target-cpu.md) - CPU-specific optimization

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-cold-unlikely.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-cold-unlikely.md
@@ -1,0 +1,152 @@
+# opt-cold-unlikely
+
+> Mark unlikely code paths with `#[cold]` to help compiler optimization
+
+## Why It Matters
+
+The `#[cold]` attribute tells the compiler that a function is rarely called. The compiler uses this to optimize code layout—keeping cold code away from hot code improves instruction cache utilization. Combined with branch layout optimization, this can measurably improve performance.
+
+## Bad
+
+```rust
+// All branches treated equally
+fn validate(input: &str) -> Result<Data, ValidationError> {
+    if input.is_empty() {
+        return Err(ValidationError::Empty);  // Rare
+    }
+    
+    if input.len() > 1000 {
+        return Err(ValidationError::TooLong);  // Rare  
+    }
+    
+    if !input.is_ascii() {
+        return Err(ValidationError::NonAscii);  // Rare
+    }
+    
+    // This is the common case
+    Ok(parse_data(input))
+}
+```
+
+## Good
+
+```rust
+fn validate(input: &str) -> Result<Data, ValidationError> {
+    if input.is_empty() {
+        return cold_empty_error();
+    }
+    
+    if input.len() > 1000 {
+        return cold_too_long_error();
+    }
+    
+    if !input.is_ascii() {
+        return cold_non_ascii_error();
+    }
+    
+    Ok(parse_data(input))
+}
+
+#[cold]
+fn cold_empty_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::Empty)
+}
+
+#[cold]
+fn cold_too_long_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::TooLong)
+}
+
+#[cold]
+fn cold_non_ascii_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::NonAscii)
+}
+```
+
+## What #[cold] Does
+
+1. **Code placement**: Cold functions are placed in separate code sections, away from hot code
+2. **Branch prediction**: Compiler generates branch hints favoring the non-cold path
+3. **Inlining decisions**: Cold functions are not inlined into hot paths
+4. **Optimization budget**: Compiler spends less effort optimizing cold code
+
+## Common Cold Patterns
+
+```rust
+// Error handling
+#[cold]
+fn handle_error<E: std::fmt::Display>(e: E) -> ! {
+    eprintln!("Fatal error: {}", e);
+    std::process::exit(1);
+}
+
+// Logging rare events
+#[cold]
+fn log_rare_event(event: &Event) {
+    log::warn!("Rare event occurred: {:?}", event);
+}
+
+// Fallback paths
+#[cold]
+fn slow_fallback(data: &Data) -> Output {
+    // This path should rarely be taken
+    compute_slowly(data)
+}
+
+// Panic handlers
+#[cold]
+fn panic_invalid_state(state: &State) -> ! {
+    panic!("Invalid state: {:?}", state);
+}
+```
+
+## Assertions and Invariants
+
+```rust
+fn get_unchecked(&self, index: usize) -> &T {
+    if index >= self.len {
+        cold_bounds_panic(index, self.len);
+    }
+    unsafe { &*self.ptr.add(index) }
+}
+
+#[cold]
+#[inline(never)]
+fn cold_bounds_panic(index: usize, len: usize) -> ! {
+    panic!("index out of bounds: the len is {} but the index is {}", len, index);
+}
+```
+
+## Combining with #[inline(never)]
+
+```rust
+// Usually combine both for maximum effect
+#[cold]
+#[inline(never)]
+fn error_path() -> Error {
+    // Complex error construction stays out of hot code
+    Error {
+        backtrace: Backtrace::capture(),
+        context: gather_context(),
+    }
+}
+```
+
+## Measuring Impact
+
+```rust
+// Check code layout with objdump
+// objdump -d target/release/binary | less
+
+// Look for .cold sections
+// nm target/release/binary | grep cold
+
+// Profile to verify improvement
+// perf stat -e cache-misses,cache-references ./binary
+```
+
+## See Also
+
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Combining with inline(never)
+- [opt-likely-hint](./opt-likely-hint.md) - Branch prediction hints
+- [err-result-over-panic](./err-result-over-panic.md) - Error handling

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-always-rare.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-always-rare.md
@@ -1,0 +1,141 @@
+# opt-inline-always-rare
+
+> Use `#[inline(always)]` sparingly—only for critical hot paths proven by profiling
+
+## Why It Matters
+
+`#[inline(always)]` forces the compiler to inline a function regardless of heuristics. Overuse increases binary size, hurts instruction cache, and can slow down code. The compiler is usually smarter about inlining than humans. Reserve this for measured hot paths where benchmarks prove a benefit.
+
+## Bad
+
+```rust
+// Annotating everything - trusting intuition over data
+#[inline(always)]
+pub fn get_name(&self) -> &str {
+    &self.name
+}
+
+#[inline(always)]
+pub fn calculate_tax(amount: f64) -> f64 {
+    amount * 0.1
+}
+
+#[inline(always)]
+fn helper(x: i32) -> i32 {
+    x + 1
+}
+
+// Result: bloated binary, poor cache utilization
+```
+
+## Good
+
+```rust
+// Let compiler decide for most functions
+pub fn get_name(&self) -> &str {
+    &self.name
+}
+
+pub fn calculate_tax(amount: f64) -> f64 {
+    amount * 0.1
+}
+
+// Only force inline for proven hot paths
+impl Hasher for MyHasher {
+    // Hasher::write is called millions of times in tight loops
+    // Profiling showed 15% improvement from forced inlining
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        // Very small, very hot
+        self.state = self.state.wrapping_add(bytes.len() as u64);
+    }
+}
+```
+
+## When #[inline(always)] Helps
+
+```rust
+// ✅ Tiny functions in hot inner loops
+#[inline(always)]
+fn fast_hash(a: u64, b: u64) -> u64 {
+    a.wrapping_mul(b).wrapping_add(a)
+}
+
+// ✅ Generic functions that benefit from monomorphization
+#[inline(always)]
+fn swap<T>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b);
+}
+
+// ✅ Iterator adapters and closures
+#[inline(always)]
+fn apply<T, F: Fn(T) -> T>(f: F, x: T) -> T {
+    f(x)
+}
+
+// ✅ SIMD/vectorization helpers
+#[inline(always)]
+fn add_simd(a: &[f32], b: &[f32], out: &mut [f32]) {
+    // ...
+}
+```
+
+## Inline Variants
+
+```rust
+// #[inline] - hint to inline, compiler may ignore
+#[inline]
+fn suggested_inline(x: i32) -> i32 { x + 1 }
+
+// #[inline(always)] - force inline (almost always)
+#[inline(always)]
+fn force_inline(x: i32) -> i32 { x + 1 }
+
+// #[inline(never)] - prevent inlining (for profiling, code size)
+#[inline(never)]
+fn no_inline(x: i32) -> i32 { x + 1 }
+
+// No annotation - compiler decides based on heuristics
+fn compiler_decides(x: i32) -> i32 { x + 1 }
+```
+
+## Measuring Inline Impact
+
+```rust
+// Use criterion to benchmark
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_with_inline(c: &mut Criterion) {
+    c.bench_function("hot_path_inline", |b| {
+        b.iter(|| hot_loop())
+    });
+}
+
+// Compare binary sizes
+// cargo bloat --release --crates
+
+// Check if function was inlined
+// cargo asm --rust my_crate::hot_function
+```
+
+## Generic Functions
+
+```rust
+// Generic functions across crate boundaries often need #[inline]
+// Because the generic code is compiled in the calling crate
+
+// In library crate:
+#[inline]  // Allow inlining in downstream crates
+pub fn generic_function<T: Display>(x: T) {
+    println!("{}", x);
+}
+
+// Without #[inline], the generic function can't be inlined
+// across crate boundaries even if beneficial
+```
+
+## See Also
+
+- [opt-inline-small](./opt-inline-small.md) - Regular inline for small functions
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Preventing inlining
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimizing

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-never-cold.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-never-cold.md
@@ -1,0 +1,181 @@
+# opt-inline-never-cold
+
+> Use `#[inline(never)]` and `#[cold]` for error paths and rarely-executed code
+
+## Why It Matters
+
+Inlining error handling code into hot paths wastes instruction cache space and can prevent other optimizations. `#[inline(never)]` keeps cold code out of the hot path. `#[cold]` tells the compiler this branch is unlikely, enabling better branch prediction hints and code layout.
+
+## Bad
+
+```rust
+fn process_data(data: &[u8]) -> Result<Output, Error> {
+    if data.is_empty() {
+        // Error path inlined into hot function
+        return Err(Error::Empty {
+            context: format!("Expected data, got empty slice"),
+            suggestions: vec!["Check input", "Validate before calling"],
+        });
+    }
+    
+    // Hot path - now polluted with error construction code
+    do_processing(data)
+}
+```
+
+## Good
+
+```rust
+fn process_data(data: &[u8]) -> Result<Output, Error> {
+    if data.is_empty() {
+        return Err(empty_data_error());  // Cold path stays small
+    }
+    
+    do_processing(data)
+}
+
+#[cold]
+#[inline(never)]
+fn empty_data_error() -> Error {
+    Error::Empty {
+        context: format!("Expected data, got empty slice"),
+        suggestions: vec!["Check input", "Validate before calling"],
+    }
+}
+```
+
+## #[cold] for Unlikely Branches
+
+```rust
+fn parse_value(input: &str) -> Result<i32, ParseError> {
+    match input.parse() {
+        Ok(n) => Ok(n),
+        Err(e) => cold_parse_error(input, e),
+    }
+}
+
+#[cold]
+fn cold_parse_error(input: &str, e: std::num::ParseIntError) -> Result<i32, ParseError> {
+    Err(ParseError {
+        input: input.to_string(),
+        source: e,
+    })
+}
+```
+
+## Panic Paths
+
+```rust
+fn get_index(&self, idx: usize) -> &T {
+    if idx >= self.len {
+        cold_out_of_bounds(idx, self.len);
+    }
+    unsafe { self.ptr.add(idx).as_ref().unwrap() }
+}
+
+#[cold]
+#[inline(never)]
+fn cold_out_of_bounds(idx: usize, len: usize) -> ! {
+    panic!("index {} out of bounds for length {}", idx, len);
+}
+```
+
+## Error Construction Functions
+
+```rust
+// Keep error construction out of hot path
+impl MyError {
+    #[cold]
+    pub fn io_error(source: std::io::Error, path: &Path) -> Self {
+        MyError::Io {
+            source,
+            path: path.to_path_buf(),
+            context: get_context(),
+        }
+    }
+    
+    #[cold]
+    pub fn validation_error(msg: &str, field: &str) -> Self {
+        MyError::Validation {
+            message: msg.to_string(),
+            field: field.to_string(),
+        }
+    }
+}
+
+fn read_config(path: &Path) -> Result<Config, MyError> {
+    std::fs::read_to_string(path)
+        .map_err(|e| MyError::io_error(e, path))?
+        .parse()
+        .map_err(|e| MyError::parse_error(e))
+}
+```
+
+## likely/unlikely Hints
+
+```rust
+// Nightly: intrinsics for branch hints
+#![feature(core_intrinsics)]
+use std::intrinsics::{likely, unlikely};
+
+fn process(data: Option<&Data>) -> Result<Output, Error> {
+    if unlikely(data.is_none()) {
+        return cold_none_error();
+    }
+    
+    let data = data.unwrap();
+    
+    if likely(data.is_valid()) {
+        fast_process(data)
+    } else {
+        slow_validate_and_process(data)
+    }
+}
+
+// Stable alternative: structure code so hot path is "fall through"
+fn process(data: Option<&Data>) -> Result<Output, Error> {
+    let data = match data {
+        Some(d) => d,
+        None => return cold_none_error(),  // Early return = unlikely hint
+    };
+    
+    // Compiler assumes code after early returns is "hot"
+    fast_process(data)
+}
+```
+
+## Pattern: Extract Cold Code
+
+```rust
+// Before: cold code inline
+fn hot_function(x: i32) -> i32 {
+    if x < 0 {
+        log::error!("Negative value: {}", x);
+        eprintln!("Debug info: {:?}", std::backtrace::Backtrace::capture());
+        return 0;
+    }
+    x * 2
+}
+
+// After: cold code extracted
+fn hot_function(x: i32) -> i32 {
+    if x < 0 {
+        return handle_negative(x);
+    }
+    x * 2
+}
+
+#[cold]
+#[inline(never)]
+fn handle_negative(x: i32) -> i32 {
+    log::error!("Negative value: {}", x);
+    eprintln!("Debug info: {:?}", std::backtrace::Backtrace::capture());
+    0
+}
+```
+
+## See Also
+
+- [opt-inline-small](./opt-inline-small.md) - Inlining for hot code
+- [opt-inline-always-rare](./opt-inline-always-rare.md) - Forced inlining
+- [err-result-over-panic](./err-result-over-panic.md) - Error handling patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-small.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-inline-small.md
@@ -1,0 +1,160 @@
+# opt-inline-small
+
+> Use `#[inline]` for small hot functions
+
+## Why It Matters
+
+Function call overhead (stack frame setup, register saves, jumps) can dominate small functions. Inlining eliminates this overhead and enables further optimizations by the compiler. The compiler often inlines automatically, but hints help for cross-crate calls.
+
+## Bad
+
+```rust
+// Small hot function without inline hint
+// May not be inlined across crate boundaries
+fn is_ascii_digit(b: u8) -> bool {
+    b >= b'0' && b <= b'9'
+}
+
+// Called millions of times
+for byte in data {
+    if is_ascii_digit(*byte) {  // Function call overhead
+        count += 1;
+    }
+}
+```
+
+## Good
+
+```rust
+#[inline]
+fn is_ascii_digit(b: u8) -> bool {
+    b >= b'0' && b <= b'9'
+}
+
+// Now the compiler will inline this
+for byte in data {
+    if is_ascii_digit(*byte) {  // Inlined, no call overhead
+        count += 1;
+    }
+}
+```
+
+## Inline Attributes
+
+```rust
+// No attribute - compiler decides (usually good for same-crate)
+fn auto_decide() { }
+
+// Suggest inlining - helps cross-crate
+#[inline]
+fn suggest_inline() { }
+
+// Strongly suggest inlining - almost always inlined
+#[inline(always)]
+fn force_inline() { }
+
+// Strongly suggest NOT inlining - for large/cold code
+#[inline(never)]
+fn prevent_inline() { }
+```
+
+## When to Use Each
+
+```rust
+// #[inline] - Small functions, especially in libraries
+#[inline]
+pub fn len(&self) -> usize {
+    self.inner.len()
+}
+
+// #[inline(always)] - Critical hot path, verified by profiling
+#[inline(always)]
+fn hot_inner_loop_helper(x: u32) -> u32 {
+    x.wrapping_mul(0x9E3779B9)
+}
+
+// #[inline(never)] - Error handlers, cold paths
+#[inline(never)]
+fn handle_error(err: Error) -> ! {
+    eprintln!("Fatal: {}", err);
+    std::process::exit(1);
+}
+
+// No attribute - large functions, infrequent calls
+fn complex_processing(data: &mut Data) {
+    // Many lines of code...
+}
+```
+
+## Evidence from ripgrep
+
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/printer/src/standard.rs
+
+#[inline(always)]
+fn write_prelude(
+    &self,
+    absolute_byte_offset: u64,
+    line_number: Option<u64>,
+    column: Option<u64>,
+) -> io::Result<()> {
+    // Hot path in printing matches
+}
+
+#[inline(always)]
+fn write_line(&self, line: &[u8]) -> io::Result<()> {
+    // Called for every line
+}
+```
+
+## Generic Functions
+
+```rust
+// Generic functions are already candidates for per-monomorphization inlining
+// But #[inline] helps ensure it across crates
+
+#[inline]
+pub fn min<T: Ord>(a: T, b: T) -> T {
+    if a < b { a } else { b }
+}
+```
+
+## Cautions
+
+```rust
+// DON'T inline large functions - hurts instruction cache
+#[inline(always)]  // BAD for large function
+fn large_complex_function(data: &mut [u8]) {
+    // 100+ lines of code
+    // Inlining bloats every call site
+}
+
+// DON'T assume inlining always helps - measure!
+// Sometimes the compiler makes better decisions
+
+// Inlining is non-transitive
+#[inline]
+fn outer() {
+    inner();  // inner() also needs #[inline] to be inlined together
+}
+
+fn inner() { }  // Won't be inlined at outer's call sites
+```
+
+## Verifying Inlining
+
+```bash
+# Check if function was inlined using Cachegrind
+# Non-inlined functions show entry/exit counts
+
+# Or examine assembly
+cargo rustc --release -- --emit=asm
+# Look for call instructions vs inlined code
+```
+
+## See Also
+
+- [opt-inline-always-rare](opt-inline-always-rare.md) - Use #[inline(always)] sparingly
+- [opt-inline-never-cold](opt-inline-never-cold.md) - Use #[inline(never)] for cold paths
+- [opt-cold-unlikely](opt-cold-unlikely.md) - Use #[cold] for unlikely paths
+- [opt-lto-release](opt-lto-release.md) - LTO enables cross-crate inlining

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-likely-hint.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-likely-hint.md
@@ -1,0 +1,171 @@
+# opt-likely-hint
+
+> Use code structure to hint at likely branches; use intrinsics on nightly
+
+## Why It Matters
+
+Modern CPUs predict branches to speculatively execute code. Mispredictions cause pipeline stalls (10-20 cycles). Helping the compiler understand which branches are likely allows it to generate optimal code layout and branch hints, improving performance in hot paths.
+
+## Stable Rust: Code Structure Hints
+
+```rust
+// Pattern 1: Early returns for unlikely cases
+fn process(data: Option<&Data>) -> i32 {
+    // Compiler assumes early return is "unlikely"
+    let data = match data {
+        None => return 0,  // Unlikely
+        Some(d) => d,
+    };
+    
+    // Hot path continues here
+    complex_processing(data)
+}
+
+// Pattern 2: if-else ordering
+fn calculate(x: i32) -> i32 {
+    if x >= 0 {
+        // Put likely case in "if" branch
+        x * 2
+    } else {
+        // Unlikely case in "else"
+        handle_negative(x)
+    }
+}
+
+// Pattern 3: Cold function extraction
+fn hot_path(data: &[u8]) -> Result<(), Error> {
+    if data.is_empty() {
+        return cold_empty_error();  // Extracted = unlikely
+    }
+    
+    process_fast(data)
+}
+
+#[cold]
+fn cold_empty_error() -> Result<(), Error> {
+    Err(Error::EmptyInput)
+}
+```
+
+## Nightly: Intrinsics
+
+```rust
+#![feature(core_intrinsics)]
+use std::intrinsics::{likely, unlikely};
+
+fn process(data: &Data) -> i32 {
+    if unlikely(data.is_corrupted()) {
+        return handle_corruption(data);
+    }
+    
+    if likely(data.is_cached()) {
+        return fast_cached_path(data);
+    }
+    
+    slow_uncached_path(data)
+}
+```
+
+## Boolean Likely Wrapper (Nightly)
+
+```rust
+#![feature(core_intrinsics)]
+
+#[inline(always)]
+fn likely(b: bool) -> bool {
+    std::intrinsics::likely(b)
+}
+
+#[inline(always)]
+fn unlikely(b: bool) -> bool {
+    std::intrinsics::unlikely(b)
+}
+
+// Usage
+if likely(x > 0) {
+    hot_path(x)
+} else {
+    cold_path(x)
+}
+```
+
+## Stable: likely-stable Crate
+
+```rust
+use likely_stable::{likely, unlikely};
+
+fn check(value: i32) -> bool {
+    if unlikely(value < 0) {
+        handle_negative()
+    } else if likely(value < 1000) {
+        handle_common()
+    } else {
+        handle_large()
+    }
+}
+```
+
+## Loop Optimization
+
+```rust
+fn search(data: &[i32], target: i32) -> Option<usize> {
+    for (i, &item) in data.iter().enumerate() {
+        // Assume most iterations DON'T find the target
+        if unlikely(item == target) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+// Alternative: structure for likely case
+fn search_common(data: &[i32], target: i32) -> Option<usize> {
+    // If target is usually found
+    for (i, &item) in data.iter().enumerate() {
+        if likely(item == target) {
+            return Some(i);
+        }
+    }
+    None
+}
+```
+
+## Match Arm Ordering
+
+```rust
+// Put most common variants first
+fn process_message(msg: Message) {
+    match msg {
+        // Most common - listed first
+        Message::Data(d) => handle_data(d),
+        Message::Heartbeat => (), // Second most common
+        
+        // Rare cases last
+        Message::Error(e) => handle_error(e),
+        Message::Shutdown => shutdown(),
+    }
+}
+```
+
+## Benchmark-Driven Hints
+
+```rust
+// Profile first to know which branches are actually likely!
+fn speculative(x: i32) -> i32 {
+    // DON'T GUESS - measure with profiling
+    // perf record / perf report
+    // cargo flamegraph
+    
+    if x > threshold {  // Is this actually common?
+        path_a(x)
+    } else {
+        path_b(x)
+    }
+}
+```
+
+## See Also
+
+- [opt-cold-unlikely](./opt-cold-unlikely.md) - #[cold] for unlikely functions
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Keeping cold code separate
+- [perf-profile-first](./perf-profile-first.md) - Profile to know what's likely

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-lto-release.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-lto-release.md
@@ -1,0 +1,132 @@
+# opt-lto-release
+
+> Enable LTO in release builds
+
+## Why It Matters
+
+Link-Time Optimization (LTO) enables optimizations across crate boundaries that aren't possible during normal compilation. This includes cross-crate inlining, dead code elimination, and devirtualization. Typically provides 5-20% performance improvement.
+
+## Bad
+
+```toml
+# Cargo.toml - default release profile
+[profile.release]
+opt-level = 3
+# No LTO = missed optimization opportunities
+```
+
+## Good
+
+```toml
+# Cargo.toml - optimized release profile
+[profile.release]
+opt-level = 3
+lto = "fat"          # Maximum optimization
+codegen-units = 1    # Better optimization (single codegen unit)
+panic = "abort"      # Smaller binary, no unwind tables
+strip = true         # Remove symbols for smaller binary
+```
+
+## LTO Options Explained
+
+```toml
+# No LTO (default)
+lto = false
+
+# Thin LTO - fast compilation, most benefits
+lto = "thin"
+
+# Fat LTO - slowest compilation, maximum optimization
+lto = "fat"
+# Equivalent to:
+lto = true
+
+# Thin-local - LTO within each crate only
+lto = "off"
+```
+
+## Trade-offs
+
+| Setting | Compile Time | Binary Size | Performance |
+|---------|--------------|-------------|-------------|
+| `lto = false` | Fast | Larger | Baseline |
+| `lto = "thin"` | Medium | Smaller | +5-15% |
+| `lto = "fat"` | Slow | Smallest | +10-20% |
+
+## Evidence from Production
+
+```toml
+# From Anchor (Solana framework)
+# https://github.com/solana-foundation/anchor/blob/master/cli/src/rust_template.rs
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+
+# From ripgrep (release-lto profile)
+# https://github.com/BurntSushi/ripgrep/blob/master/Cargo.toml
+[profile.release-lto]
+inherits = "release"
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+```
+
+## Complete Optimized Profile
+
+```toml
+[profile.release]
+opt-level = 3        # Maximum optimization
+lto = "fat"          # Link-time optimization
+codegen-units = 1    # Single codegen unit for better optimization
+panic = "abort"      # Remove panic unwinding code
+strip = true         # Strip symbols
+debug = false        # No debug info
+
+# For benchmarking (need some debug info for profiling)
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+# Fast dev builds with optimized dependencies
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3        # Optimize dependencies even in dev
+```
+
+## When to Use Each
+
+| Situation | LTO Setting |
+|-----------|-------------|
+| Development | `false` (fast compiles) |
+| CI builds | `"thin"` (balance) |
+| Release binaries | `"fat"` (max perf) |
+| Libraries (crates.io) | `false` (users choose) |
+
+## Measuring Impact
+
+```bash
+# Build without LTO
+cargo build --release
+hyperfine ./target/release/myapp
+
+# Build with LTO
+# (after adding lto = "fat" to Cargo.toml)
+cargo build --release
+hyperfine ./target/release/myapp
+
+# Compare binary sizes
+ls -la target/release/myapp
+```
+
+## See Also
+
+- [opt-codegen-units](opt-codegen-units.md) - Use codegen-units = 1
+- [opt-pgo-profile](opt-pgo-profile.md) - Profile-guided optimization
+- [perf-release-profile](perf-release-profile.md) - Full release profile settings

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-pgo-profile.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-pgo-profile.md
@@ -1,0 +1,167 @@
+# opt-pgo-profile
+
+> Use Profile-Guided Optimization (PGO) for maximum performance
+
+## Why It Matters
+
+PGO uses real runtime behavior to guide compiler optimization decisions. By profiling actual workloads, the compiler learns which code paths are hot, optimizing them aggressively while deprioritizing cold paths. This can yield 10-30% performance improvements beyond standard optimizations.
+
+## The PGO Process
+
+1. **Instrument**: Build with profiling instrumentation
+2. **Profile**: Run representative workloads
+3. **Optimize**: Rebuild using collected profile data
+
+## Step-by-Step
+
+```bash
+# Step 1: Build instrumented binary
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" \
+    cargo build --release
+
+# Step 2: Run representative workloads
+./target/release/my_app < test_data_1.txt
+./target/release/my_app < test_data_2.txt
+./target/release/my_app < typical_workload.txt
+
+# Step 3: Merge profile data
+llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data
+
+# Step 4: Build optimized binary using profile
+RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata" \
+    cargo build --release
+```
+
+## Cargo Configuration
+
+```toml
+# Cargo.toml
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+
+# PGO flags set via RUSTFLAGS environment variable
+```
+
+## Build Script
+
+```bash
+#!/bin/bash
+set -e
+
+PGO_DIR=/tmp/pgo-$(date +%s)
+
+# Clean
+cargo clean
+
+# Instrumented build
+echo "Building instrumented binary..."
+RUSTFLAGS="-Cprofile-generate=$PGO_DIR" cargo build --release
+
+# Run workloads
+echo "Collecting profile data..."
+./target/release/my_app --benchmark-mode
+./target/release/my_app < test_fixtures/typical.txt
+./target/release/my_app < test_fixtures/stress.txt
+
+# Merge profiles
+echo "Merging profile data..."
+llvm-profdata merge -o $PGO_DIR/merged.profdata $PGO_DIR
+
+# Optimized build
+echo "Building optimized binary..."
+RUSTFLAGS="-Cprofile-use=$PGO_DIR/merged.profdata" cargo build --release
+
+echo "Done! Optimized binary at target/release/my_app"
+```
+
+## Representative Workloads
+
+```rust
+// Create benchmarks that match real usage patterns
+
+// Good: actual data samples
+fn profile_workload() {
+    for file in real_customer_data_samples() {
+        process_file(&file);
+    }
+}
+
+// Good: synthetic but realistic
+fn profile_synthetic() {
+    for _ in 0..10000 {
+        let data = generate_realistic_data();
+        process(&data);
+    }
+}
+
+// Bad: artificial microbenchmarks
+fn profile_bad() {
+    for _ in 0..1000000 {
+        small_operation();  // Doesn't reflect real hot paths
+    }
+}
+```
+
+## BOLT Post-Link Optimization
+
+For even more gains, combine PGO with BOLT:
+
+```bash
+# After PGO build, apply BOLT
+llvm-bolt target/release/my_app \
+    -o target/release/my_app.bolt \
+    -data=perf.data \
+    -reorder-blocks=ext-tsp \
+    -reorder-functions=hfsort
+
+# BOLT can add another 5-15% on top of PGO
+```
+
+## CI/CD Integration
+
+```yaml
+# GitHub Actions example
+jobs:
+  pgo-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install LLVM tools
+        run: sudo apt-get install llvm
+      
+      - name: Instrumented build
+        run: RUSTFLAGS="-Cprofile-generate=/tmp/pgo" cargo build --release
+      
+      - name: Run profiling workloads
+        run: ./scripts/run_profiling_workloads.sh
+      
+      - name: Merge profiles
+        run: llvm-profdata merge -o /tmp/pgo/merged.profdata /tmp/pgo
+      
+      - name: Optimized build
+        run: RUSTFLAGS="-Cprofile-use=/tmp/pgo/merged.profdata" cargo build --release
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimized-binary
+          path: target/release/my_app
+```
+
+## When to Use PGO
+
+| Use PGO | Skip PGO |
+|---------|----------|
+| Production deployments | Development builds |
+| Performance-critical apps | Libraries (users can PGO) |
+| Stable workload patterns | Highly variable workloads |
+| Sufficient profiling data | Quick iteration cycles |
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - LTO works well with PGO
+- [opt-codegen-units](./opt-codegen-units.md) - Single codegen unit for PGO
+- [perf-profile-first](./perf-profile-first.md) - Profiling basics

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-simd-portable.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-simd-portable.md
@@ -1,0 +1,144 @@
+# opt-simd-portable
+
+> Use portable SIMD for vectorized operations across architectures
+
+## Why It Matters
+
+SIMD (Single Instruction, Multiple Data) processes multiple values per instruction—4x, 8x, or more speedup for suitable algorithms. Rust's portable SIMD (nightly) and crates like `wide` provide cross-platform vectorization without architecture-specific intrinsics. For stable Rust, let LLVM auto-vectorize or use platform-specific crates.
+
+## Autovectorization (Stable)
+
+```rust
+// LLVM often vectorizes simple patterns automatically
+fn sum(data: &[f32]) -> f32 {
+    data.iter().sum()  // May vectorize to SIMD
+}
+
+fn add_arrays(a: &[f32], b: &[f32], out: &mut [f32]) {
+    for ((x, y), o) in a.iter().zip(b).zip(out.iter_mut()) {
+        *o = x + y;  // Often vectorizes
+    }
+}
+
+// Help autovectorization:
+// 1. Use iterators over indexing
+// 2. Avoid early exits in loops
+// 3. Use chunks_exact for aligned access
+```
+
+## Portable SIMD (Nightly)
+
+```rust
+#![feature(portable_simd)]
+use std::simd::*;
+
+fn sum_simd(data: &[f32]) -> f32 {
+    let (prefix, middle, suffix) = data.as_simd::<8>();
+    
+    // Handle unaligned prefix
+    let mut sum = prefix.iter().sum::<f32>();
+    
+    // SIMD loop - 8 floats at a time
+    let mut simd_sum = f32x8::splat(0.0);
+    for chunk in middle {
+        simd_sum += *chunk;
+    }
+    sum += simd_sum.reduce_sum();
+    
+    // Handle unaligned suffix
+    sum += suffix.iter().sum::<f32>();
+    
+    sum
+}
+
+fn dot_product(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    
+    let (a_pre, a_mid, a_suf) = a.as_simd::<8>();
+    let (b_pre, b_mid, b_suf) = b.as_simd::<8>();
+    
+    let scalar: f32 = a_pre.iter().zip(b_pre).map(|(x, y)| x * y).sum();
+    
+    let mut simd_sum = f32x8::splat(0.0);
+    for (av, bv) in a_mid.iter().zip(b_mid) {
+        simd_sum += *av * *bv;
+    }
+    
+    let suffix: f32 = a_suf.iter().zip(b_suf).map(|(x, y)| x * y).sum();
+    
+    scalar + simd_sum.reduce_sum() + suffix
+}
+```
+
+## wide Crate (Stable)
+
+```rust
+use wide::*;
+
+fn process_simd(data: &mut [f32]) {
+    // Process 8 floats at a time
+    for chunk in data.chunks_exact_mut(8) {
+        let v = f32x8::from(chunk);
+        let result = v * f32x8::splat(2.0) + f32x8::splat(1.0);
+        chunk.copy_from_slice(&result.to_array());
+    }
+}
+
+fn blend_images(a: &[u8], b: &[u8], alpha: f32, out: &mut [u8]) {
+    let alpha_v = f32x8::splat(alpha);
+    let one_minus = f32x8::splat(1.0 - alpha);
+    
+    for ((a_chunk, b_chunk), out_chunk) in 
+        a.chunks_exact(8).zip(b.chunks_exact(8)).zip(out.chunks_exact_mut(8)) 
+    {
+        let av = f32x8::from([
+            a_chunk[0] as f32, a_chunk[1] as f32, /* ... */
+        ]);
+        let bv = f32x8::from([
+            b_chunk[0] as f32, b_chunk[1] as f32, /* ... */
+        ]);
+        
+        let result = av * one_minus + bv * alpha_v;
+        // Convert back to u8...
+    }
+}
+```
+
+## Platform-Specific (When Needed)
+
+```rust
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn sum_avx2(data: &[f32]) -> f32 {
+    let mut sum = _mm256_setzero_ps();
+    
+    for chunk in data.chunks_exact(8) {
+        let v = _mm256_loadu_ps(chunk.as_ptr());
+        sum = _mm256_add_ps(sum, v);
+    }
+    
+    // Horizontal sum
+    let high = _mm256_extractf128_ps(sum, 1);
+    let low = _mm256_castps256_ps128(sum);
+    let sum128 = _mm_add_ps(high, low);
+    // ... continue reduction
+}
+```
+
+## Choosing an Approach
+
+| Approach | Stability | Portability | Control |
+|----------|-----------|-------------|---------|
+| Autovectorization | Stable | Excellent | Low |
+| `wide` crate | Stable | Good | Medium |
+| Portable SIMD | Nightly | Excellent | High |
+| Intrinsics | Stable | None | Maximum |
+
+## See Also
+
+- [opt-target-cpu](./opt-target-cpu.md) - Enable SIMD features
+- [opt-bounds-check](./opt-bounds-check.md) - Unchecked access for SIMD
+- [perf-profile-first](./perf-profile-first.md) - Identify vectorization opportunities

--- a/.cursor/skills/rust-skills-leonardomso/rules/opt-target-cpu.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/opt-target-cpu.md
@@ -1,0 +1,154 @@
+# opt-target-cpu
+
+> Use `target-cpu=native` for maximum performance on known deployment targets
+
+## Why It Matters
+
+By default, Rust compiles for a generic x86-64 baseline (roughly Sandy Bridge era). Modern CPUs have SIMD extensions (AVX2, AVX-512), improved instructions, and micro-architectural optimizations that go unused. `target-cpu=native` enables all features of your current CPU, potentially unlocking significant speedups.
+
+## Bad
+
+```toml
+# Cargo.toml - compiles for generic x86-64
+[profile.release]
+# No target-cpu specified
+# Binary works everywhere but uses only SSE2
+```
+
+## Good
+
+```toml
+# .cargo/config.toml - for known deployment target
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
+# Or specific CPU for cross-compilation
+# rustflags = ["-C", "target-cpu=skylake"]
+```
+
+## Via Environment
+
+```bash
+# Build with native optimizations
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+
+# Check what features are enabled
+rustc --print cfg -C target-cpu=native | grep target_feature
+```
+
+## Common Target CPUs
+
+```bash
+# x86-64 targets
+target-cpu=native          # Current machine
+target-cpu=x86-64          # Baseline (SSE2)
+target-cpu=x86-64-v2       # SSE4.2, POPCNT
+target-cpu=x86-64-v3       # AVX2, BMI2
+target-cpu=x86-64-v4       # AVX-512
+
+# Intel specific
+target-cpu=skylake         # 6th gen Core
+target-cpu=alderlake       # 12th gen Core
+
+# AMD specific
+target-cpu=znver3          # Zen 3
+target-cpu=znver4          # Zen 4
+
+# ARM
+target-cpu=apple-m1        # Apple Silicon
+target-cpu=neoverse-n1     # AWS Graviton2
+```
+
+## Feature Detection at Runtime
+
+```rust
+// For portable binaries that use native features when available
+#[cfg(target_arch = "x86_64")]
+fn process_fast(data: &[u8]) -> u64 {
+    if is_x86_feature_detected!("avx2") {
+        unsafe { process_avx2(data) }
+    } else if is_x86_feature_detected!("sse4.2") {
+        unsafe { process_sse42(data) }
+    } else {
+        process_generic(data)
+    }
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn process_avx2(data: &[u8]) -> u64 {
+    // AVX2 optimized implementation
+}
+```
+
+## Multi-Architecture Builds
+
+```bash
+# Build multiple binaries
+RUSTFLAGS="-C target-cpu=x86-64" cargo build --release
+mv target/release/app target/release/app-generic
+
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release
+mv target/release/app target/release/app-avx2
+
+# Select at runtime
+if supports_avx2; then
+    ./app-avx2
+else
+    ./app-generic
+fi
+```
+
+## Cargo Configuration
+
+```toml
+# .cargo/config.toml
+
+# Native builds for development
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=native"]
+
+# AWS deployment (Graviton2)
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=neoverse-n1"]
+
+# Intel server deployment
+[target.x86_64-unknown-linux-gnu.deployment]
+rustflags = ["-C", "target-cpu=skylake-avx512"]
+```
+
+## What Changes
+
+```rust
+// With AVX2 enabled:
+// - 256-bit SIMD operations
+// - Better autovectorization
+// - FMA (fused multiply-add)
+// - BMI (bit manipulation)
+
+// Example: sum of squares
+fn sum_squares(data: &[f64]) -> f64 {
+    data.iter().map(|x| x * x).sum()
+}
+// Generic: scalar loop
+// AVX2: processes 4 f64s per iteration
+```
+
+## Checking Enabled Features
+
+```bash
+# What's enabled for native?
+rustc --print cfg -C target-cpu=native | grep feature
+
+# Compare generic vs native
+rustc --print cfg -C target-cpu=x86-64 | grep feature
+rustc --print cfg -C target-cpu=native | grep feature
+
+# View generated assembly
+cargo asm --rust --release my_crate::hot_function
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - Combine with LTO
+- [opt-simd-portable](./opt-simd-portable.md) - Portable SIMD
+- [opt-codegen-units](./opt-codegen-units.md) - Single codegen unit

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-arc-shared.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-arc-shared.md
@@ -1,0 +1,141 @@
+# own-arc-shared
+
+> Use `Arc<T>` for thread-safe shared ownership
+
+## Why It Matters
+
+`Arc` (Atomic Reference Counted) provides shared ownership across threads. Unlike `Rc`, its reference count is updated atomically, making it safe for concurrent access. Use it when multiple threads need to read the same data.
+
+## Bad
+
+```rust
+use std::rc::Rc;
+use std::thread;
+
+let data = Rc::new(vec![1, 2, 3]);
+let data_clone = Rc::clone(&data);
+
+// ERROR: Rc cannot be sent between threads safely
+thread::spawn(move || {
+    println!("{:?}", data_clone);
+});
+```
+
+## Good
+
+```rust
+use std::sync::Arc;
+use std::thread;
+
+let data = Arc::new(vec![1, 2, 3]);
+let data_clone = Arc::clone(&data);
+
+thread::spawn(move || {
+    println!("{:?}", data_clone);  // Safe!
+});
+
+println!("{:?}", data);  // Original still accessible
+```
+
+## Arc with Mutex for Mutable Shared State
+
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+let counter = Arc::new(Mutex::new(0));
+let mut handles = vec![];
+
+for _ in 0..10 {
+    let counter = Arc::clone(&counter);
+    let handle = thread::spawn(move || {
+        let mut num = counter.lock().unwrap();
+        *num += 1;
+    });
+    handles.push(handle);
+}
+
+for handle in handles {
+    handle.join().unwrap();
+}
+
+println!("Result: {}", *counter.lock().unwrap());
+```
+
+## Arc vs Rc Decision Tree
+
+```
+Need shared ownership?
+├── No → Use owned value or references
+└── Yes → Will it cross thread boundaries?
+    ├── No → Use Rc<T> (cheaper, no atomic ops)
+    └── Yes → Use Arc<T>
+        └── Need mutation?
+            ├── No → Arc<T> is enough
+            └── Yes → Arc<Mutex<T>> or Arc<RwLock<T>>
+```
+
+## Common Patterns
+
+```rust
+use std::sync::Arc;
+
+// Shared configuration (read-only)
+struct AppConfig {
+    database_url: String,
+    max_connections: u32,
+}
+
+fn setup_workers(config: Arc<AppConfig>) {
+    for i in 0..4 {
+        let config = Arc::clone(&config);
+        std::thread::spawn(move || {
+            println!("Worker {} using db: {}", i, config.database_url);
+        });
+    }
+}
+
+// Shared cache with interior mutability
+use std::sync::RwLock;
+use std::collections::HashMap;
+
+type Cache = Arc<RwLock<HashMap<String, String>>>;
+
+fn get_cached(cache: &Cache, key: &str) -> Option<String> {
+    cache.read().unwrap().get(key).cloned()
+}
+
+fn set_cached(cache: &Cache, key: String, value: String) {
+    cache.write().unwrap().insert(key, value);
+}
+```
+
+## Performance Considerations
+
+```rust
+// Arc::clone is cheap - just increments atomic counter
+let a = Arc::new(large_data);
+let b = Arc::clone(&a);  // Fast! No data copied
+
+// But atomic operations have overhead vs Rc
+// Use Rc in single-threaded contexts for better performance
+
+// Avoid cloning Arc in hot loops if possible
+// Bad:
+for item in items {
+    let arc = Arc::clone(&shared);  // Atomic op each iteration
+    process(arc, item);
+}
+
+// Better: Clone once outside loop if possible
+let arc = Arc::clone(&shared);
+for item in items {
+    process(&arc, item);  // Pass reference
+}
+```
+
+## See Also
+
+- [own-rc-single-thread](own-rc-single-thread.md) - Use Rc for single-threaded sharing
+- [own-mutex-interior](own-mutex-interior.md) - Use Mutex for interior mutability
+- [async-clone-before-await](async-clone-before-await.md) - Clone Arc before await points

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-borrow-over-clone.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-borrow-over-clone.md
@@ -1,0 +1,95 @@
+# own-borrow-over-clone
+
+> Prefer `&T` borrowing over `.clone()`
+
+## Why It Matters
+
+Cloning allocates new memory and copies data, while borrowing is free. Unnecessary clones can significantly impact performance, especially in hot paths or with large data structures.
+
+## Bad
+
+```rust
+fn process(data: &String) {
+    let local = data.clone();  // Unnecessary allocation!
+    println!("{}", local);
+}
+
+fn count_words(text: &String) -> usize {
+    let owned = text.clone();  // Why clone just to read?
+    owned.split_whitespace().count()
+}
+
+// Clone in a loop - multiplied cost
+fn process_all(items: &[String]) {
+    for item in items {
+        let copy = item.clone();  // N allocations!
+        handle(&copy);
+    }
+}
+```
+
+## Good
+
+```rust
+fn process(data: &str) {  // Accept &str, more flexible
+    println!("{}", data);  // No allocation needed
+}
+
+fn count_words(text: &str) -> usize {
+    text.split_whitespace().count()  // Just borrow
+}
+
+// Borrow in a loop - zero allocations
+fn process_all(items: &[String]) {
+    for item in items {
+        handle(item);  // Pass reference
+    }
+}
+```
+
+## When Clone Is Acceptable
+
+```rust
+// 1. Need owned data for storage
+struct Cache {
+    data: HashMap<String, String>,
+}
+
+impl Cache {
+    fn insert(&mut self, key: &str, value: &str) {
+        // Clone needed - we're storing owned data
+        self.data.insert(key.to_string(), value.to_string());
+    }
+}
+
+// 2. Need to send across threads
+fn spawn_worker(data: &Config) {
+    let owned = data.clone();  // Clone needed for 'static
+    std::thread::spawn(move || {
+        use_config(owned);
+    });
+}
+
+// 3. Copy types (no heap allocation)
+let x: i32 = 42;
+let y = x;  // Copy, not clone - this is fine
+```
+
+## Evidence
+
+From ripgrep's codebase - uses `Cow` to avoid clones:
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/globset/src/pathutil.rs
+pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
+    match *path {
+        Cow::Borrowed(path) => Cow::Borrowed(&path[last_slash..]),
+        Cow::Owned(ref path) => Cow::Owned(path.clone()),
+    }
+}
+```
+
+## See Also
+
+- [own-slice-over-vec](own-slice-over-vec.md) - Accept slices instead of references to collections
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for conditional ownership
+- [mem-clone-from](mem-clone-from.md) - Reuse allocations when cloning

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-clone-explicit.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-clone-explicit.md
@@ -1,0 +1,135 @@
+# own-clone-explicit
+
+> Use explicit `Clone` for types where copying has meaningful cost
+
+## Why It Matters
+
+Unlike `Copy` which is implicit and "free," `Clone` requires an explicit `.clone()` call, signaling that duplication has a cost. This makes heap allocations and deep copies visible in code, helping developers reason about performance. Types with heap data (`String`, `Vec`, `Box`) should implement `Clone` but not `Copy`.
+
+## Bad
+
+```rust
+// Hiding expensive operations
+fn process_data(data: Vec<u32>) -> Vec<u32> {
+    let backup = data; // Moved, not copied - but unclear at call site
+    transform(backup)
+}
+
+let my_data = vec![1, 2, 3, 4, 5];
+let result = process_data(my_data);
+// my_data is moved - surprise if you expected it to still exist
+```
+
+## Good
+
+```rust
+fn process_data(data: Vec<u32>) -> Vec<u32> {
+    let backup = data; 
+    transform(backup)
+}
+
+let my_data = vec![1, 2, 3, 4, 5];
+let result = process_data(my_data.clone()); // Explicit: "I know this allocates"
+// my_data still available
+
+// Or better - take reference if you don't need ownership
+fn process_data_ref(data: &[u32]) -> Vec<u32> {
+    transform(data)
+}
+let result = process_data_ref(&my_data); // No clone needed
+```
+
+## Custom Clone Implementation
+
+For types with mixed cheap/expensive fields, implement `Clone` manually:
+
+```rust
+#[derive(Debug)]
+struct Document {
+    id: u64,              // Cheap to copy
+    content: String,      // Expensive to clone
+    metadata: Metadata,   // Moderate cost
+}
+
+impl Clone for Document {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            content: self.content.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+    
+    // Optimization: reuse existing allocations
+    fn clone_from(&mut self, source: &Self) {
+        self.id = source.id;
+        self.content.clone_from(&source.content); // Reuses capacity
+        self.metadata.clone_from(&source.metadata);
+    }
+}
+```
+
+## clone_from Optimization
+
+`clone_from` can reuse existing allocations:
+
+```rust
+let mut buffer = String::with_capacity(1000);
+
+// Bad: drops old allocation, creates new one
+buffer = source.clone();
+
+// Good: reuses existing capacity if sufficient
+buffer.clone_from(&source);
+```
+
+## Derive vs Manual Clone
+
+```rust
+// Derive when all fields need cloning
+#[derive(Clone)]
+struct Simple {
+    data: Vec<u8>,
+    name: String,
+}
+
+// Manual when you need special behavior
+struct CachedValue {
+    value: i32,
+    cache: RefCell<Option<ExpensiveComputation>>,
+}
+
+impl Clone for CachedValue {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value,
+            cache: RefCell::new(None), // Don't clone cache, let it rebuild
+        }
+    }
+}
+```
+
+## When to Avoid Clone
+
+```rust
+// Instead of cloning, consider:
+
+// 1. References
+fn process(data: &MyType) { } // Borrow instead of clone
+
+// 2. Cow for conditional cloning
+fn process(data: Cow<'_, str>) { } // Clone only if mutation needed
+
+// 3. Arc for shared ownership
+let shared = Arc::new(expensive_data);
+let handle = shared.clone(); // Cheap: just increments counter
+
+// 4. Passing by value when caller is done with it
+fn consume(data: MyType) { } // Caller moves, no clone
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - When implicit Copy is appropriate
+- [own-cow-conditional](./own-cow-conditional.md) - Avoiding clones with Cow
+- [mem-clone-from](./mem-clone-from.md) - Optimizing repeated clones

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-copy-small.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-copy-small.md
@@ -1,0 +1,124 @@
+# own-copy-small
+
+> Implement `Copy` for small, simple types
+
+## Why It Matters
+
+Types that implement `Copy` are implicitly duplicated on assignment instead of moved. This eliminates the need for explicit `.clone()` calls and makes the code more ergonomic. For small types (generally ≤16 bytes), copying is as fast or faster than moving a pointer.
+
+## Bad
+
+```rust
+// Small type without Copy - requires explicit clone
+#[derive(Clone, Debug)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn distance(p1: Point, p2: Point) -> f64 {
+    ((p2.x - p1.x).powi(2) + (p2.y - p1.y).powi(2)).sqrt()
+}
+
+let origin = Point { x: 0.0, y: 0.0 };
+let target = Point { x: 3.0, y: 4.0 };
+
+let d1 = distance(origin.clone(), target.clone()); // Tedious
+let d2 = distance(origin.clone(), target.clone()); // Every use needs clone
+// origin and target still usable but verbose
+```
+
+## Good
+
+```rust
+// Small type with Copy - implicit duplication
+#[derive(Clone, Copy, Debug)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn distance(p1: Point, p2: Point) -> f64 {
+    ((p2.x - p1.x).powi(2) + (p2.y - p1.y).powi(2)).sqrt()
+}
+
+let origin = Point { x: 0.0, y: 0.0 };
+let target = Point { x: 3.0, y: 4.0 };
+
+let d1 = distance(origin, target); // Implicitly copied
+let d2 = distance(origin, target); // Still works!
+// origin and target remain valid
+```
+
+## Copy Requirements
+
+A type can implement `Copy` only if:
+1. All fields implement `Copy`
+2. No custom `Drop` implementation
+3. No heap-allocated data (`String`, `Vec`, `Box`, etc.)
+
+```rust
+// ✅ Can be Copy
+#[derive(Clone, Copy)]
+struct Color {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+// ❌ Cannot be Copy - contains String
+#[derive(Clone)]
+struct Person {
+    name: String,  // String is not Copy
+    age: u32,
+}
+
+// ❌ Cannot be Copy - has Drop
+struct FileHandle {
+    fd: i32,
+}
+impl Drop for FileHandle {
+    fn drop(&mut self) { /* close file */ }
+}
+```
+
+## Size Guidelines
+
+| Size | Recommendation |
+|------|----------------|
+| ≤ 16 bytes | Implement `Copy` |
+| 17-64 bytes | Consider `Copy`, benchmark if critical |
+| > 64 bytes | Probably don't, prefer references |
+
+```rust
+use std::mem::size_of;
+
+#[derive(Clone, Copy)]
+struct SmallId(u64); // 8 bytes ✅
+
+#[derive(Clone, Copy)]
+struct Rect { x: f32, y: f32, w: f32, h: f32 } // 16 bytes ✅
+
+#[derive(Clone)] // No Copy - 72 bytes
+struct Transform {
+    matrix: [[f64; 3]; 3], // 72 bytes, too large
+}
+```
+
+## Common Copy Types
+
+Standard library types that are `Copy`:
+- All primitives: `i32`, `f64`, `bool`, `char`, etc.
+- References: `&T`, `&mut T`
+- Raw pointers: `*const T`, `*mut T`
+- Function pointers: `fn(T) -> U`
+- Tuples of `Copy` types: `(i32, f64)`
+- Arrays of `Copy` types: `[u8; 32]`
+- `Option<T>` where `T: Copy`
+- `PhantomData<T>`
+
+## See Also
+
+- [own-clone-explicit](./own-clone-explicit.md) - When Clone without Copy is appropriate
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern often uses Copy

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-cow-conditional.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-cow-conditional.md
@@ -1,0 +1,135 @@
+# own-cow-conditional
+
+> Use `Cow<'a, T>` for conditional ownership
+
+## Why It Matters
+
+`Cow` (Clone-on-Write) lets you avoid allocations when you *might* need to own data but usually don't. It holds either a borrowed reference or an owned value, cloning only when mutation is needed.
+
+## Bad
+
+```rust
+// Always allocates, even when input doesn't need modification
+fn normalize_path(path: &str) -> String {
+    if path.contains("//") {
+        path.replace("//", "/")  // Allocation needed
+    } else {
+        path.to_string()  // Unnecessary allocation!
+    }
+}
+
+// Always clones the error message
+fn format_error(code: u32) -> String {
+    match code {
+        404 => "Not Found".to_string(),      // Unnecessary!
+        500 => "Internal Error".to_string(), // Unnecessary!
+        _ => format!("Error {}", code),      // This one needs allocation
+    }
+}
+```
+
+## Good
+
+```rust
+use std::borrow::Cow;
+
+// Only allocates when needed
+fn normalize_path(path: &str) -> Cow<'_, str> {
+    if path.contains("//") {
+        Cow::Owned(path.replace("//", "/"))  // Allocate
+    } else {
+        Cow::Borrowed(path)  // Zero-cost borrow
+    }
+}
+
+// Static strings stay borrowed
+fn format_error(code: u32) -> Cow<'static, str> {
+    match code {
+        404 => Cow::Borrowed("Not Found"),      // No allocation
+        500 => Cow::Borrowed("Internal Error"), // No allocation
+        _ => Cow::Owned(format!("Error {}", code)), // Allocate only for unknown
+    }
+}
+```
+
+## Real-World Example from ripgrep
+
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/globset/src/pathutil.rs
+pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
+    let last_slash = path.rfind_byte(b'/').map(|i| i + 1).unwrap_or(0);
+    match *path {
+        Cow::Borrowed(path) => Some(Cow::Borrowed(&path[last_slash..])),
+        Cow::Owned(ref path) => {
+            let mut path = path.clone();
+            path.drain_bytes(..last_slash);
+            Some(Cow::Owned(path))
+        }
+    }
+}
+```
+
+## Clone-on-Write Pattern
+
+```rust
+use std::borrow::Cow;
+
+fn process_text(text: Cow<'_, str>) -> Cow<'_, str> {
+    if text.contains("bad_word") {
+        // to_mut() clones if borrowed, returns &mut if owned
+        let mut owned = text.into_owned();
+        owned = owned.replace("bad_word", "***");
+        Cow::Owned(owned)
+    } else {
+        text  // Pass through unchanged
+    }
+}
+
+// Usage
+let borrowed: Cow<str> = Cow::Borrowed("hello world");
+let result = process_text(borrowed);  // No allocation!
+
+let with_bad: Cow<str> = Cow::Borrowed("hello bad_word");
+let result = process_text(with_bad);  // Allocates only here
+```
+
+## Cow with Collections
+
+```rust
+use std::borrow::Cow;
+
+// Mixed borrowed/owned in a collection
+fn collect_errors<'a>(
+    static_errors: &[&'static str],
+    dynamic_errors: Vec<String>,
+) -> Vec<Cow<'a, str>> {
+    let mut errors: Vec<Cow<str>> = Vec::new();
+    
+    // Static strings - no allocation
+    for &e in static_errors {
+        errors.push(Cow::Borrowed(e));
+    }
+    
+    // Dynamic strings - take ownership
+    for e in dynamic_errors {
+        errors.push(Cow::Owned(e));
+    }
+    
+    errors
+}
+```
+
+## When to Use Cow
+
+| Situation | Use Cow? |
+|-----------|----------|
+| Usually borrow, sometimes own | Yes |
+| Always need owned data | No, just use owned type |
+| Always borrow | No, just use reference |
+| Hot path, avoiding all allocations | Yes |
+| Returning static strings or formatted | Yes |
+
+## See Also
+
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning
+- [mem-avoid-format](mem-avoid-format.md) - Avoid format! when possible

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-lifetime-elision.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-lifetime-elision.md
@@ -1,0 +1,134 @@
+# own-lifetime-elision
+
+> Rely on lifetime elision rules; add explicit lifetimes only when required
+
+## Why It Matters
+
+Rust's lifetime elision rules handle most common borrowing patterns automatically. Adding explicit lifetimes where they're not needed clutters code without adding clarity. However, understanding when elision applies helps you know when explicit lifetimes are truly necessary.
+
+## Bad
+
+```rust
+// Unnecessary explicit lifetimes - elision handles these
+fn first_word<'a>(s: &'a str) -> &'a str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+fn get_name<'a>(person: &'a Person) -> &'a str {
+    &person.name
+}
+
+impl<'a> Display for Wrapper<'a> {
+    fn fmt<'b>(&'b self, f: &'b mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+```
+
+## Good
+
+```rust
+// Let elision do its job
+fn first_word(s: &str) -> &str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+fn get_name(person: &Person) -> &str {
+    &person.name
+}
+
+impl Display for Wrapper<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+```
+
+## The Three Elision Rules
+
+1. **Each input reference gets its own lifetime:**
+   ```rust
+   fn foo(x: &str, y: &str) 
+   // becomes
+   fn foo<'a, 'b>(x: &'a str, y: &'b str)
+   ```
+
+2. **One input reference → output gets same lifetime:**
+   ```rust
+   fn foo(x: &str) -> &str
+   // becomes  
+   fn foo<'a>(x: &'a str) -> &'a str
+   ```
+
+3. **Method with `&self`/`&mut self` → output gets self's lifetime:**
+   ```rust
+   fn foo(&self, x: &str) -> &str
+   // becomes
+   fn foo<'a, 'b>(&'a self, x: &'b str) -> &'a str
+   ```
+
+## When Explicit Lifetimes ARE Required
+
+```rust
+// Multiple input references, output could come from either
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// Struct holding references
+struct Parser<'input> {
+    source: &'input str,
+    position: usize,
+}
+
+// Multiple distinct lifetimes needed
+struct Context<'s, 'c> {
+    source: &'s str,
+    cache: &'c mut Cache,
+}
+
+// Static lifetime for constants
+fn get_default() -> &'static str {
+    "default"
+}
+```
+
+## Anonymous Lifetime `'_`
+
+Use `'_` to let the compiler infer while being explicit about the presence of a lifetime:
+
+```rust
+// In struct definitions
+impl Iterator for Parser<'_> {
+    type Item = Token;
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+
+// In function signatures where it adds clarity
+fn parse(input: &str) -> Result<Ast<'_>, Error> { ... }
+
+// Especially useful in trait bounds
+fn process(data: &impl AsRef<str>) -> Cow<'_, str> { ... }
+```
+
+## Common Patterns
+
+```rust
+// ✅ Elision works
+fn trim(s: &str) -> &str { s.trim() }
+fn first(v: &[i32]) -> Option<&i32> { v.first() }
+fn name(&self) -> &str { &self.name }
+
+// ❌ Elision fails - multiple inputs, ambiguous output
+fn pick(a: &str, b: &str, first: bool) -> &str // Error!
+
+// ✅ Fixed with explicit lifetime
+fn pick<'a>(a: &'a str, b: &'a str, first: bool) -> &'a str {
+    if first { a } else { b }
+}
+```
+
+## See Also
+
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Prefer borrowing to avoid ownership issues
+- [api-impl-asref](./api-impl-asref.md) - Generic borrowing with AsRef

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-move-large.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-move-large.md
@@ -1,0 +1,134 @@
+# own-move-large
+
+> Move large types instead of copying; use `Box` if moves are expensive
+
+## Why It Matters
+
+In Rust, "moving" a value means copying its bytes to a new location and invalidating the old one. For large types (hundreds of bytes), this memcpy can be expensive. Boxing large types reduces move cost to copying a single pointer (8 bytes), making moves cheap regardless of the actual data size.
+
+## Bad
+
+```rust
+// Large struct moved repeatedly = expensive memcpy each time
+struct GameState {
+    board: [[Cell; 100]; 100],  // 10,000 cells
+    history: [Move; 1000],       // 1,000 moves
+    players: [Player; 4],        // Player data
+    // Total: potentially tens of KB
+}
+
+fn process_state(state: GameState) -> GameState {
+    // Moving ~40KB+ of data
+    let mut new_state = state;  // Memcpy here
+    new_state.apply_rules();
+    new_state  // Memcpy on return
+}
+
+let state = GameState::new();
+let state = process_state(state);  // Two large memcpys
+```
+
+## Good
+
+```rust
+// Box reduces move cost to 8 bytes
+struct GameState {
+    board: Box<[[Cell; 100]; 100]>,  // Pointer to heap
+    history: Vec<Move>,               // Already heap-allocated
+    players: [Player; 4],
+}
+
+fn process_state(mut state: GameState) -> GameState {
+    // Moving just pointers + small inline data
+    state.apply_rules();
+    state  // Cheap move
+}
+
+// Or use Box at call site for one-off cases
+fn process_large(state: Box<LargeStruct>) -> Box<LargeStruct> {
+    // 8-byte move regardless of LargeStruct size
+    state
+}
+```
+
+## When to Box
+
+| Type Size | Move Frequency | Recommendation |
+|-----------|----------------|----------------|
+| < 128 bytes | Any | Don't box |
+| 128-512 bytes | Rare | Probably don't box |
+| 128-512 bytes | Frequent | Consider boxing |
+| > 512 bytes | Any | Box or use references |
+| > 4KB | Any | Definitely box |
+
+## Stack vs Heap Tradeoffs
+
+```rust
+// Stack: fast allocation, limited size, moves copy bytes
+struct StackHeavy {
+    data: [u8; 4096],  // 4KB on stack
+}
+
+// Heap: allocation cost, unlimited size, moves copy pointer
+struct HeapLight {
+    data: Box<[u8; 4096]>,  // 8 bytes on stack, 4KB on heap
+}
+
+// Measure with size_of
+use std::mem::size_of;
+assert_eq!(size_of::<StackHeavy>(), 4096);
+assert_eq!(size_of::<HeapLight>(), 8);
+```
+
+## Alternative: References
+
+When you don't need ownership transfer, use references:
+
+```rust
+// Best: no move at all
+fn analyze_state(state: &GameState) -> Analysis {
+    // Borrows state, no copying
+    compute_analysis(state)
+}
+
+// Mutable borrow for in-place modification
+fn update_state(state: &mut GameState) {
+    state.tick();
+}
+```
+
+## Pattern: Builder Returns Boxed
+
+```rust
+impl LargeConfig {
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+}
+
+impl ConfigBuilder {
+    // Return boxed to avoid large move
+    pub fn build(self) -> Box<LargeConfig> {
+        Box::new(LargeConfig {
+            // ... fields from builder
+        })
+    }
+}
+```
+
+## Profile First
+
+Don't prematurely optimize. Use tools to identify if moves are actually a bottleneck:
+
+```rust
+// Check type sizes
+println!("Size of GameState: {}", std::mem::size_of::<GameState>());
+
+// Profile with cargo flamegraph or perf to find hot memcpys
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - Cheap types should be Copy
+- [mem-box-large-variant](./mem-box-large-variant.md) - Boxing enum variants
+- [perf-profile-first](./perf-profile-first.md) - Measure before optimizing

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-mutex-interior.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-mutex-interior.md
@@ -1,0 +1,105 @@
+# own-mutex-interior
+
+> Use `Mutex<T>` for interior mutability across threads
+
+## Why It Matters
+
+When you need shared mutable state across threads, `Mutex<T>` provides safe interior mutability with synchronization. Unlike `RefCell`, `Mutex` is `Send + Sync` and uses OS-level locking to ensure only one thread can access the data at a time.
+
+## Bad
+
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+
+// RefCell is !Sync - this won't compile
+let shared = Arc::new(RefCell::new(vec![]));
+
+// ERROR: RefCell cannot be shared between threads safely
+std::thread::spawn({
+    let shared = shared.clone();
+    move || shared.borrow_mut().push(1)
+});
+```
+
+## Good
+
+```rust
+use std::sync::{Arc, Mutex};
+
+let shared = Arc::new(Mutex::new(vec![]));
+
+let handles: Vec<_> = (0..10).map(|i| {
+    let shared = shared.clone();
+    std::thread::spawn(move || {
+        let mut data = shared.lock().unwrap();
+        data.push(i);
+    })
+}).collect();
+
+for handle in handles {
+    handle.join().unwrap();
+}
+
+println!("{:?}", shared.lock().unwrap()); // All values present
+```
+
+## Mutex Poisoning
+
+If a thread panics while holding a lock, the mutex becomes "poisoned":
+
+```rust
+use std::sync::{Arc, Mutex};
+
+let mutex = Arc::new(Mutex::new(0));
+
+// Handle poisoning gracefully
+match mutex.lock() {
+    Ok(guard) => println!("Value: {}", *guard),
+    Err(poisoned) => {
+        // Recover the data anyway
+        let guard = poisoned.into_inner();
+        println!("Recovered value: {}", *guard);
+    }
+}
+
+// Or ignore poisoning (use with caution)
+let guard = mutex.lock().unwrap_or_else(|e| e.into_inner());
+```
+
+## Prefer parking_lot::Mutex
+
+For better performance, consider `parking_lot::Mutex`:
+
+```rust
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+let shared = Arc::new(Mutex::new(vec![]));
+
+// No poisoning, no Result to unwrap
+let mut data = shared.lock();
+data.push(42);
+// Lock automatically released when guard drops
+```
+
+Benefits of `parking_lot`:
+- No poisoning (returns guard directly)
+- Smaller size (1 byte vs 40+ bytes)
+- Better performance under contention
+- Fair locking option available
+
+## When to Use What
+
+| Type | Threading | Overhead | Use Case |
+|------|-----------|----------|----------|
+| `RefCell<T>` | Single | Minimal | Interior mutability, same thread |
+| `Mutex<T>` | Multi | Locking | Shared mutable state across threads |
+| `RwLock<T>` | Multi | Locking | Many readers, few writers |
+| `parking_lot::Mutex` | Multi | Less | Drop-in std::Mutex replacement |
+
+## See Also
+
+- [own-rwlock-readers](./own-rwlock-readers.md) - When reads dominate writes
+- [own-refcell-interior](./own-refcell-interior.md) - Single-threaded alternative
+- [async-no-lock-await](./async-no-lock-await.md) - Avoiding locks across await points

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-rc-single-thread.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-rc-single-thread.md
@@ -1,0 +1,65 @@
+# own-rc-single-thread
+
+> Use `Rc<T>` for shared ownership in single-threaded contexts
+
+## Why It Matters
+
+`Rc<T>` (Reference Counted) provides shared ownership without the atomic overhead of `Arc<T>`. In single-threaded code, `Rc` is faster because it uses non-atomic reference counting. Using `Arc` when you don't need thread-safety wastes CPU cycles on unnecessary synchronization.
+
+## Bad
+
+```rust
+use std::sync::Arc;
+
+// Single-threaded application using Arc unnecessarily
+fn build_tree() -> Arc<Node> {
+    let root = Arc::new(Node::new("root"));
+    let child1 = Arc::new(Node::new("child1"));
+    let child2 = Arc::new(Node::new("child2"));
+    
+    // All in same thread, but paying atomic overhead
+    root.add_child(child1.clone());
+    root.add_child(child2.clone());
+    root
+}
+```
+
+Atomic operations have measurable overhead even without contention.
+
+## Good
+
+```rust
+use std::rc::Rc;
+
+// Single-threaded: use Rc for zero atomic overhead
+fn build_tree() -> Rc<Node> {
+    let root = Rc::new(Node::new("root"));
+    let child1 = Rc::new(Node::new("child1"));
+    let child2 = Rc::new(Node::new("child2"));
+    
+    root.add_child(child1.clone());
+    root.add_child(child2.clone());
+    root
+}
+
+// Compiler enforces single-thread: Rc is !Send + !Sync
+// Attempting to send across threads = compile error
+```
+
+## Decision Guide
+
+| Scenario | Use |
+|----------|-----|
+| Single-threaded, shared ownership | `Rc<T>` |
+| Multi-threaded, shared ownership | `Arc<T>` |
+| Single owner, might need multiple later | Start with `Rc`, upgrade if needed |
+| Library code, unknown threading model | `Arc<T>` (safer default) |
+
+## Evidence
+
+The Rust standard library itself uses `Rc` extensively in single-threaded contexts like the `std::rc` module documentation examples.
+
+## See Also
+
+- [own-arc-shared](./own-arc-shared.md) - When you need thread-safe sharing
+- [own-refcell-interior](./own-refcell-interior.md) - Combining Rc with interior mutability

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-refcell-interior.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-refcell-interior.md
@@ -1,0 +1,97 @@
+# own-refcell-interior
+
+> Use `RefCell<T>` for interior mutability in single-threaded code
+
+## Why It Matters
+
+Rust's borrow checker enforces rules at compile time, but sometimes you need to mutate data through a shared reference. `RefCell<T>` moves borrow checking to runtime, allowing mutation through `&self`. This is essential for patterns like caches, lazy initialization, and observer patterns where compile-time borrowing is too restrictive.
+
+## Bad
+
+```rust
+struct Cache {
+    // Requires &mut self to update, breaking shared reference patterns
+    data: HashMap<String, String>,
+}
+
+impl Cache {
+    fn get_or_compute(&mut self, key: &str) -> &str {
+        // Caller needs &mut Cache, can't share cache reference
+        if !self.data.contains_key(key) {
+            self.data.insert(key.to_string(), expensive_compute(key));
+        }
+        &self.data[key]
+    }
+}
+```
+
+This forces exclusive access even for logically shared operations.
+
+## Good
+
+```rust
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+struct Cache {
+    data: RefCell<HashMap<String, String>>,
+}
+
+impl Cache {
+    fn get_or_compute(&self, key: &str) -> String {
+        // Can mutate through &self
+        let mut data = self.data.borrow_mut();
+        if !data.contains_key(key) {
+            data.insert(key.to_string(), expensive_compute(key));
+        }
+        data[key].clone()
+    }
+}
+
+// Multiple references can coexist
+let cache = Cache::new();
+let ref1 = &cache;
+let ref2 = &cache;
+ref1.get_or_compute("key1");
+ref2.get_or_compute("key2");
+```
+
+## Common Pattern: Rc<RefCell<T>>
+
+```rust
+use std::rc::Rc;
+use std::cell::RefCell;
+
+// Shared mutable state in single-threaded code
+type SharedState = Rc<RefCell<AppState>>;
+
+fn create_handlers(state: SharedState) -> Vec<Box<dyn Fn()>> {
+    vec![
+        Box::new({
+            let state = state.clone();
+            move || state.borrow_mut().increment()
+        }),
+        Box::new({
+            let state = state.clone();
+            move || state.borrow_mut().decrement()
+        }),
+    ]
+}
+```
+
+## Runtime Panics
+
+`RefCell` panics if you violate borrowing rules at runtime:
+
+```rust
+let cell = RefCell::new(5);
+let borrow1 = cell.borrow();
+let borrow2 = cell.borrow_mut(); // PANIC: already borrowed
+```
+
+Use `try_borrow()` and `try_borrow_mut()` for fallible borrowing.
+
+## See Also
+
+- [own-rc-single-thread](./own-rc-single-thread.md) - Combining with Rc for shared ownership
+- [own-mutex-interior](./own-mutex-interior.md) - Thread-safe alternative

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-rwlock-readers.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-rwlock-readers.md
@@ -1,0 +1,122 @@
+# own-rwlock-readers
+
+> Use `RwLock<T>` when reads significantly outnumber writes
+
+## Why It Matters
+
+`Mutex<T>` allows only one thread to access data at a time, even for reads. `RwLock<T>` allows multiple concurrent readers OR one exclusive writer. For read-heavy workloads, this dramatically improves throughput by eliminating unnecessary serialization of read operations.
+
+## Bad
+
+```rust
+use std::sync::{Arc, Mutex};
+
+// Configuration rarely changes but is read constantly
+let config = Arc::new(Mutex::new(Config::load()));
+
+// Every read blocks other reads unnecessarily
+fn get_setting(config: &Mutex<Config>, key: &str) -> String {
+    let guard = config.lock().unwrap();
+    guard.get(key).to_string()
+}
+
+// 100 threads reading = serialized, one at a time
+```
+
+## Good
+
+```rust
+use std::sync::{Arc, RwLock};
+
+// Multiple readers can proceed concurrently
+let config = Arc::new(RwLock::new(Config::load()));
+
+fn get_setting(config: &RwLock<Config>, key: &str) -> String {
+    let guard = config.read().unwrap(); // Multiple threads can hold read lock
+    guard.get(key).to_string()
+}
+
+fn update_setting(config: &RwLock<Config>, key: &str, value: &str) {
+    let mut guard = config.write().unwrap(); // Exclusive access for writes
+    guard.set(key, value);
+}
+
+// 100 threads reading = parallel execution
+```
+
+## parking_lot::RwLock
+
+Prefer `parking_lot::RwLock` for better performance:
+
+```rust
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+let data = Arc::new(RwLock::new(HashMap::new()));
+
+// Read - no unwrap needed
+let value = data.read().get("key").cloned();
+
+// Write
+data.write().insert("key".to_string(), "value".to_string());
+
+// Upgradeable read lock (unique to parking_lot)
+let upgradeable = data.upgradable_read();
+if upgradeable.get("key").is_none() {
+    let mut write = parking_lot::RwLockUpgradableReadGuard::upgrade(upgradeable);
+    write.insert("key".to_string(), "default".to_string());
+}
+```
+
+## When RwLock Hurts
+
+RwLock has overhead for tracking readers. It can be slower than Mutex when:
+
+| Scenario | Better Choice |
+|----------|---------------|
+| Writes are frequent (>20% of operations) | `Mutex` |
+| Lock held very briefly | `Mutex` |
+| Single-threaded | `RefCell` |
+| Reads dominate, lock held longer | `RwLock` |
+
+## Write Starvation
+
+Standard `RwLock` may starve writers if readers are continuous. `parking_lot::RwLock` is fair by default.
+
+```rust
+// parking_lot is writer-fair, preventing starvation
+use parking_lot::RwLock;
+
+// Or use std with explicit fairness (nightly)
+// #![feature(rwlock_downgrade)]
+```
+
+## Real-World Pattern: Cached Computation
+
+```rust
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+struct CachedData {
+    cache: RwLock<Option<ExpensiveResult>>,
+}
+
+impl CachedData {
+    fn get(&self) -> ExpensiveResult {
+        // Fast path: read lock
+        if let Some(cached) = self.cache.read().as_ref() {
+            return cached.clone();
+        }
+        
+        // Slow path: compute and cache
+        let result = compute_expensive();
+        *self.cache.write() = Some(result.clone());
+        result
+    }
+}
+```
+
+## See Also
+
+- [own-mutex-interior](./own-mutex-interior.md) - When writes are frequent
+- [async-no-lock-await](./async-no-lock-await.md) - RwLock in async contexts

--- a/.cursor/skills/rust-skills-leonardomso/rules/own-slice-over-vec.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/own-slice-over-vec.md
@@ -1,0 +1,119 @@
+# own-slice-over-vec
+
+> Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+
+## Why It Matters
+
+Accepting `&[T]` instead of `&Vec<T>` makes your function more flexible - it can accept slices from arrays, vectors, or other sources. Similarly, `&str` accepts string slices from `String`, `&'static str`, or substrings.
+
+## Bad
+
+```rust
+// Overly restrictive - only accepts &Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// Overly restrictive - only accepts &String
+fn greet(name: &String) {
+    println!("Hello, {}", name);
+}
+
+// Can't call with arrays or slices
+let arr = [1, 2, 3];
+// sum(&arr);  // ERROR: expected &Vec<i32>
+
+let literal = "world";
+// greet(&literal);  // ERROR: expected &String
+```
+
+## Good
+
+```rust
+// Flexible - accepts any slice-like thing
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// Flexible - accepts any string-like thing
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// Now all of these work:
+let vec = vec![1, 2, 3];
+let arr = [4, 5, 6];
+let slice = &vec[0..2];
+
+sum(&vec);    // Vec coerces to slice
+sum(&arr);    // Array coerces to slice
+sum(slice);   // Slice works directly
+
+let string = String::from("Alice");
+let literal = "Bob";
+
+greet(&string);  // String coerces to &str
+greet(literal);  // &str works directly
+```
+
+## The Deref Coercion Chain
+
+```rust
+// These coercions happen automatically:
+// Vec<T>  -> &[T]   (via Deref)
+// String  -> &str   (via Deref)
+// Box<T>  -> &T     (via Deref)
+// Arc<T>  -> &T     (via Deref)
+
+fn process(data: &[u8]) { /* ... */ }
+
+let vec: Vec<u8> = vec![1, 2, 3];
+let boxed: Box<[u8]> = vec.into_boxed_slice();
+let arc: Arc<[u8]> = Arc::from(&[1, 2, 3][..]);
+
+process(&vec);    // Works
+process(&boxed);  // Works
+process(&arc);    // Works
+```
+
+## Path Types Too
+
+```rust
+// Bad
+fn read_config(path: &PathBuf) -> Config { /* ... */ }
+
+// Good - accepts &Path, &PathBuf, &str, &String
+fn read_config(path: &Path) -> Config { /* ... */ }
+
+// Even better - accept anything path-like
+fn read_config(path: impl AsRef<Path>) -> Config {
+    let path = path.as_ref();
+    // ...
+}
+```
+
+## When to Accept Owned Types
+
+```rust
+// Accept owned when you need to store it
+struct Logger {
+    prefix: String,  // Needs to own the string
+}
+
+impl Logger {
+    // Take ownership - caller decides to clone or move
+    fn new(prefix: String) -> Self {
+        Self { prefix }
+    }
+    
+    // Or use Into for flexibility
+    fn with_prefix(prefix: impl Into<String>) -> Self {
+        Self { prefix: prefix.into() }
+    }
+}
+```
+
+## See Also
+
+- [api-impl-asref](api-impl-asref.md) - Accept `impl AsRef<T>` for maximum flexibility
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-black-box-bench.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-black-box-bench.md
@@ -1,0 +1,153 @@
+# perf-black-box-bench
+
+> Use black_box in benchmarks
+
+## Why It Matters
+
+The compiler aggressively optimizes code, potentially eliminating computations whose results aren't used. In benchmarks, this can lead to measuring nothing instead of the actual code. `std::hint::black_box()` prevents the compiler from optimizing away values, ensuring accurate measurements.
+
+## Bad
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_bad(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            let result = expensive_computation(42);
+            // Result unused - compiler may eliminate the call!
+        });
+    });
+}
+
+fn benchmark_also_bad(c: &mut Criterion) {
+    let input = 42;  // Constant - compiler may precompute
+    
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            expensive_computation(input)
+            // Return value may still be optimized away
+        });
+    });
+}
+```
+
+## Good
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_good(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            // black_box on input prevents constant folding
+            let result = expensive_computation(black_box(42));
+            // black_box on output prevents dead code elimination
+            black_box(result)
+        });
+    });
+}
+
+// Or simpler with Criterion's built-in support
+fn benchmark_simpler(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| expensive_computation(black_box(42)))
+    });
+}
+```
+
+## What black_box Does
+
+| Without black_box | With black_box |
+|-------------------|----------------|
+| Input may be constant-folded | Input treated as unknown |
+| Result may be eliminated | Result must be computed |
+| Loops may be optimized away | Each iteration runs |
+| Functions may be inlined | Call semantics preserved |
+
+## Standard Library Usage
+
+```rust
+use std::hint::black_box;
+
+fn main() {
+    // In std since Rust 1.66
+    let result = black_box(compute_something(black_box(input)));
+}
+```
+
+## Criterion's black_box
+
+Criterion re-exports `std::hint::black_box`:
+
+```rust
+use criterion::black_box;
+
+// Equivalent to std::hint::black_box
+```
+
+## Pattern: Benchmark with Setup
+
+```rust
+fn benchmark_with_setup(c: &mut Criterion) {
+    c.bench_function("process_data", |b| {
+        // Setup outside iter - not measured
+        let data = generate_test_data(1000);
+        
+        b.iter(|| {
+            // black_box the input reference
+            let result = process(black_box(&data));
+            black_box(result)
+        });
+    });
+}
+```
+
+## Pattern: Benchmark Multiple Inputs
+
+```rust
+fn benchmark_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling");
+    
+    for size in [100, 1000, 10000] {
+        let data = generate_data(size);
+        
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &data,
+            |b, data| {
+                b.iter(|| process(black_box(data)))
+            },
+        );
+    }
+    group.finish();
+}
+```
+
+## Common Mistakes
+
+```rust
+// WRONG: black_box inside loop does nothing useful
+for _ in 0..1000 {
+    black_box(());  // Doesn't help
+    compute();
+}
+
+// RIGHT: black_box the computation result
+for _ in 0..1000 {
+    black_box(compute());
+}
+
+// WRONG: Only blocking output, not input
+let x = 42;  // Constant, may be optimized
+black_box(expensive(x));
+
+// RIGHT: Block both
+black_box(expensive(black_box(42)));
+```
+
+## See Also
+
+- [test-criterion-bench](./test-criterion-bench.md) - Using Criterion
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimize
+- [perf-release-profile](./perf-release-profile.md) - Release settings

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-chain-avoid.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-chain-avoid.md
@@ -1,0 +1,136 @@
+# perf-chain-avoid
+
+> Avoid chain in hot loops
+
+## Why It Matters
+
+`Iterator::chain()` adds overhead for checking which iterator is active on every `.next()` call. In hot loops, this branch prediction overhead can impact performance. For performance-critical code, prefer single iterators or pre-combined collections.
+
+## Bad
+
+```rust
+// Chain in hot inner loop
+fn process_hot_path(a: &[i32], b: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    
+    // Called millions of times
+    for _ in 0..1_000_000 {
+        for x in a.iter().chain(b.iter()) {  // Branch every iteration
+            sum += *x as i64;
+        }
+    }
+    sum
+}
+
+// Chaining multiple small slices in tight loop
+fn combine_results(parts: &[&[u8]]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for part in parts {
+        for byte in std::iter::once(&0u8).chain(part.iter()) {
+            result.push(*byte);
+        }
+    }
+    result
+}
+```
+
+## Good
+
+```rust
+// Separate loops - branch-free inner loops
+fn process_hot_path(a: &[i32], b: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    
+    for _ in 0..1_000_000 {
+        for x in a {
+            sum += *x as i64;
+        }
+        for x in b {
+            sum += *x as i64;
+        }
+    }
+    sum
+}
+
+// Pre-combine outside hot loop
+fn combine_results(parts: &[&[u8]]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for part in parts {
+        result.push(0u8);
+        result.extend_from_slice(part);
+    }
+    result
+}
+```
+
+## When Chain Is Fine
+
+Chain is perfectly acceptable when:
+
+```rust
+// One-time iteration, not in hot path
+fn collect_all(a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    a.into_iter().chain(b).collect()
+}
+
+// Lazy evaluation with short-circuit
+fn find_in_either(a: &[Item], b: &[Item], target: i32) -> Option<&Item> {
+    a.iter().chain(b.iter()).find(|x| x.id == target)
+}
+
+// Small number of elements
+fn get_prefixes() -> impl Iterator<Item = &'static str> {
+    ["Mr.", "Mrs.", "Dr."].iter().copied()
+        .chain(["Prof."].iter().copied())
+}
+```
+
+## Alternative Patterns
+
+### Pre-allocate and Extend
+
+```rust
+fn merge_slices(slices: &[&[i32]]) -> Vec<i32> {
+    let total: usize = slices.iter().map(|s| s.len()).sum();
+    let mut result = Vec::with_capacity(total);
+    for slice in slices {
+        result.extend_from_slice(slice);
+    }
+    result
+}
+```
+
+### Use append for Vecs
+
+```rust
+fn combine_vecs(mut a: Vec<i32>, mut b: Vec<i32>) -> Vec<i32> {
+    a.append(&mut b);  // Moves elements, no reallocation if a has capacity
+    a
+}
+```
+
+### Flatten Instead of Chain
+
+```rust
+// Instead of: a.iter().chain(b.iter()).chain(c.iter())
+let all = [a, b, c];
+for item in all.iter().flat_map(|slice| slice.iter()) {
+    process(item);
+}
+```
+
+## Performance Impact
+
+| Pattern | Per-Item Overhead |
+|---------|-------------------|
+| Single iterator | None |
+| `chain(a, b)` | 1 branch per item |
+| `chain(a, b, c)` | 2 branches per item |
+| Nested chains | Compounds |
+| Separate loops | None (but code duplication) |
+
+## See Also
+
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache-friendly patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-collect-into.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-collect-into.md
@@ -1,0 +1,133 @@
+# perf-collect-into
+
+> Use collect_into for reusing containers
+
+## Why It Matters
+
+`collect_into()` (stabilized in Rust 1.83) allows collecting iterator results into an existing collection, reusing its allocation. This avoids the allocation that `collect()` would make for a new collection.
+
+## Bad
+
+```rust
+// Allocates new Vec each time
+fn process_batches(batches: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
+    batches.into_iter()
+        .map(|batch| {
+            batch.into_iter()
+                .filter(|x| *x > 0)
+                .collect::<Vec<_>>()  // New allocation per batch
+        })
+        .collect()
+}
+
+// Can't reuse cleared buffer
+fn filter_loop(data: &[Vec<i32>]) {
+    for batch in data {
+        let filtered: Vec<_> = batch.iter()
+            .filter(|&&x| x > 0)
+            .copied()
+            .collect();  // New allocation each iteration
+        process(&filtered);
+    }
+}
+```
+
+## Good
+
+```rust
+// Reuse buffer with collect_into
+fn filter_loop(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();  // Keep allocation
+        batch.iter()
+            .filter(|&&x| x > 0)
+            .copied()
+            .collect_into(&mut buffer);
+        process(&buffer);
+    }
+}
+
+// Also works with extend pattern
+fn filter_loop_extend(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();
+        buffer.extend(
+            batch.iter()
+                .filter(|&&x| x > 0)
+                .copied()
+        );
+        process(&buffer);
+    }
+}
+```
+
+## Pre-1.83 Alternative: extend
+
+Before `collect_into()` was stabilized, use `extend()`:
+
+```rust
+fn reuse_buffer(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();
+        buffer.extend(batch.iter().filter(|&&x| x > 0).copied());
+        process(&buffer);
+    }
+}
+```
+
+## Pattern: Transform and Reuse
+
+```rust
+fn transform_batches(batches: &[Vec<RawData>]) -> Vec<ProcessedData> {
+    let mut temp = Vec::new();
+    let mut all_results = Vec::new();
+    
+    for batch in batches {
+        temp.clear();
+        batch.iter()
+            .map(ProcessedData::from)
+            .collect_into(&mut temp);
+        
+        // Process temp, append to results
+        all_results.extend(temp.drain(..).filter(|p| p.is_valid()));
+    }
+    
+    all_results
+}
+```
+
+## Supported Collections
+
+`collect_into()` works with any type implementing `Extend`:
+
+```rust
+use std::collections::{HashSet, HashMap, VecDeque};
+
+let mut vec = Vec::new();
+let mut set = HashSet::new();
+let mut deque = VecDeque::new();
+
+(0..10).collect_into(&mut vec);
+(0..10).collect_into(&mut set);
+(0..10).collect_into(&mut deque);
+```
+
+## Comparison
+
+| Method | Allocation | Buffer Reuse |
+|--------|------------|--------------|
+| `.collect()` | New each time | No |
+| `.collect_into(&mut buf)` | Reuses buffer | Yes |
+| `buf.extend(iter)` | Reuses buffer | Yes |
+
+## See Also
+
+- [perf-drain-reuse](./perf-drain-reuse.md) - Drain for reuse
+- [mem-reuse-collections](./mem-reuse-collections.md) - Collection reuse
+- [perf-extend-batch](./perf-extend-batch.md) - Batch extensions

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-collect-once.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-collect-once.md
@@ -1,0 +1,120 @@
+# perf-collect-once
+
+> Don't collect intermediate iterators
+
+## Why It Matters
+
+Each `.collect()` allocates a new collection. Chaining multiple operations with intermediate collections wastes memory and CPU cycles. Keep iterator chains lazy and collect only once at the end.
+
+## Bad
+
+```rust
+// Three allocations, three passes
+fn process_users(users: Vec<User>) -> Vec<String> {
+    let active: Vec<_> = users.into_iter()
+        .filter(|u| u.is_active)
+        .collect();
+    
+    let verified: Vec<_> = active.into_iter()
+        .filter(|u| u.is_verified)
+        .collect();
+    
+    verified.into_iter()
+        .map(|u| u.name)
+        .collect()
+}
+
+// Collecting to count
+fn count_valid(items: &[Item]) -> usize {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .collect::<Vec<_>>()  // Unnecessary!
+        .len()
+}
+```
+
+## Good
+
+```rust
+// One allocation, one pass
+fn process_users(users: Vec<User>) -> Vec<String> {
+    users.into_iter()
+        .filter(|u| u.is_active)
+        .filter(|u| u.is_verified)
+        .map(|u| u.name)
+        .collect()
+}
+
+// No allocation needed
+fn count_valid(items: &[Item]) -> usize {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .count()
+}
+```
+
+## Pattern: Deferred Collection
+
+```rust
+// Create the iterator chain
+fn prepare_data(raw: Vec<RawData>) -> impl Iterator<Item = ProcessedData> {
+    raw.into_iter()
+        .filter(|d| d.is_valid())
+        .map(ProcessedData::from)
+}
+
+// Collect only when needed
+let data: Vec<_> = prepare_data(input).collect();
+
+// Or consume without collecting
+prepare_data(input).for_each(|d| process(d));
+```
+
+## When Intermediate Collection Is Needed
+
+```rust
+// Need to iterate multiple times
+let items: Vec<_> = data.iter()
+    .filter(|x| x.is_valid())
+    .collect();
+
+let count = items.len();
+let first = items.first();
+for item in &items {
+    process(item);
+}
+
+// Need to sort (requires concrete collection)
+let mut sorted: Vec<_> = data.iter()
+    .filter(|x| x.is_active)
+    .collect();
+sorted.sort_by_key(|x| x.priority);
+```
+
+## Comparison
+
+| Approach | Allocations | Passes | Memory |
+|----------|-------------|--------|--------|
+| Multiple `.collect()` | N | N | O(N × data) |
+| Single chain + `.collect()` | 1 | 1 | O(data) |
+| No `.collect()` (streaming) | 0 | 1 | O(1) |
+
+## Pattern: Collect with Capacity
+
+When you must collect, pre-allocate:
+
+```rust
+// With estimated capacity
+let mut result = Vec::with_capacity(items.len());
+result.extend(
+    items.iter()
+        .filter(|x| x.is_valid())
+        .map(|x| x.clone())
+);
+```
+
+## See Also
+
+- [perf-iter-lazy](./perf-iter-lazy.md) - Keep iterators lazy
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocate collections
+- [anti-collect-intermediate](./anti-collect-intermediate.md) - Anti-pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-drain-reuse.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-drain-reuse.md
@@ -1,0 +1,137 @@
+# perf-drain-reuse
+
+> Use drain to reuse allocations
+
+## Why It Matters
+
+`drain()` removes elements from a collection while keeping its allocated capacity. This allows reusing the same allocation across iterations, avoiding repeated allocate/deallocate cycles in loops.
+
+## Bad
+
+```rust
+// Allocates new Vec every iteration
+fn process_batches(data: Vec<Item>) {
+    let mut remaining = data;
+    
+    while !remaining.is_empty() {
+        let batch: Vec<_> = remaining.drain(..100.min(remaining.len())).collect();
+        process_batch(batch);
+        // remaining keeps its capacity - good
+        // but batch allocates new every time - bad
+    }
+}
+
+// Clears and reallocates
+fn reuse_buffer() {
+    for _ in 0..1000 {
+        let mut buffer = Vec::new();  // Allocates each iteration
+        fill_buffer(&mut buffer);
+        process(&buffer);
+    }
+}
+```
+
+## Good
+
+```rust
+// Reuses allocation with drain
+fn process_batches(mut data: Vec<Item>) {
+    let mut batch = Vec::with_capacity(100);
+    
+    while !data.is_empty() {
+        batch.extend(data.drain(..100.min(data.len())));
+        process_batch(&batch);
+        batch.clear();  // Keeps capacity
+    }
+}
+
+// Reuses buffer across iterations
+fn reuse_buffer() {
+    let mut buffer = Vec::new();
+    
+    for _ in 0..1000 {
+        buffer.clear();  // Keeps capacity
+        fill_buffer(&mut buffer);
+        process(&buffer);
+    }
+}
+```
+
+## Drain Methods
+
+| Collection | Method | Behavior |
+|------------|--------|----------|
+| `Vec<T>` | `.drain(range)` | Remove range, shift remaining |
+| `Vec<T>` | `.drain(..)` | Remove all (like clear) |
+| `VecDeque<T>` | `.drain(range)` | Remove range |
+| `String` | `.drain(range)` | Remove char range |
+| `HashMap<K,V>` | `.drain()` | Remove all entries |
+| `HashSet<T>` | `.drain()` | Remove all elements |
+
+## Pattern: Batch Processing
+
+```rust
+fn process_in_chunks(mut items: Vec<Item>, chunk_size: usize) {
+    while !items.is_empty() {
+        let chunk: Vec<_> = items.drain(..chunk_size.min(items.len())).collect();
+        process_chunk(chunk);
+    }
+}
+```
+
+## Pattern: Transfer Between Collections
+
+```rust
+// Move all elements without reallocation
+fn transfer_all(src: &mut Vec<Item>, dst: &mut Vec<Item>) {
+    dst.extend(src.drain(..));
+    // src is now empty but keeps capacity
+}
+
+// Move matching elements
+fn transfer_matching(src: &mut Vec<Item>, dst: &mut Vec<Item>, predicate: impl Fn(&Item) -> bool) {
+    let matching: Vec<_> = src.drain(..).filter(predicate).collect();
+    dst.extend(matching);
+}
+```
+
+## Pattern: HashMap Drain
+
+```rust
+use std::collections::HashMap;
+
+fn process_and_clear(map: &mut HashMap<String, Value>) {
+    // Process all entries, clearing the map
+    for (key, value) in map.drain() {
+        process(key, value);
+    }
+    // map is now empty but keeps capacity
+}
+```
+
+## drain vs clear vs take
+
+| Operation | Elements | Capacity | Returns |
+|-----------|----------|----------|---------|
+| `.clear()` | Removed | Kept | Nothing |
+| `.drain(..)` | Removed | Kept | Iterator |
+| `std::mem::take()` | Moved out | Reset to 0 | Owned collection |
+
+```rust
+// clear: just empty
+vec.clear();
+
+// drain: empty and iterate
+for item in vec.drain(..) {
+    process(item);
+}
+
+// take: swap with empty, get ownership
+let old_vec = std::mem::take(&mut vec);
+```
+
+## See Also
+
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing collections
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-entry-api.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-entry-api.md
@@ -1,0 +1,134 @@
+# perf-entry-api
+
+> Use entry API for map insert-or-update
+
+## Why It Matters
+
+The entry API performs a single lookup for insert-or-update operations. Without it, you lookup twice: once to check existence, once to insert. For `HashMap` and `BTreeMap`, the entry API is both faster and more idiomatic.
+
+## Bad
+
+```rust
+use std::collections::HashMap;
+
+// Double lookup: contains_key + insert
+fn increment(map: &mut HashMap<String, u32>, key: String) {
+    if map.contains_key(&key) {
+        *map.get_mut(&key).unwrap() += 1;
+    } else {
+        map.insert(key, 1);
+    }
+}
+
+// Double lookup with get + insert
+fn get_or_insert(map: &mut HashMap<String, Vec<i32>>, key: String) -> &mut Vec<i32> {
+    if !map.contains_key(&key) {
+        map.insert(key.clone(), Vec::new());
+    }
+    map.get_mut(&key).unwrap()
+}
+
+// Triple lookup pattern
+fn update_or_default(map: &mut HashMap<String, Config>, key: &str, value: i32) {
+    match map.get(key) {
+        Some(config) => {
+            let mut new_config = config.clone();
+            new_config.value = value;
+            map.insert(key.to_string(), new_config);
+        }
+        None => {
+            map.insert(key.to_string(), Config::default());
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+// Single lookup with entry
+fn increment(map: &mut HashMap<String, u32>, key: String) {
+    *map.entry(key).or_insert(0) += 1;
+}
+
+// Single lookup, returns mutable reference
+fn get_or_insert(map: &mut HashMap<String, Vec<i32>>, key: String) -> &mut Vec<i32> {
+    map.entry(key).or_insert_with(Vec::new)
+}
+
+// Single lookup with and_modify
+fn update_or_default(map: &mut HashMap<String, Config>, key: String, value: i32) {
+    map.entry(key)
+        .and_modify(|config| config.value = value)
+        .or_insert_with(Config::default);
+}
+```
+
+## Entry API Methods
+
+| Method | Behavior |
+|--------|----------|
+| `.or_insert(val)` | Insert `val` if empty |
+| `.or_insert_with(f)` | Insert `f()` if empty (lazy) |
+| `.or_default()` | Insert `Default::default()` if empty |
+| `.and_modify(f)` | Apply `f` if occupied |
+| `.or_insert_with_key(f)` | Insert `f(&key)` if empty |
+
+## Pattern: Count Occurrences
+
+```rust
+fn word_count(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for word in text.split_whitespace() {
+        *counts.entry(word).or_insert(0) += 1;
+    }
+    counts
+}
+```
+
+## Pattern: Group By
+
+```rust
+fn group_by_category(items: Vec<Item>) -> HashMap<Category, Vec<Item>> {
+    let mut groups: HashMap<Category, Vec<Item>> = HashMap::new();
+    for item in items {
+        groups.entry(item.category.clone())
+            .or_default()
+            .push(item);
+    }
+    groups
+}
+```
+
+## Pattern: Complex Entry Logic
+
+```rust
+match map.entry(key) {
+    Entry::Occupied(mut entry) => {
+        let value = entry.get_mut();
+        if should_update(value) {
+            *value = new_value;
+        }
+    }
+    Entry::Vacant(entry) => {
+        entry.insert(default_value);
+    }
+}
+```
+
+## Performance
+
+| Pattern | Lookups | Hash Computations |
+|---------|---------|-------------------|
+| `contains_key` + `insert` | 2 | 2 |
+| `get` + `insert` | 2 | 2 |
+| `entry().or_insert()` | 1 | 1 |
+
+## See Also
+
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocate maps
+- [perf-drain-reuse](./perf-drain-reuse.md) - Reuse map allocations

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-extend-batch.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-extend-batch.md
@@ -1,0 +1,150 @@
+# perf-extend-batch
+
+> Use extend for batch insertions
+
+## Why It Matters
+
+`extend()` can pre-allocate capacity for the incoming elements and insert them in a single operation. Individual `push()` calls may trigger multiple reallocations as the collection grows. For adding multiple elements, `extend()` is both faster and clearer.
+
+## Bad
+
+```rust
+// Multiple potential reallocations
+fn collect_results(sources: Vec<Source>) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for source in sources {
+        for result in source.get_results() {
+            results.push(result);  // May reallocate
+        }
+    }
+    results
+}
+
+// Loop with push for known data
+fn build_list() -> Vec<i32> {
+    let mut list = Vec::new();
+    for i in 0..1000 {
+        list.push(i);  // Many reallocations
+    }
+    list
+}
+
+// Appending another collection
+fn combine(mut a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    for item in b {
+        a.push(item);
+    }
+    a
+}
+```
+
+## Good
+
+```rust
+// Single extend with size hint
+fn collect_results(sources: Vec<Source>) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for source in sources {
+        results.extend(source.get_results());
+    }
+    results
+}
+
+// Direct collection from iterator
+fn build_list() -> Vec<i32> {
+    (0..1000).collect()
+}
+
+// Extend for combining
+fn combine(mut a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    a.extend(b);
+    a
+}
+```
+
+## Extend with Capacity
+
+For best performance, combine with `reserve()`:
+
+```rust
+fn merge_all(chunks: Vec<Vec<Item>>) -> Vec<Item> {
+    // Calculate total size
+    let total: usize = chunks.iter().map(|c| c.len()).sum();
+    
+    let mut result = Vec::with_capacity(total);
+    for chunk in chunks {
+        result.extend(chunk);
+    }
+    result
+}
+```
+
+## Extend Methods
+
+| Method | Description |
+|--------|-------------|
+| `.extend(iter)` | Add all elements from iterator |
+| `.extend_from_slice(&[T])` | Add from slice (for `Copy` types) |
+| `.append(&mut Vec)` | Move all from another Vec |
+
+## Pattern: Building Strings
+
+```rust
+// Bad: multiple allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result.push_str(part);  // May reallocate
+    }
+    result
+}
+
+// Good: extend with known parts
+fn build_message(parts: &[&str]) -> String {
+    let total_len: usize = parts.iter().map(|s| s.len()).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(part);
+    }
+    result
+}
+
+// Better: collect/join
+fn build_message(parts: &[&str]) -> String {
+    parts.concat()  // or parts.join("")
+}
+```
+
+## HashMap/HashSet Extend
+
+```rust
+use std::collections::HashMap;
+
+// Extend from iterator of tuples
+fn merge_maps(mut base: HashMap<String, i32>, other: HashMap<String, i32>) -> HashMap<String, i32> {
+    base.extend(other);  // Moves entries from other
+    base
+}
+
+// Extend from iterator
+let mut set = HashSet::new();
+set.extend(items.iter().map(|i| i.id));
+```
+
+## Performance
+
+| Operation | Allocations | Complexity |
+|-----------|-------------|------------|
+| N × `push()` | O(log N) | O(N) amortized |
+| `extend(iter)` | O(1)* | O(N) |
+| `with_capacity` + `extend` | 1 | O(N) |
+
+*When iterator provides accurate `size_hint()`
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation
+- [perf-drain-reuse](./perf-drain-reuse.md) - Reusing allocations
+- [mem-reuse-collections](./mem-reuse-collections.md) - Collection reuse

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-iter-lazy.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-iter-lazy.md
@@ -1,0 +1,123 @@
+# perf-iter-lazy
+
+> Keep iterators lazy, collect only when needed
+
+## Why It Matters
+
+Rust iterators are lazy—they compute values on demand. This enables single-pass processing, avoids intermediate allocations, and allows short-circuiting. Calling `.collect()` too early forces evaluation and allocates unnecessarily.
+
+## Bad
+
+```rust
+// Collects intermediate results unnecessarily
+fn process(data: Vec<i32>) -> Vec<i32> {
+    let filtered: Vec<_> = data.into_iter()
+        .filter(|x| *x > 0)
+        .collect();  // Unnecessary allocation
+    
+    let mapped: Vec<_> = filtered.into_iter()
+        .map(|x| x * 2)
+        .collect();  // Another unnecessary allocation
+    
+    mapped.into_iter()
+        .take(10)
+        .collect()
+}
+
+// Collects before checking existence
+fn has_positive(data: &[i32]) -> bool {
+    let positives: Vec<_> = data.iter()
+        .filter(|&&x| x > 0)
+        .collect();  // Allocates entire filtered result
+    
+    !positives.is_empty()
+}
+```
+
+## Good
+
+```rust
+// Single chain, single collect
+fn process(data: Vec<i32>) -> Vec<i32> {
+    data.into_iter()
+        .filter(|x| *x > 0)
+        .map(|x| x * 2)
+        .take(10)
+        .collect()
+}
+
+// Short-circuits on first match
+fn has_positive(data: &[i32]) -> bool {
+    data.iter().any(|&x| x > 0)
+}
+```
+
+## Lazy Iterator Methods
+
+These methods return iterators (lazy):
+
+| Method | Description |
+|--------|-------------|
+| `.filter()` | Keep matching elements |
+| `.map()` | Transform elements |
+| `.take(n)` | Limit to n elements |
+| `.skip(n)` | Skip first n elements |
+| `.zip()` | Pair with another iterator |
+| `.chain()` | Concatenate iterators |
+| `.flat_map()` | Map and flatten |
+| `.enumerate()` | Add index |
+
+## Consuming Methods
+
+These methods consume the iterator (evaluate immediately):
+
+| Method | Description |
+|--------|-------------|
+| `.collect()` | Gather into collection |
+| `.for_each()` | Execute side effect |
+| `.count()` | Count elements |
+| `.sum()` | Sum elements |
+| `.fold()` | Accumulate value |
+| `.any()` | Check if any match |
+| `.all()` | Check if all match |
+| `.find()` | Find first match |
+
+## Short-Circuit Benefits
+
+```rust
+// Without lazy: processes ALL items
+let found: Vec<_> = items.iter()
+    .filter(|x| expensive_check(x))
+    .collect();
+let result = found.first();
+
+// With lazy: stops at first match
+let result = items.iter()
+    .find(|x| expensive_check(x));
+```
+
+## Pattern: Process Without Collecting
+
+```rust
+// Print all matches without allocating
+data.iter()
+    .filter(|x| x.is_valid())
+    .for_each(|x| println!("{}", x));
+
+// Count without collecting
+let count = data.iter()
+    .filter(|x| x.is_valid())
+    .count();
+
+// Sum without intermediate collection
+let total: i64 = data.iter()
+    .filter(|x| x.is_valid())
+    .map(|x| x.value as i64)
+    .sum();
+```
+
+## See Also
+
+- [perf-collect-once](./perf-collect-once.md) - Single collect
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators
+- [anti-collect-intermediate](./anti-collect-intermediate.md) - Anti-pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-iter-over-index.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-iter-over-index.md
@@ -1,0 +1,113 @@
+# perf-iter-over-index
+
+> Prefer iterators over manual indexing
+
+## Why It Matters
+
+Iterators are the idiomatic way to traverse collections in Rust. They enable bounds check elimination, SIMD auto-vectorization, and cleaner code. Manual indexing (`for i in 0..len`) often prevents these optimizations and introduces off-by-one error risks.
+
+## Bad
+
+```rust
+// Manual indexing - bounds checked every iteration
+fn sum_squares(data: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    for i in 0..data.len() {
+        sum += (data[i] as i64) * (data[i] as i64);
+    }
+    sum
+}
+
+// Index-based iteration with multiple collections
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len().min(b.len()) {
+        sum += a[i] * b[i];
+    }
+    sum
+}
+
+// Mutating with indices
+fn double_values(data: &mut [i32]) {
+    for i in 0..data.len() {
+        data[i] *= 2;
+    }
+}
+```
+
+## Good
+
+```rust
+// Iterator - bounds checks eliminated, SIMD-friendly
+fn sum_squares(data: &[i32]) -> i64 {
+    data.iter()
+        .map(|&x| (x as i64) * (x as i64))
+        .sum()
+}
+
+// Zip iterators - no manual length handling
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| x * y)
+        .sum()
+}
+
+// Mutable iteration
+fn double_values(data: &mut [i32]) {
+    for x in data.iter_mut() {
+        *x *= 2;
+    }
+}
+```
+
+## When Indexing Is Needed
+
+Sometimes you genuinely need indices:
+
+```rust
+// Need the index for output or processing
+for (i, value) in data.iter().enumerate() {
+    println!("Index {}: {}", i, value);
+}
+
+// Non-sequential access patterns
+fn interleave(data: &mut [i32]) {
+    let mid = data.len() / 2;
+    for i in 0..mid {
+        data.swap(i * 2, mid + i);
+    }
+}
+```
+
+## Performance Comparison
+
+| Pattern | Bounds Checks | SIMD Potential | Clarity |
+|---------|---------------|----------------|---------|
+| `for i in 0..len` | Every access | Limited | Medium |
+| `for &x in slice` | None | High | High |
+| `.iter().enumerate()` | None | Medium | High |
+| `get_unchecked` | None (unsafe) | High | Low |
+
+## Iterator Advantages
+
+```rust
+// Chaining operations - single pass
+let result: Vec<_> = data.iter()
+    .filter(|x| **x > 0)
+    .map(|x| x * 2)
+    .collect();
+
+// Early termination optimized
+let found = data.iter().any(|&x| x == target);
+
+// Parallel iteration (with rayon)
+use rayon::prelude::*;
+let sum: i64 = data.par_iter().map(|&x| x as i64).sum();
+```
+
+## See Also
+
+- [perf-iter-lazy](./perf-iter-lazy.md) - Keep iterators lazy
+- [opt-bounds-check](./opt-bounds-check.md) - Bounds check elimination
+- [anti-index-over-iter](./anti-index-over-iter.md) - Anti-pattern

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-profile-first.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-profile-first.md
@@ -1,0 +1,175 @@
+# perf-profile-first
+
+> Profile before optimizing
+
+## Why It Matters
+
+Intuition about performance is often wrong. The code you think is slow frequently isn't, while actual bottlenecks hide in unexpected places. Profiling shows you exactly where time is spent, preventing wasted effort on optimizations that don't matter.
+
+## Bad
+
+```rust
+// Optimizing without measuring
+fn process(data: &[Item]) -> Vec<Output> {
+    // "I bet this clone is slow..."
+    let cloned: Vec<_> = data.iter().cloned().collect();
+    
+    // Actually, 99% of time is spent here:
+    cloned.iter().map(|x| expensive_computation(x)).collect()
+}
+
+// Over-engineering rarely-called code
+#[inline(always)]
+fn rarely_called() {
+    // This runs once at startup...
+}
+```
+
+## Good
+
+```rust
+// 1. Profile first
+// cargo flamegraph --bin myapp
+// cargo instruments -t time --bin myapp (macOS)
+
+// 2. Find the actual bottleneck
+// Flamegraph shows expensive_computation takes 95% of time
+
+// 3. Optimize the hot spot
+fn process(data: &[Item]) -> Vec<Output> {
+    // Clone is fine - only 1% of time
+    let cloned: Vec<_> = data.iter().cloned().collect();
+    
+    // Focus optimization HERE
+    cloned.par_iter()  // Parallelize the expensive part
+        .map(|x| expensive_computation(x))
+        .collect()
+}
+```
+
+## Profiling Tools
+
+### Flamegraphs (Recommended Start)
+
+```bash
+# Install
+cargo install flamegraph
+
+# Profile
+cargo flamegraph --bin myapp -- <args>
+
+# Opens flamegraph.svg showing call stacks by time
+```
+
+### perf (Linux)
+
+```bash
+# Record
+perf record -g cargo run --release
+
+# Report
+perf report
+
+# Or generate flamegraph
+perf script | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg
+```
+
+### Instruments (macOS)
+
+```bash
+# Install cargo-instruments
+cargo install cargo-instruments
+
+# Time profiler
+cargo instruments -t time --release
+
+# Allocations profiler
+cargo instruments -t alloc --release
+```
+
+### DHAT (Heap Profiling)
+
+```bash
+# In your code
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() {
+    let _profiler = dhat::Profiler::new_heap();
+    // ... your code
+}
+
+# Run and get allocation report
+cargo run --release
+```
+
+### criterion (Micro-benchmarks)
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_my_function(c: &mut Criterion) {
+    c.bench_function("my_function", |b| {
+        b.iter(|| my_function(black_box(input)))
+    });
+}
+
+criterion_group!(benches, bench_my_function);
+criterion_main!(benches);
+```
+
+## What to Look For
+
+```
+Flamegraph Reading:
+├── Width = time spent
+├── Height = call stack depth
+└── Look for:
+    ├── Wide bars (time hogs)
+    ├── malloc/free (allocation heavy)
+    ├── memcpy (copying data)
+    └── Unexpected functions taking time
+```
+
+## Common Findings
+
+```rust
+// Finding: HashMap operations are slow
+// Fix: Use FxHashMap or AHashMap for non-crypto hashing
+
+// Finding: String allocation in hot loop
+// Fix: Pre-allocate with capacity, use &str
+
+// Finding: Clone in hot path
+// Fix: Use references or Cow
+
+// Finding: Bounds checks visible in profile
+// Fix: Use iterators instead of indexing
+
+// Finding: Lock contention
+// Fix: Reduce critical section, use RwLock, or partition data
+```
+
+## Optimization Workflow
+
+```
+1. Write correct code first
+2. Write benchmarks for hot paths
+3. Profile under realistic load
+4. Identify actual bottlenecks
+5. Optimize ONE thing
+6. Measure improvement
+7. Repeat if needed
+```
+
+## Evidence: Rust Performance Book
+
+> "The biggest performance improvements often come from changes to algorithms or data structures, rather than low-level optimizations."
+
+> "It is worth understanding which Rust data structures and operations cause allocations, because avoiding them can greatly improve performance."
+
+## See Also
+
+- [opt-lto-release](opt-lto-release.md) - Enable LTO for release builds
+- [test-criterion-bench](test-criterion-bench.md) - Use criterion for benchmarking
+- [anti-premature-optimize](anti-premature-optimize.md) - Don't optimize without data

--- a/.cursor/skills/rust-skills-leonardomso/rules/perf-release-profile.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/perf-release-profile.md
@@ -1,0 +1,149 @@
+# perf-release-profile
+
+> Optimize release profile settings
+
+## Why It Matters
+
+The default release profile prioritizes compile speed over runtime performance. For production binaries, tuning the release profile can yield significant performance improvements (10-40% in some cases) at the cost of longer compile times.
+
+## Default Profile
+
+```toml
+[profile.release]
+opt-level = 3
+debug = false
+lto = false
+codegen-units = 16
+```
+
+## Optimized Profile
+
+```toml
+[profile.release]
+opt-level = 3          # Maximum optimization
+lto = "fat"            # Full link-time optimization
+codegen-units = 1      # Better optimization, slower compile
+panic = "abort"        # Smaller binary, no unwinding
+strip = true           # Remove symbols
+
+[profile.release.package."*"]
+# Keep dependencies optimized even if main crate changes
+opt-level = 3
+```
+
+## Profile Options
+
+| Option | Values | Effect |
+|--------|--------|--------|
+| `opt-level` | 0-3, "s", "z" | Optimization level |
+| `lto` | false, "thin", "fat" | Link-time optimization |
+| `codegen-units` | 1-256 | Parallel compilation units |
+| `panic` | "unwind", "abort" | Panic behavior |
+| `strip` | true, false, "symbols", "debuginfo" | Binary stripping |
+| `debug` | true, false, 0-2 | Debug info level |
+
+## Optimization Levels
+
+| Level | Description | Use Case |
+|-------|-------------|----------|
+| `0` | No optimization | Debug builds |
+| `1` | Basic optimization | Fast compile |
+| `2` | Most optimizations | Balanced |
+| `3` | All optimizations | Maximum performance |
+| `"s"` | Optimize for size | Embedded |
+| `"z"` | Minimize size | Smallest binary |
+
+## LTO Options
+
+| Option | Compile Time | Performance | Binary Size |
+|--------|--------------|-------------|-------------|
+| `false` | Fast | Baseline | Larger |
+| `"thin"` | Medium | Good | Smaller |
+| `"fat"` | Slow | Best | Smallest |
+
+## Custom Profiles
+
+```toml
+# Fast release builds for development
+[profile.release-dev]
+inherits = "release"
+lto = false
+codegen-units = 16
+
+# Maximum performance for production
+[profile.release-prod]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+strip = true
+
+# Profiling with symbols
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false
+```
+
+Use with: `cargo build --profile release-prod`
+
+## Dev Dependencies Optimization
+
+Speed up tests and dev builds:
+
+```toml
+[profile.dev]
+opt-level = 0
+
+# Optimize dependencies even in dev
+[profile.dev.package."*"]
+opt-level = 3
+```
+
+## Benchmarking Profile
+
+```toml
+[profile.bench]
+inherits = "release"
+debug = true      # For profiling
+strip = false     # Keep symbols for flamegraphs
+lto = "fat"       # Consistent with release-prod
+```
+
+## Size vs Speed Trade-offs
+
+```toml
+# Smallest binary
+[profile.min-size]
+inherits = "release"
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+# Balance size and speed
+[profile.balanced]
+inherits = "release"
+opt-level = "s"
+lto = "thin"
+```
+
+## Workspace Configuration
+
+```toml
+# In workspace Cargo.toml
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
+# Override for specific package
+[profile.release.package.fast-compile-lib]
+lto = false
+codegen-units = 16
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - LTO details
+- [opt-codegen-units](./opt-codegen-units.md) - Codegen units
+- [opt-pgo-profile](./opt-pgo-profile.md) - Profile-guided optimization

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-bin-dir.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-bin-dir.md
@@ -1,0 +1,142 @@
+# proj-bin-dir
+
+> Put multiple binaries in src/bin/
+
+## Why It Matters
+
+When a crate produces multiple binaries, placing them in `src/bin/` keeps the project organized. Each file becomes a separate binary target automatically, without manual `Cargo.toml` configuration.
+
+## Bad
+
+```
+my-project/
+├── Cargo.toml        # Complex [[bin]] sections for each binary
+├── src/
+│   ├── main.rs       # Which binary is this?
+│   ├── server.rs     # Is this a module or binary?
+│   ├── cli.rs        # Unclear
+│   └── lib.rs
+```
+
+```toml
+# Cargo.toml - verbose and error-prone
+[[bin]]
+name = "server"
+path = "src/server.rs"
+
+[[bin]]
+name = "cli"
+path = "src/cli.rs"
+```
+
+## Good
+
+```
+my-project/
+├── Cargo.toml        # Clean, no [[bin]] needed
+├── src/
+│   ├── lib.rs        # Shared library code
+│   └── bin/
+│       ├── server.rs # Binary: my-project-server (or just server)
+│       └── cli.rs    # Binary: my-project-cli (or just cli)
+```
+
+Each file in `src/bin/` automatically becomes a binary named after the file.
+
+## Running Binaries
+
+```bash
+# Run specific binary
+cargo run --bin server
+cargo run --bin cli
+
+# Build specific binary
+cargo build --bin server
+
+# Build all binaries
+cargo build --bins
+```
+
+## Pattern: Binary with Multiple Files
+
+For complex binaries, use directories:
+
+```
+src/
+├── lib.rs
+└── bin/
+    ├── server/
+    │   ├── main.rs      # Entry point
+    │   ├── config.rs    # Server-specific module
+    │   └── handlers.rs
+    └── cli/
+        ├── main.rs
+        └── commands.rs
+```
+
+## Pattern: Shared Library Code
+
+```rust
+// src/lib.rs - Shared code
+pub mod config;
+pub mod database;
+pub mod models;
+
+// src/bin/server.rs - Server binary
+use my_project::{config, database, models};
+
+fn main() {
+    let config = config::load();
+    let db = database::connect(&config);
+    // ...
+}
+
+// src/bin/cli.rs - CLI binary
+use my_project::{config, models};
+
+fn main() {
+    let config = config::load();
+    // CLI logic using shared code
+}
+```
+
+## Binary Naming
+
+| File Path | Binary Name |
+|-----------|-------------|
+| `src/main.rs` | `my-project` (crate name) |
+| `src/bin/server.rs` | `server` |
+| `src/bin/my-cli.rs` | `my-cli` |
+| `src/bin/server/main.rs` | `server` |
+
+## Explicit Configuration
+
+When you need custom settings:
+
+```toml
+[[bin]]
+name = "my-server"
+path = "src/bin/server.rs"
+required-features = ["server"]
+
+[[bin]]
+name = "my-cli"
+path = "src/bin/cli.rs"
+```
+
+## Pattern: Default Binary
+
+```toml
+# src/main.rs is the default binary
+# Additional binaries in src/bin/
+
+[package]
+name = "my-tool"
+default-run = "my-tool"  # Or specify another
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Keep main.rs minimal
+- [proj-workspace-large](./proj-workspace-large.md) - Workspace for larger projects
+- [proj-flat-small](./proj-flat-small.md) - Simple project structure

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-flat-small.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-flat-small.md
@@ -1,0 +1,133 @@
+# proj-flat-small
+
+> Keep small projects flat
+
+## Why It Matters
+
+Over-organizing small projects adds navigation overhead without benefit. A project with 5-10 files doesn't need nested directories. Start flat, add structure only when complexity demands it.
+
+## Bad
+
+```
+src/
+├── core/
+│   └── mod.rs           # Just re-exports
+├── domain/
+│   ├── mod.rs
+│   └── models/
+│       ├── mod.rs
+│       └── user.rs      # 50 lines
+├── infrastructure/
+│   ├── mod.rs
+│   └── database/
+│       ├── mod.rs
+│       └── connection.rs # 30 lines
+├── application/
+│   ├── mod.rs
+│   └── services/
+│       └── mod.rs       # Empty
+└── main.rs
+```
+
+## Good
+
+```
+src/
+├── main.rs
+├── lib.rs
+├── config.rs
+├── database.rs
+├── user.rs
+└── error.rs
+```
+
+## When to Add Structure
+
+| File Count | Structure |
+|------------|-----------|
+| < 10 files | Flat in `src/` |
+| 10-20 files | Group by feature |
+| 20+ files | Feature folders with submodules |
+
+## Progressive Structuring
+
+### Stage 1: Flat
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+└── database.rs
+```
+
+### Stage 2: Logical Groups
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+├── order.rs        # Getting bigger
+├── order_item.rs   # Related to order
+└── database.rs
+```
+
+### Stage 3: Feature Folders
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+├── order/          # Now complex enough
+│   ├── mod.rs
+│   ├── model.rs
+│   └── item.rs
+└── database.rs
+```
+
+## Signs You Need More Structure
+
+- Files exceed 300-500 lines
+- Related files are hard to identify
+- You're adding `_` prefixes for grouping (`user_model.rs`, `user_service.rs`)
+- New team members get lost
+- Same concepts repeated in file names
+
+## Signs of Over-Structure
+
+- Folders with 1-2 files
+- `mod.rs` files that only re-export
+- Deep nesting for simple concepts
+- More lines in module declarations than code
+
+## Example: CLI Tool
+
+```
+src/
+├── main.rs         # Argument parsing, entry point
+├── commands.rs     # CLI subcommands
+├── config.rs       # Configuration loading
+└── output.rs       # Formatting, printing
+```
+
+Not:
+
+```
+src/
+├── cli/
+│   └── commands/
+│       └── mod.rs
+├── config/
+│   └── mod.rs
+└── presentation/
+    └── output/
+        └── mod.rs
+```
+
+## See Also
+
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation
+- [proj-mod-rs-dir](./proj-mod-rs-dir.md) - Multi-file modules

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-lib-main-split.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-lib-main-split.md
@@ -1,0 +1,148 @@
+# proj-lib-main-split
+
+> Keep `main.rs` minimal, logic in `lib.rs`
+
+## Why It Matters
+
+Putting your logic in `lib.rs` makes it testable, reusable, and keeps `main.rs` as a thin entry point. Integration tests can only access your library crate, not binary code in `main.rs`.
+
+## Bad
+
+```rust
+// src/main.rs - everything here
+fn main() {
+    let args = parse_args();
+    let config = load_config(&args.config_path).unwrap();
+    let db = connect_database(&config.db_url).unwrap();
+    
+    // Hundreds of lines of application logic...
+    // All untestable from integration tests!
+}
+
+fn parse_args() -> Args { /* ... */ }
+fn load_config(path: &str) -> Result<Config, Error> { /* ... */ }
+fn connect_database(url: &str) -> Result<Db, Error> { /* ... */ }
+// ... more functions that can't be tested
+```
+
+## Good
+
+```rust
+// src/main.rs - thin entry point
+use my_app::{run, Config};
+
+fn main() -> anyhow::Result<()> {
+    let config = Config::from_env()?;
+    run(config)
+}
+
+// src/lib.rs - all the logic
+pub mod config;
+pub mod database;
+pub mod handlers;
+
+pub use config::Config;
+
+pub fn run(config: Config) -> anyhow::Result<()> {
+    let db = database::connect(&config.db_url)?;
+    let app = handlers::build_app(db);
+    app.run()
+}
+```
+
+## With CLI Arguments
+
+```rust
+// src/main.rs
+use clap::Parser;
+use my_app::{run, Args};
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    run(args)
+}
+
+// src/lib.rs
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "myapp", version, about)]
+pub struct Args {
+    #[arg(short, long)]
+    pub config: PathBuf,
+    
+    #[arg(short, long, default_value = "info")]
+    pub log_level: String,
+}
+
+pub fn run(args: Args) -> anyhow::Result<()> {
+    // All application logic here - testable!
+}
+```
+
+## Project Structure
+
+```
+my_app/
+├── Cargo.toml
+├── src/
+│   ├── main.rs       # Entry point only
+│   ├── lib.rs        # Library root, re-exports
+│   ├── config.rs     # Configuration
+│   ├── database.rs   # Database connection
+│   └── handlers/     # Request handlers
+│       ├── mod.rs
+│       └── users.rs
+└── tests/
+    └── integration.rs  # Can access lib.rs!
+```
+
+## Testing Benefits
+
+```rust
+// tests/integration.rs - can test everything!
+use my_app::{Config, run, database};
+
+#[test]
+fn test_database_connection() {
+    let config = Config::test_config();
+    let db = database::connect(&config.db_url).unwrap();
+    assert!(db.is_connected());
+}
+
+#[test]
+fn test_full_workflow() {
+    let config = Config::test_config();
+    // Test the actual run function
+    assert!(my_app::run(config).is_ok());
+}
+```
+
+## Multiple Binaries
+
+```rust
+// src/lib.rs - shared code
+pub mod core;
+pub mod utils;
+
+// src/bin/server.rs
+use my_app::core::Server;
+
+fn main() -> anyhow::Result<()> {
+    Server::new()?.run()
+}
+
+// src/bin/cli.rs
+use my_app::core::Client;
+
+fn main() -> anyhow::Result<()> {
+    let client = Client::new()?;
+    client.execute_command()
+}
+```
+
+## See Also
+
+- [proj-bin-dir](proj-bin-dir.md) - Put multiple binaries in src/bin/
+- [proj-mod-by-feature](proj-mod-by-feature.md) - Organize modules by feature
+- [test-integration-dir](test-integration-dir.md) - Integration tests in tests/

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-mod-by-feature.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-mod-by-feature.md
@@ -1,0 +1,130 @@
+# proj-mod-by-feature
+
+> Organize modules by feature, not type
+
+## Why It Matters
+
+Feature-based organization keeps related code together, making navigation intuitive and changes localized. Type-based organization (all handlers in one folder, all models in another) scatters related code across the codebase, making features harder to understand and modify.
+
+## Bad
+
+```
+src/
+├── controllers/
+│   ├── user_controller.rs
+│   ├── order_controller.rs
+│   └── product_controller.rs
+├── models/
+│   ├── user.rs
+│   ├── order.rs
+│   └── product.rs
+├── services/
+│   ├── user_service.rs
+│   ├── order_service.rs
+│   └── product_service.rs
+└── repositories/
+    ├── user_repository.rs
+    ├── order_repository.rs
+    └── product_repository.rs
+```
+
+## Good
+
+```
+src/
+├── user/
+│   ├── mod.rs           # Re-exports public items
+│   ├── model.rs         # User struct, types
+│   ├── repository.rs    # Database operations
+│   ├── service.rs       # Business logic
+│   └── handler.rs       # HTTP handlers
+├── order/
+│   ├── mod.rs
+│   ├── model.rs
+│   ├── repository.rs
+│   ├── service.rs
+│   └── handler.rs
+├── product/
+│   ├── mod.rs
+│   ├── model.rs
+│   ├── repository.rs
+│   └── handler.rs
+└── lib.rs
+```
+
+## Benefits
+
+| Aspect | Type-Based | Feature-Based |
+|--------|------------|---------------|
+| Finding code | Search across folders | One folder per feature |
+| Adding feature | Touch 4+ folders | Create one folder |
+| Understanding feature | Jump between folders | Everything in one place |
+| Deleting feature | Hunt through codebase | Delete one folder |
+| Code ownership | Unclear | Clear feature owners |
+
+## Module Structure
+
+```rust
+// src/user/mod.rs
+mod model;
+mod repository;
+mod service;
+mod handler;
+
+// Re-export public API
+pub use model::{User, UserId, CreateUserRequest};
+pub use handler::router;
+pub(crate) use service::UserService;
+```
+
+## Shared Code
+
+```
+src/
+├── user/
+├── order/
+├── shared/              # Cross-cutting concerns
+│   ├── mod.rs
+│   ├── database.rs      # Connection pool
+│   ├── error.rs         # Common error types
+│   └── middleware.rs    # Auth, logging
+└── lib.rs
+```
+
+## When to Flatten
+
+Small modules don't need deep nesting:
+
+```
+src/
+├── user/
+│   ├── mod.rs           # Contains User struct + simple functions
+│   └── repository.rs    # Only if complex enough
+├── config.rs            # Simple enough for single file
+└── lib.rs
+```
+
+## Hybrid Approach
+
+For larger features, nest further by concern:
+
+```
+src/
+├── billing/
+│   ├── mod.rs
+│   ├── invoice/
+│   │   ├── mod.rs
+│   │   ├── model.rs
+│   │   └── service.rs
+│   ├── payment/
+│   │   ├── mod.rs
+│   │   ├── model.rs
+│   │   └── processor.rs
+│   └── shared.rs
+```
+
+## See Also
+
+- [proj-flat-small](./proj-flat-small.md) - Keep small projects flat
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Clean public API
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-mod-rs-dir.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-mod-rs-dir.md
@@ -1,0 +1,120 @@
+# proj-mod-rs-dir
+
+> Use mod.rs for multi-file modules
+
+## Why It Matters
+
+Rust offers two styles for multi-file modules. The `mod.rs` style is clearer for larger modules and aligns with how most Rust projects are structured. Choose one style consistently.
+
+## Two Styles
+
+### Style 1: mod.rs (Recommended for larger modules)
+
+```
+src/
+├── user/
+│   ├── mod.rs          # Module root
+│   ├── model.rs
+│   └── repository.rs
+└── lib.rs
+```
+
+```rust
+// src/lib.rs
+mod user;  // Looks for user/mod.rs or user.rs
+
+// src/user/mod.rs
+mod model;
+mod repository;
+pub use model::User;
+```
+
+### Style 2: Adjacent file (Recommended for smaller modules)
+
+```
+src/
+├── user.rs             # Module root
+├── user/
+│   ├── model.rs
+│   └── repository.rs
+└── lib.rs
+```
+
+```rust
+// src/lib.rs
+mod user;  // Looks for user.rs, then user/ for submodules
+
+// src/user.rs
+mod model;
+mod repository;
+pub use model::User;
+```
+
+## When to Use Each
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Simple module (1-3 submodules) | Adjacent file (`user.rs` + `user/`) |
+| Complex module (4+ submodules) | `mod.rs` style (`user/mod.rs`) |
+| Deep nesting | `mod.rs` at each level |
+| Library with public modules | Consistent style throughout |
+
+## mod.rs Benefits
+
+- Clear that `user/` is a module directory
+- All module code inside the folder
+- Easier to move/rename entire modules
+- Common in large codebases (tokio, serde)
+
+## Adjacent File Benefits
+
+- Module declaration outside directory
+- Can see module's interface without entering folder
+- Matches Rust 2018+ default lint preference
+- Good for small modules with few submodules
+
+## Example: Complex Module
+
+```
+src/
+├── database/
+│   ├── mod.rs          # Main module, re-exports
+│   ├── connection.rs   # Connection pool
+│   ├── migrations.rs   # Schema migrations
+│   ├── queries/        # Sub-module for queries
+│   │   ├── mod.rs
+│   │   ├── user.rs
+│   │   └── order.rs
+│   └── error.rs
+└── lib.rs
+```
+
+```rust
+// src/database/mod.rs
+mod connection;
+mod migrations;
+mod queries;
+mod error;
+
+pub use connection::Pool;
+pub use error::DatabaseError;
+pub use queries::{UserQueries, OrderQueries};
+```
+
+## Consistency Rule
+
+Pick one style for your project and stick with it:
+
+```rust
+// Cargo.toml or clippy.toml
+[lints.clippy]
+mod_module_files = "warn"  # Enforces mod.rs style
+# OR
+self_named_module_files = "warn"  # Enforces adjacent style
+```
+
+## See Also
+
+- [proj-flat-small](./proj-flat-small.md) - Keep small projects flat
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-prelude-module.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-prelude-module.md
@@ -1,0 +1,155 @@
+# proj-prelude-module
+
+> Create prelude module for common imports
+
+## Why It Matters
+
+A `prelude` module collects the most commonly used types and traits for glob import. Users write `use my_crate::prelude::*` instead of many individual imports. This follows the pattern established by `std::prelude`.
+
+## Bad
+
+```rust
+// Users must import everything individually
+use my_crate::Client;
+use my_crate::Config;
+use my_crate::Error;
+use my_crate::Request;
+use my_crate::Response;
+use my_crate::traits::Handler;
+use my_crate::traits::Middleware;
+use my_crate::types::Method;
+```
+
+## Good
+
+```rust
+// src/lib.rs
+pub mod prelude {
+    pub use crate::{
+        Client,
+        Config,
+        Error,
+        Request,
+        Response,
+    };
+    pub use crate::traits::{Handler, Middleware};
+    pub use crate::types::Method;
+}
+
+// Users write:
+use my_crate::prelude::*;
+```
+
+## What to Include
+
+| Include | Don't Include |
+|---------|---------------|
+| Core types users always need | Rarely-used types |
+| Common traits | Implementation details |
+| Error types | Internal helpers |
+| Extension traits | Feature-gated items (usually) |
+| Type aliases | Everything |
+
+## Example: Web Framework Prelude
+
+```rust
+pub mod prelude {
+    // Core request/response
+    pub use crate::{Request, Response, Body};
+    
+    // Error handling
+    pub use crate::Error;
+    
+    // Common traits
+    pub use crate::traits::{FromRequest, IntoResponse};
+    
+    // Routing
+    pub use crate::Router;
+    
+    // HTTP types
+    pub use crate::http::{Method, StatusCode};
+}
+```
+
+## Example: Database Library Prelude
+
+```rust
+pub mod prelude {
+    // Connection and pool
+    pub use crate::{Connection, Pool};
+    
+    // Query building
+    pub use crate::query::{Query, Select, Insert, Update, Delete};
+    
+    // Traits for custom types
+    pub use crate::traits::{FromRow, ToSql};
+    
+    // Error type
+    pub use crate::Error;
+}
+```
+
+## Pattern: Tiered Preludes
+
+```rust
+// Minimal prelude
+pub mod prelude {
+    pub use crate::{Client, Config, Error};
+}
+
+// Full prelude for power users
+pub mod full_prelude {
+    pub use crate::prelude::*;
+    pub use crate::advanced::*;
+    pub use crate::extensions::*;
+}
+```
+
+## Pattern: Feature-Gated Prelude Items
+
+```rust
+pub mod prelude {
+    pub use crate::{Client, Error};
+    
+    #[cfg(feature = "async")]
+    pub use crate::async_client::AsyncClient;
+    
+    #[cfg(feature = "serde")]
+    pub use crate::serde::{Serialize, Deserialize};
+}
+```
+
+## Guidelines
+
+1. **Be conservative** - Only include truly common items
+2. **Avoid conflicts** - Don't include names that might clash (e.g., `Error`)
+3. **Document it** - List what's included in module docs
+4. **Stay stable** - Removing items is breaking change
+
+## Documenting the Prelude
+
+```rust
+//! Common imports for convenient glob importing.
+//!
+//! # Usage
+//!
+//! ```
+//! use my_crate::prelude::*;
+//! ```
+//!
+//! # Contents
+//!
+//! This prelude re-exports:
+//! - [`Client`] - The main API client
+//! - [`Config`] - Client configuration
+//! - [`Error`] - Error type
+pub mod prelude {
+    // ...
+}
+```
+
+## See Also
+
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns
+- [api-extension-trait](./api-extension-trait.md) - Extension traits
+- [doc-module-inner](./doc-module-inner.md) - Module documentation

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-crate-internal.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-crate-internal.md
@@ -1,0 +1,139 @@
+# proj-pub-crate-internal
+
+> Use pub(crate) for internal APIs
+
+## Why It Matters
+
+`pub(crate)` exposes items within the crate but hides them from external users. This creates clear boundaries between public API and internal implementation, preventing accidental breakage and reducing public API surface.
+
+## Bad
+
+```rust
+// Everything public - users depend on internals
+pub mod internal {
+    pub struct InternalState {
+        pub buffer: Vec<u8>,    // Implementation detail exposed
+        pub dirty: bool,
+    }
+    
+    pub fn process_internal(state: &mut InternalState) {
+        // Users can call this, creating coupling
+    }
+}
+
+pub struct Widget {
+    pub state: internal::InternalState,  // Exposed!
+}
+```
+
+## Good
+
+```rust
+// Internal module with crate visibility
+pub(crate) mod internal {
+    pub(crate) struct InternalState {
+        pub(crate) buffer: Vec<u8>,
+        pub(crate) dirty: bool,
+    }
+    
+    pub(crate) fn process_internal(state: &mut InternalState) {
+        // Only callable within crate
+    }
+}
+
+pub struct Widget {
+    state: internal::InternalState,  // Private field
+}
+
+impl Widget {
+    pub fn new() -> Self {
+        Self {
+            state: internal::InternalState {
+                buffer: Vec::new(),
+                dirty: false,
+            }
+        }
+    }
+    
+    pub fn do_something(&mut self) {
+        internal::process_internal(&mut self.state);
+    }
+}
+```
+
+## Visibility Levels
+
+| Visibility | Accessible From |
+|------------|-----------------|
+| `pub` | Everywhere |
+| `pub(crate)` | Current crate only |
+| `pub(super)` | Parent module only |
+| `pub(in path)` | Specific module path |
+| (private) | Current module only |
+
+## Pattern: Internal Module
+
+```rust
+// src/lib.rs
+mod internal;  // Private module
+pub mod api;   // Public API
+
+// src/internal.rs
+pub(crate) struct Helper;
+pub(crate) fn helper_function() -> Helper { Helper }
+
+// src/api.rs
+use crate::internal::{Helper, helper_function};
+
+pub struct PublicType {
+    helper: Helper,  // Uses internal type, but field is private
+}
+```
+
+## Pattern: Test Visibility
+
+```rust
+pub struct Parser {
+    // Private implementation
+    state: ParserState,
+}
+
+// Expose for testing but not public API
+#[cfg(test)]
+pub(crate) fn debug_state(&self) -> &ParserState {
+    &self.state
+}
+
+// Or use a dedicated test helper
+#[doc(hidden)]
+pub mod __test_helpers {
+    pub use super::ParserState;
+}
+```
+
+## Pattern: Feature Module Internals
+
+```rust
+// src/user/mod.rs
+mod repository;  // Private
+mod service;     // Private
+
+pub use service::UserService;  // Only export the public API
+
+// repository and service are pub(crate) internally
+// so other modules in crate can use them if needed
+```
+
+## Benefits
+
+| Approach | API Stability | Flexibility |
+|----------|---------------|-------------|
+| All `pub` | Any change breaks users | None |
+| `pub(crate)` internals | Only `pub` items matter | Can refactor freely |
+| Private | Maximum encapsulation | Limits crate flexibility |
+
+## See Also
+
+- [proj-pub-super-parent](./proj-pub-super-parent.md) - Parent-only visibility
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Clean re-exports
+- [api-non-exhaustive](./api-non-exhaustive.md) - Future-proof structs

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-super-parent.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-super-parent.md
@@ -1,0 +1,135 @@
+# proj-pub-super-parent
+
+> Use pub(super) for parent-only visibility
+
+## Why It Matters
+
+`pub(super)` exposes items only to the immediate parent module. This is useful for helper functions and types that submodules share but shouldn't be visible to the rest of the crate.
+
+## Bad
+
+```rust
+// src/parser/mod.rs
+pub mod lexer;
+pub mod ast;
+
+// src/parser/lexer.rs
+pub fn internal_helper() {  // Visible to entire crate!
+    // Helper only needed by lexer and ast
+}
+
+pub(crate) struct Token {  // Visible to entire crate
+    // Only parser submodules need this
+}
+```
+
+## Good
+
+```rust
+// src/parser/mod.rs
+pub mod lexer;
+pub mod ast;
+
+// Shared types for parser submodules only
+pub(super) struct Token {
+    pub(super) kind: TokenKind,
+    pub(super) span: Span,
+}
+
+pub(super) fn shared_helper() -> Token {
+    // Only visible in parser/*
+}
+
+// src/parser/lexer.rs
+use super::{Token, shared_helper};
+
+pub fn lex(input: &str) -> Vec<Token> {
+    shared_helper();
+    // ...
+}
+
+// src/parser/ast.rs
+use super::Token;
+
+pub fn parse(tokens: Vec<Token>) -> Ast {
+    // ...
+}
+```
+
+## Visibility Hierarchy
+
+```
+src/
+├── lib.rs           # crate root
+├── parser/
+│   ├── mod.rs       # pub(super) items visible here
+│   ├── lexer.rs     # can use pub(super) from mod.rs
+│   └── ast.rs       # can use pub(super) from mod.rs
+└── codegen.rs       # CANNOT see pub(super) parser items
+```
+
+## Pattern: Layered Visibility
+
+```rust
+// src/database/mod.rs
+mod connection;
+mod query;
+mod pool;
+
+// Only this module's children can see
+pub(super) struct RawConnection { /* ... */ }
+
+// Entire crate can see
+pub(crate) struct Pool { /* ... */ }
+
+// Everyone can see
+pub struct Database { /* ... */ }
+```
+
+## Pattern: Test Helpers
+
+```rust
+// src/parser/mod.rs
+mod lexer;
+mod ast;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test helper visible only to parser module's tests
+    pub(super) fn make_test_token() -> Token {
+        Token { kind: TokenKind::Test, span: Span::dummy() }
+    }
+}
+
+// src/parser/lexer.rs
+#[cfg(test)]
+mod tests {
+    use super::super::tests::make_test_token;
+    // ...
+}
+```
+
+## Comparison
+
+| Visibility | Scope | Use Case |
+|------------|-------|----------|
+| `pub` | Everywhere | Public API |
+| `pub(crate)` | Crate-wide | Internal shared utilities |
+| `pub(super)` | Parent module | Submodule helpers |
+| `pub(in path)` | Specific path | Precise control |
+| (private) | Current module | Implementation details |
+
+## When to Use pub(super)
+
+- Helper functions shared between sibling modules
+- Types used by submodules but not the rest of crate
+- Implementation details of a module group
+- Test utilities for a module tree
+
+## See Also
+
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Crate visibility
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-use-reexport.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-pub-use-reexport.md
@@ -1,0 +1,162 @@
+# proj-pub-use-reexport
+
+> Use pub use for clean public API
+
+## Why It Matters
+
+`pub use` re-exports items from submodules at the current module level. This creates a flat, ergonomic public API while keeping internal organization flexible. Users import from one place; you can reorganize internals without breaking their code.
+
+## Bad
+
+```rust
+// lib.rs - Deep module paths exposed
+pub mod error;
+pub mod config;
+pub mod client;
+pub mod types;
+
+// Users must write:
+use my_crate::error::MyError;
+use my_crate::config::Config;
+use my_crate::client::http::HttpClient;
+use my_crate::types::request::Request;
+```
+
+## Good
+
+```rust
+// lib.rs - Flat public API
+mod error;
+mod config;
+mod client;
+mod types;
+
+pub use error::MyError;
+pub use config::Config;
+pub use client::http::HttpClient;
+pub use types::request::Request;
+
+// Users write:
+use my_crate::{Config, HttpClient, MyError, Request};
+```
+
+## Pattern: Selective Re-export
+
+```rust
+// src/lib.rs
+mod internal;
+
+// Only re-export what users need
+pub use internal::{
+    PublicStruct,
+    PublicTrait,
+    public_function,
+};
+
+// Keep implementation details hidden
+// internal::helper_function is NOT exported
+```
+
+## Pattern: Rename on Re-export
+
+```rust
+mod v1 {
+    pub struct Client { /* old implementation */ }
+}
+
+mod v2 {
+    pub struct Client { /* new implementation */ }
+}
+
+// Re-export with clear names
+pub use v2::Client;
+pub use v1::Client as LegacyClient;
+```
+
+## Pattern: Prelude Module
+
+```rust
+// src/lib.rs
+pub mod prelude {
+    pub use crate::{
+        Config,
+        Client,
+        Error,
+        Request,
+        Response,
+    };
+}
+
+// Users can glob import common items
+use my_crate::prelude::*;
+```
+
+## Pattern: Feature-Gated Re-exports
+
+```rust
+// src/lib.rs
+mod core;
+mod serde_impl;
+mod async_impl;
+
+pub use core::*;
+
+#[cfg(feature = "serde")]
+pub use serde_impl::*;
+
+#[cfg(feature = "async")]
+pub use async_impl::*;
+```
+
+## Comparison: Module Structure vs Public API
+
+```rust
+// Internal structure (complex)
+src/
+├── transport/
+│   ├── http/
+│   │   └── client.rs    // HttpClient
+│   └── grpc/
+│       └── client.rs    // GrpcClient
+├── auth/
+│   └── token.rs         // Token
+└── lib.rs
+
+// Public API (flat)
+pub use transport::http::client::HttpClient;
+pub use transport::grpc::client::GrpcClient;
+pub use auth::token::Token;
+
+// Users see:
+my_crate::HttpClient
+my_crate::GrpcClient
+my_crate::Token
+```
+
+## Re-export External Types
+
+```rust
+// Re-export dependencies users will need
+pub use bytes::Bytes;
+pub use http::{Method, StatusCode};
+
+// Now users don't need to depend on these crates directly
+```
+
+## Glob Re-exports
+
+Use sparingly:
+
+```rust
+// OK for internal modules
+pub use internal::*;
+
+// Careful with external crates - pollutes namespace
+pub use serde::*;  // Usually too broad
+```
+
+## See Also
+
+- [proj-prelude-module](./proj-prelude-module.md) - Prelude pattern
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Internal visibility
+- [api-non-exhaustive](./api-non-exhaustive.md) - API stability

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-workspace-deps.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-workspace-deps.md
@@ -1,0 +1,186 @@
+# proj-workspace-deps
+
+> Use workspace dependency inheritance for consistent versions across crates
+
+## Why It Matters
+
+Multi-crate workspaces often have dependency version drift—different crates using different versions of the same dependency. Workspace dependency inheritance (Rust 1.64+) lets you declare dependencies once in the workspace `Cargo.toml` and inherit them in member crates, ensuring consistency.
+
+## Bad
+
+```toml
+# crate-a/Cargo.toml
+[dependencies]
+serde = "1.0.150"
+tokio = "1.25"
+
+# crate-b/Cargo.toml  
+[dependencies]
+serde = "1.0.188"  # Different version!
+tokio = "1.32"     # Different version!
+
+# Version drift leads to:
+# - Larger binaries (multiple versions)
+# - Compilation time increase
+# - Subtle behavior differences
+```
+
+## Good
+
+```toml
+# Root Cargo.toml
+[workspace]
+members = ["crate-a", "crate-b", "crate-c"]
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.32", features = ["full"] }
+thiserror = "1.0"
+anyhow = "1.0"
+tracing = "0.1"
+
+# crate-a/Cargo.toml
+[dependencies]
+serde.workspace = true
+tokio.workspace = true
+
+# crate-b/Cargo.toml
+[dependencies]
+serde.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+```
+
+## Override Features
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+tokio = { version = "1.32", features = ["rt-multi-thread"] }
+
+# crate-a/Cargo.toml - add extra features
+[dependencies]
+tokio = { workspace = true, features = ["net", "io-util"] }
+# Gets both workspace features AND local features
+
+# crate-b/Cargo.toml - minimal features
+[dependencies]
+tokio = { workspace = true }  # Just workspace features
+```
+
+## Dev and Build Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+criterion = "0.5"
+proptest = "1.0"
+trybuild = "1.0"
+cc = "1.0"
+
+# crate-a/Cargo.toml
+[dev-dependencies]
+criterion.workspace = true
+proptest.workspace = true
+
+[build-dependencies]
+cc.workspace = true
+```
+
+## Internal Crate Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+# Internal crates
+my-core = { path = "crates/core" }
+my-utils = { path = "crates/utils" }
+my-derive = { path = "crates/derive" }
+
+# External crates
+serde = "1.0"
+
+# crate-a/Cargo.toml
+[dependencies]
+my-core.workspace = true
+my-utils.workspace = true
+serde.workspace = true
+```
+
+## Optional Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+serde = { version = "1.0", optional = true }  # Won't work!
+
+# Optional must be set in member, not workspace
+[workspace.dependencies]
+serde = "1.0"
+
+# crate-a/Cargo.toml
+[dependencies]
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde"]
+```
+
+## Complete Workspace Example
+
+```toml
+# Root Cargo.toml
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/user/repo"
+
+[workspace.dependencies]
+# Internal
+my-core = { path = "crates/core", version = "0.1" }
+
+# Async
+tokio = { version = "1.32", features = ["full"] }
+futures = "0.3"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+thiserror = "1.0"
+anyhow = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+# Testing
+proptest = "1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+# crates/core/Cargo.toml
+[package]
+name = "my-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Workspace structure
+- [api-serde-optional](./api-serde-optional.md) - Optional dependencies
+- [lint-deny-correctness](./lint-deny-correctness.md) - Workspace lints

--- a/.cursor/skills/rust-skills-leonardomso/rules/proj-workspace-large.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/proj-workspace-large.md
@@ -1,0 +1,162 @@
+# proj-workspace-large
+
+> Use workspaces for large projects
+
+## Why It Matters
+
+Cargo workspaces manage multiple related crates under one repository. They share a single `Cargo.lock`, build cache, and can be versioned together. For large projects, workspaces improve build times, enforce modularity, and simplify dependency management.
+
+## Bad
+
+```
+# Separate repositories for each crate
+my-app-core/
+my-app-cli/
+my-app-server/
+my-app-common/
+
+# Each has its own Cargo.lock
+# Dependencies may drift
+# Cross-crate development is painful
+```
+
+## Good
+
+```
+my-app/
+├── Cargo.toml          # Workspace root
+├── Cargo.lock          # Shared lock file
+├── crates/
+│   ├── core/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   ├── cli/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   ├── server/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   └── common/
+│       ├── Cargo.toml
+│       └── src/
+└── README.md
+```
+
+## Workspace Cargo.toml
+
+```toml
+# Root Cargo.toml
+[workspace]
+resolver = "2"  # Use the new resolver
+members = [
+    "crates/core",
+    "crates/cli",
+    "crates/server",
+    "crates/common",
+]
+
+# Shared dependencies - all crates use same versions
+[workspace.dependencies]
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+tracing = "0.1"
+anyhow = "1.0"
+
+# Shared lints
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+all = "warn"
+```
+
+## Member Crate Cargo.toml
+
+```toml
+# crates/core/Cargo.toml
+[package]
+name = "my-app-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Inherit from workspace
+tokio = { workspace = true }
+serde = { workspace = true }
+
+# Crate-specific dependencies
+uuid = "1.0"
+
+# Internal dependency
+my-app-common = { path = "../common" }
+
+[lints]
+workspace = true  # Inherit workspace lints
+```
+
+## When to Use Workspaces
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Single binary/library | No workspace needed |
+| Library + CLI | Maybe, depends on size |
+| Multiple related crates | Yes |
+| Shared internal libraries | Yes |
+| Microservices mono-repo | Yes |
+| Plugin architecture | Yes |
+
+## Benefits
+
+| Aspect | Single Crate | Workspace |
+|--------|--------------|-----------|
+| Build cache | Crate only | Shared across all |
+| Dependency versions | Per-crate | Synchronized |
+| Compile times | Full rebuild | Incremental |
+| Modularity | Files/modules | Crate boundaries |
+| Publishing | Single crate | Independent |
+
+## Commands
+
+```bash
+# Build all crates
+cargo build --workspace
+
+# Build specific crate
+cargo build -p my-app-core
+
+# Test all crates
+cargo test --workspace
+
+# Run specific binary
+cargo run -p my-app-cli
+
+# Check all
+cargo check --workspace
+```
+
+## Pattern: Virtual Workspace
+
+Root Cargo.toml is workspace-only (no `[package]`):
+
+```toml
+[workspace]
+members = ["crates/*"]
+
+[workspace.dependencies]
+# ...
+```
+
+## Pattern: Crate Interdependencies
+
+```toml
+# crates/server/Cargo.toml
+[dependencies]
+my-app-core = { path = "../core" }
+my-app-common = { path = "../common" }
+```
+
+## See Also
+
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace dependencies
+- [proj-bin-dir](./proj-bin-dir.md) - Multiple binaries
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-arrange-act-assert.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-arrange-act-assert.md
@@ -1,0 +1,160 @@
+# test-arrange-act-assert
+
+> Structure tests with clear Arrange, Act, Assert sections
+
+## Why It Matters
+
+The AAA pattern makes tests readable and maintainable. Each section has a clear purpose: set up test data, execute the code under test, verify the results. This structure helps identify what's being tested and makes tests easier to debug when they fail.
+
+## Bad
+
+```rust
+#[test]
+fn test_user() {
+    assert_eq!(User::new("alice", "alice@example.com").unwrap().name(), "alice");
+    assert!(User::new("", "email@example.com").is_err());
+    let u = User::new("bob", "bob@example.com").unwrap();
+    assert!(u.validate());
+    assert_eq!(u.email(), "bob@example.com");
+}
+// Multiple concerns, hard to understand, hard to debug
+```
+
+## Good
+
+```rust
+#[test]
+fn new_user_has_correct_name() {
+    // Arrange
+    let name = "alice";
+    let email = "alice@example.com";
+    
+    // Act
+    let user = User::new(name, email).unwrap();
+    
+    // Assert
+    assert_eq!(user.name(), "alice");
+}
+
+#[test]
+fn user_creation_fails_with_empty_name() {
+    // Arrange
+    let name = "";
+    let email = "email@example.com";
+    
+    // Act
+    let result = User::new(name, email);
+    
+    // Assert
+    assert!(result.is_err());
+    assert!(matches!(result, Err(UserError::EmptyName)));
+}
+```
+
+## With Comments
+
+```rust
+#[test]
+fn order_total_includes_tax() {
+    // Arrange
+    let mut order = Order::new();
+    order.add_item(Item::new("Widget", 100.00));
+    order.add_item(Item::new("Gadget", 50.00));
+    let tax_rate = 0.10;
+    
+    // Act
+    let total = order.calculate_total(tax_rate);
+    
+    // Assert
+    let expected = (100.00 + 50.00) * 1.10;
+    assert_eq!(total, expected);
+}
+```
+
+## Complex Arrange
+
+```rust
+#[test]
+fn search_returns_matching_documents() {
+    // Arrange
+    let mut index = SearchIndex::new();
+    index.add_document(Document::new(1, "rust programming"));
+    index.add_document(Document::new(2, "python programming"));
+    index.add_document(Document::new(3, "rust web development"));
+    
+    let query = Query::new("rust");
+    
+    // Act
+    let results = index.search(&query);
+    
+    // Assert
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|d| d.id == 1));
+    assert!(results.iter().any(|d| d.id == 3));
+}
+```
+
+## Async Tests
+
+```rust
+#[tokio::test]
+async fn fetch_user_returns_user_data() {
+    // Arrange
+    let client = TestClient::new();
+    let user_id = 42;
+    
+    // Act
+    let result = client.fetch_user(user_id).await;
+    
+    // Assert
+    assert!(result.is_ok());
+    let user = result.unwrap();
+    assert_eq!(user.id, user_id);
+}
+```
+
+## Helper Functions
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Arrange helpers
+    fn create_test_user() -> User {
+        User::new("test", "test@example.com").unwrap()
+    }
+    
+    fn create_order_with_items(items: &[(&str, f64)]) -> Order {
+        let mut order = Order::new();
+        for (name, price) in items {
+            order.add_item(Item::new(name, *price));
+        }
+        order
+    }
+    
+    // Assert helpers
+    fn assert_order_total(order: &Order, expected: f64) {
+        let total = order.calculate_total(0.0);
+        assert!((total - expected).abs() < 0.01);
+    }
+    
+    #[test]
+    fn order_total_sums_items() {
+        // Arrange
+        let order = create_order_with_items(&[
+            ("A", 10.0),
+            ("B", 20.0),
+        ]);
+        
+        // Act & Assert
+        assert_order_total(&order, 30.0);
+    }
+}
+```
+
+## See Also
+
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming
+- [test-fixture-raii](./test-fixture-raii.md) - Test setup/teardown
+- [test-mock-traits](./test-mock-traits.md) - Mocking dependencies

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-cfg-test-module.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-cfg-test-module.md
@@ -1,0 +1,151 @@
+# test-cfg-test-module
+
+> Put unit tests in `#[cfg(test)] mod tests { }` within each module
+
+## Why It Matters
+
+The `#[cfg(test)]` attribute ensures test code is only compiled during `cargo test`, not in release builds. Placing tests in a `tests` submodule within the same file keeps tests close to the code they test while maintaining separation. This is Rust's idiomatic unit test pattern.
+
+## Bad
+
+```rust
+// Tests without cfg(test) - compiled into release binary
+mod tests {
+    #[test]
+    fn test_something() { ... }  // Included in release build!
+}
+
+// Tests in separate file without access to private items
+// src/my_module.rs
+fn private_helper() { ... }
+
+// tests/my_module_test.rs
+// Can't access private_helper!
+```
+
+## Good
+
+```rust
+// src/my_module.rs
+
+fn public_api() -> i32 {
+    private_helper() * 2
+}
+
+fn private_helper() -> i32 {
+    21
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;  // Access to private items
+    
+    #[test]
+    fn test_public_api() {
+        assert_eq!(public_api(), 42);
+    }
+    
+    #[test]
+    fn test_private_helper() {
+        assert_eq!(private_helper(), 21);  // Can test private!
+    }
+}
+```
+
+## Module Structure
+
+```rust
+// src/lib.rs
+mod parser;
+mod lexer;
+mod ast;
+
+// src/parser.rs
+pub fn parse(input: &str) -> Result<Ast, Error> {
+    let tokens = tokenize(input)?;
+    build_ast(tokens)
+}
+
+fn tokenize(input: &str) -> Result<Vec<Token>, Error> { ... }
+fn build_ast(tokens: Vec<Token>) -> Result<Ast, Error> { ... }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_parse_simple() {
+        let ast = parse("1 + 2").unwrap();
+        assert_eq!(ast.evaluate(), 3);
+    }
+    
+    #[test]
+    fn test_tokenize() {
+        let tokens = tokenize("1 + 2").unwrap();
+        assert_eq!(tokens.len(), 3);
+    }
+}
+```
+
+## Test Helpers
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test-only helpers
+    fn create_test_data() -> Data {
+        Data {
+            id: 1,
+            name: "test".into(),
+            values: vec![1, 2, 3],
+        }
+    }
+    
+    fn assert_valid(data: &Data) {
+        assert!(data.id > 0);
+        assert!(!data.name.is_empty());
+    }
+    
+    #[test]
+    fn test_processing() {
+        let data = create_test_data();
+        let result = process(&data);
+        assert_valid(&result);
+    }
+}
+```
+
+## Multiple Test Modules
+
+```rust
+// For larger test suites, use submodules
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod parsing {
+        use super::*;
+        
+        #[test]
+        fn test_parse_number() { ... }
+        
+        #[test]
+        fn test_parse_string() { ... }
+    }
+    
+    mod validation {
+        use super::*;
+        
+        #[test]
+        fn test_validate_range() { ... }
+    }
+}
+```
+
+## See Also
+
+- [test-use-super](./test-use-super.md) - Importing from parent module
+- [test-integration-dir](./test-integration-dir.md) - Integration tests
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-criterion-bench.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-criterion-bench.md
@@ -1,0 +1,171 @@
+# test-criterion-bench
+
+> Use `criterion` for benchmarking
+
+## Why It Matters
+
+Criterion provides statistically rigorous benchmarking with warmup, multiple iterations, outlier detection, and comparison between runs. It's far more reliable than simple timing with `Instant::now()`.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "my_benchmark"
+harness = false
+```
+
+## Basic Benchmark
+
+```rust
+// benches/my_benchmark.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn bench_fibonacci(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| {
+        b.iter(|| fibonacci(black_box(20)))
+    });
+}
+
+criterion_group!(benches, bench_fibonacci);
+criterion_main!(benches);
+```
+
+## black_box is Critical
+
+```rust
+// BAD: Compiler may optimize away the computation
+b.iter(|| fibonacci(20));  // Result unused, might be eliminated
+
+// GOOD: black_box prevents optimization
+b.iter(|| fibonacci(black_box(20)));
+
+// Also wrap the result if needed
+b.iter(|| black_box(fibonacci(black_box(20))));
+```
+
+## Comparing Implementations
+
+```rust
+fn bench_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("String concat");
+    
+    let data = "hello";
+    
+    group.bench_function("format!", |b| {
+        b.iter(|| format!("{}{}", black_box(data), " world"))
+    });
+    
+    group.bench_function("push_str", |b| {
+        b.iter(|| {
+            let mut s = String::from(black_box(data));
+            s.push_str(" world");
+            s
+        })
+    });
+    
+    group.bench_function("concat", |b| {
+        b.iter(|| [black_box(data), " world"].concat())
+    });
+    
+    group.finish();
+}
+```
+
+## Parameterized Benchmarks
+
+```rust
+fn bench_vec_push(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Vec::push");
+    
+    for size in [100, 1000, 10000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut v = Vec::new();
+                    for i in 0..size {
+                        v.push(black_box(i));
+                    }
+                    v
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+```
+
+## Throughput Measurement
+
+```rust
+use criterion::Throughput;
+
+fn bench_parse(c: &mut Criterion) {
+    let input = "a]ong string to parse...";
+    
+    let mut group = c.benchmark_group("Parser");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    
+    group.bench_function("parse", |b| {
+        b.iter(|| parse(black_box(input)))
+    });
+    
+    group.finish();
+}
+```
+
+## Running Benchmarks
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Run specific benchmark
+cargo bench -- fib
+
+# Save baseline for comparison
+cargo bench -- --save-baseline main
+
+# Compare against baseline
+cargo bench -- --baseline main
+```
+
+## Evidence from tokio
+
+```rust
+// https://github.com/tokio-rs/tokio/blob/master/benches/sync_mpsc.rs
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn send_data<T: Default, const SIZE: usize>(
+    g: &mut BenchmarkGroup<WallTime>, 
+    prefix: &str
+) {
+    let rt = rt();
+    g.bench_function(format!("{prefix}_{SIZE}"), |b| {
+        b.iter(|| {
+            let (tx, mut rx) = mpsc::channel::<T>(SIZE);
+            rt.block_on(tx.send(T::default())).unwrap();
+            rt.block_on(rx.recv()).unwrap();
+        })
+    });
+}
+```
+
+## See Also
+
+- [perf-profile-first](perf-profile-first.md) - Profile before optimizing
+- [perf-black-box-bench](perf-black-box-bench.md) - Use black_box in benchmarks

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-descriptive-names.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-descriptive-names.md
@@ -1,0 +1,142 @@
+# test-descriptive-names
+
+> Use descriptive test names that explain what is being tested
+
+## Why It Matters
+
+Test names appear in test output and serve as documentation. A good test name tells you what behavior is being verified without reading the test body. When a test fails, a descriptive name immediately tells you what broke.
+
+## Bad
+
+```rust
+#[test]
+fn test1() { ... }
+
+#[test]
+fn test_parse() { ... }  // Parse what? What behavior?
+
+#[test]
+fn it_works() { ... }
+
+#[test]
+fn test_function() { ... }
+
+// Failure output: "test test_parse ... FAILED"
+// What failed? No idea.
+```
+
+## Good
+
+```rust
+#[test]
+fn parse_returns_error_for_empty_input() { ... }
+
+#[test]
+fn parse_handles_unicode_characters() { ... }
+
+#[test]
+fn user_creation_requires_valid_email() { ... }
+
+#[test]
+fn expired_token_is_rejected() { ... }
+
+// Failure output: "test parse_returns_error_for_empty_input ... FAILED"
+// Immediately know what broke!
+```
+
+## Naming Patterns
+
+```rust
+// Pattern: function_condition_expected_result
+#[test]
+fn parse_valid_json_returns_document() { ... }
+
+#[test]
+fn parse_invalid_json_returns_syntax_error() { ... }
+
+// Pattern: scenario_expectation
+#[test]
+fn empty_cart_has_zero_total() { ... }
+
+#[test]
+fn adding_item_increases_cart_total() { ... }
+
+// Pattern: when_given_then (BDD-style)
+#[test]
+fn when_user_not_found_then_returns_404() { ... }
+```
+
+## Edge Cases
+
+```rust
+#[test]
+fn handles_empty_string() { ... }
+
+#[test]
+fn handles_max_length_input() { ... }
+
+#[test]
+fn handles_unicode_emoji() { ... }
+
+#[test]
+fn handles_null_bytes() { ... }
+
+#[test]
+fn handles_concurrent_access() { ... }
+```
+
+## Error Cases
+
+```rust
+#[test]
+fn rejects_negative_quantity() { ... }
+
+#[test]
+fn returns_error_for_invalid_email_format() { ... }
+
+#[test]
+fn panics_on_double_initialization() { ... }
+
+#[test]
+fn timeout_returns_timeout_error() { ... }
+```
+
+## Module Organization
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod parsing {
+        use super::*;
+        
+        #[test]
+        fn accepts_valid_json() { ... }
+        
+        #[test]
+        fn rejects_trailing_comma() { ... }
+    }
+    
+    mod validation {
+        use super::*;
+        
+        #[test]
+        fn requires_name_field() { ... }
+        
+        #[test]
+        fn email_must_contain_at_symbol() { ... }
+    }
+}
+
+// Test output:
+// tests::parsing::accepts_valid_json
+// tests::parsing::rejects_trailing_comma
+// tests::validation::requires_name_field
+```
+
+## See Also
+
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure
+- [test-cfg-test-module](./test-cfg-test-module.md) - Test module organization
+- [doc-examples-section](./doc-examples-section.md) - Documentation tests

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-doctest-examples.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-doctest-examples.md
@@ -1,0 +1,168 @@
+# test-doctest-examples
+
+> Keep documentation examples as executable doctests
+
+## Why It Matters
+
+Doctests are examples in documentation that are automatically tested. They serve dual purposes: demonstrating usage to readers and verifying the examples compile and work. When your API changes, failing doctests catch outdated documentation.
+
+## Bad
+
+```rust
+/// Parses a number from a string.
+/// 
+/// Example:
+/// let n = parse("42");  // Not tested!
+/// assert_eq!(n, 42);
+pub fn parse(s: &str) -> i32 {
+    s.parse().unwrap()
+}
+
+// Documentation can become outdated:
+/// Adds two numbers.
+/// 
+/// ```
+/// let sum = add(1, 2, 3);  // Wrong number of args - not caught!
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Good
+
+```rust
+/// Parses a number from a string.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::parse;
+/// 
+/// let n = parse("42");
+/// assert_eq!(n, 42);
+/// ```
+pub fn parse(s: &str) -> i32 {
+    s.parse().unwrap()
+}
+
+/// Adds two numbers.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::add;
+/// 
+/// let sum = add(1, 2);
+/// assert_eq!(sum, 3);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Hiding Setup Code
+
+```rust
+/// Processes data from a file.
+/// 
+/// # Examples
+/// 
+/// ```
+/// # use std::io::Write;
+/// # let mut file = tempfile::NamedTempFile::new().unwrap();
+/// # writeln!(file, "test data").unwrap();
+/// # let path = file.path();
+/// use my_crate::process_file;
+/// 
+/// let result = process_file(path)?;
+/// assert!(!result.is_empty());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn process_file(path: &Path) -> Result<String, Error> {
+    std::fs::read_to_string(path).map_err(Error::from)
+}
+```
+
+## Showing Error Handling
+
+```rust
+/// Parses and validates an email address.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::Email;
+/// 
+/// let email = Email::parse("user@example.com")?;
+/// assert_eq!(email.domain(), "example.com");
+/// # Ok::<(), my_crate::EmailError>(())
+/// ```
+/// 
+/// # Errors
+/// 
+/// Returns error for invalid format:
+/// 
+/// ```
+/// use my_crate::Email;
+/// 
+/// assert!(Email::parse("not-an-email").is_err());
+/// ```
+pub fn parse(s: &str) -> Result<Email, EmailError> {
+    // ...
+}
+```
+
+## no_run and ignore
+
+```rust
+/// Starts the server.
+/// 
+/// ```no_run
+/// use my_crate::Server;
+/// 
+/// // This compiles but doesn't run (would block forever)
+/// Server::new().run();
+/// ```
+pub fn run(&self) { ... }
+
+/// Platform-specific example.
+/// 
+/// ```ignore
+/// // This might not compile on all platforms
+/// use windows_specific::Feature;
+/// ```
+```
+
+## compile_fail
+
+```rust
+/// This type is not Clone.
+/// 
+/// ```compile_fail
+/// use my_crate::UniqueHandle;
+/// 
+/// let a = UniqueHandle::new();
+/// let b = a.clone();  // Error: Clone not implemented
+/// ```
+pub struct UniqueHandle { ... }
+```
+
+## Running Doctests
+
+```bash
+# Run all tests including doctests
+cargo test
+
+# Run only doctests
+cargo test --doc
+
+# Run doctests for specific item
+cargo test --doc my_function
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Documentation structure
+- [doc-hidden-setup](./doc-hidden-setup.md) - Hiding setup code
+- [doc-question-mark](./doc-question-mark.md) - Error handling in examples

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-fixture-raii.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-fixture-raii.md
@@ -1,0 +1,151 @@
+# test-fixture-raii
+
+> Use RAII pattern (Drop trait) for automatic test cleanup
+
+## Why It Matters
+
+Tests often need setup and teardown—creating temp files, starting servers, setting environment variables. Using RAII (Resource Acquisition Is Initialization) with Drop ensures cleanup happens automatically, even if the test panics. This prevents test pollution and resource leaks.
+
+## Bad
+
+```rust
+#[test]
+fn test_with_temp_file() {
+    let path = "/tmp/test_file.txt";
+    std::fs::write(path, "test data").unwrap();
+    
+    let result = process_file(path);
+    
+    std::fs::remove_file(path).unwrap();  // Might not run if test panics!
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_with_env_var() {
+    std::env::set_var("MY_VAR", "test_value");
+    
+    let result = read_config();
+    
+    std::env::remove_var("MY_VAR");  // Might not run if test panics!
+    assert!(result.is_ok());
+}
+```
+
+## Good
+
+```rust
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_with_temp_file() {
+    // Arrange - file deleted automatically when `file` drops
+    let file = NamedTempFile::new().unwrap();
+    std::fs::write(file.path(), "test data").unwrap();
+    
+    // Act
+    let result = process_file(file.path());
+    
+    // Assert - file cleaned up even if assertion panics
+    assert!(result.is_ok());
+}
+
+// Custom RAII guard for environment variables
+struct EnvGuard {
+    key: String,
+    original: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        EnvGuard {
+            key: key.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(v) => std::env::set_var(&self.key, v),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+#[test]
+fn test_with_env_var() {
+    let _guard = EnvGuard::set("MY_VAR", "test_value");
+    
+    let result = read_config();
+    
+    assert!(result.is_ok());
+}  // MY_VAR automatically restored
+```
+
+## Common RAII Patterns
+
+```rust
+// Temporary directory
+use tempfile::TempDir;
+
+#[test]
+fn test_with_temp_dir() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("test.txt");
+    std::fs::write(&file_path, "data").unwrap();
+    
+    // dir and all contents deleted on drop
+}
+
+// Server guard
+struct TestServer {
+    handle: std::thread::JoinHandle<()>,
+    shutdown: std::sync::mpsc::Sender<()>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(());
+        // Wait for server to stop
+    }
+}
+
+// Database transaction rollback
+struct TestTransaction<'a> {
+    conn: &'a mut Connection,
+}
+
+impl Drop for TestTransaction<'_> {
+    fn drop(&mut self) {
+        self.conn.execute("ROLLBACK").unwrap();
+    }
+}
+```
+
+## scopeguard Crate
+
+```rust
+use scopeguard::defer;
+
+#[test]
+fn test_with_defer() {
+    let path = "/tmp/test_file.txt";
+    std::fs::write(path, "data").unwrap();
+    
+    defer! {
+        std::fs::remove_file(path).ok();
+    }
+    
+    // Test logic here
+    // File removed when scope exits
+}
+```
+
+## See Also
+
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure
+- [test-tokio-async](./test-tokio-async.md) - Async test cleanup
+- [test-mock-traits](./test-mock-traits.md) - Mocking with RAII

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-integration-dir.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-integration-dir.md
@@ -1,0 +1,144 @@
+# test-integration-dir
+
+> Put integration tests in the `tests/` directory
+
+## Why It Matters
+
+Integration tests live in `tests/` at the crate root, separate from `src/`. Each file in `tests/` is compiled as a separate crate, testing your library's public API as external users would. This separation ensures you're testing the real public interface, not implementation details.
+
+## Structure
+
+```
+my_project/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   └── internal.rs
+└── tests/
+    ├── integration_test.rs    # Each file is a separate test binary
+    ├── api_tests.rs
+    └── common/                 # Shared test utilities
+        └── mod.rs
+```
+
+## Bad
+
+```rust
+// src/lib.rs
+// Mixing integration test logic in library code
+#[test]
+fn integration_test_full_workflow() {
+    // This is a unit test location, not integration
+}
+```
+
+## Good
+
+```rust
+// tests/integration_test.rs
+use my_crate::{Client, Config};  // Uses public API only
+
+#[test]
+fn test_full_workflow() {
+    let config = Config::default();
+    let client = Client::new(config);
+    
+    let result = client.process("input");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_error_handling() {
+    let client = Client::new(Config::strict());
+    
+    let result = client.process("invalid");
+    assert!(matches!(result, Err(Error::InvalidInput { .. })));
+}
+```
+
+## Shared Test Utilities
+
+```rust
+// tests/common/mod.rs
+use my_crate::Config;
+
+pub fn test_config() -> Config {
+    Config {
+        timeout: Duration::from_secs(5),
+        retries: 3,
+        debug: true,
+    }
+}
+
+pub fn setup_test_environment() {
+    // Set up test fixtures
+}
+
+// tests/api_tests.rs
+mod common;
+
+use my_crate::Client;
+
+#[test]
+fn test_with_shared_config() {
+    common::setup_test_environment();
+    let client = Client::new(common::test_config());
+    // ...
+}
+```
+
+## Organizing Many Tests
+
+```rust
+// tests/api/mod.rs
+mod auth;
+mod users;
+mod orders;
+
+// tests/api/auth.rs
+use my_crate::auth::{login, logout};
+
+#[test]
+fn test_login_success() { ... }
+
+#[test]
+fn test_login_invalid_credentials() { ... }
+
+// tests/api/users.rs
+use my_crate::users::{create_user, get_user};
+
+#[test]
+fn test_create_user() { ... }
+```
+
+## Integration vs Unit Tests
+
+| Unit Tests | Integration Tests |
+|------------|-------------------|
+| In `src/` with `#[cfg(test)]` | In `tests/` directory |
+| Access private items | Public API only |
+| Test individual functions | Test module interactions |
+| Fast, isolated | May be slower |
+| `cargo test --lib` | `cargo test --test '*'` |
+
+## Running Specific Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run only integration tests
+cargo test --test '*'
+
+# Run specific integration test file
+cargo test --test integration_test
+
+# Run tests matching pattern
+cargo test --test api_tests test_login
+```
+
+## See Also
+
+- [test-cfg-test-module](./test-cfg-test-module.md) - Unit test modules
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming
+- [test-tokio-async](./test-tokio-async.md) - Async integration tests

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-mock-traits.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-mock-traits.md
@@ -1,0 +1,189 @@
+# test-mock-traits
+
+> Use traits for dependencies to enable mocking in tests
+
+## Why It Matters
+
+Concrete dependencies make testing hard—you can't easily test error paths, timeouts, or edge cases without real external systems. Extracting dependencies behind traits lets you inject test doubles (mocks, fakes, stubs), enabling isolated unit tests that run fast and cover edge cases.
+
+## Bad
+
+```rust
+struct UserService {
+    db: PostgresConnection,  // Concrete type - hard to test
+}
+
+impl UserService {
+    async fn get_user(&self, id: u64) -> Result<User, Error> {
+        // Directly calls Postgres - needs real database to test
+        self.db.query("SELECT * FROM users WHERE id = $1", &[&id]).await
+    }
+}
+
+// Test requires real Postgres instance
+#[tokio::test]
+async fn test_get_user() {
+    let db = PostgresConnection::connect("postgres://...").await?;
+    let service = UserService { db };
+    // Slow, flaky, can't test error paths
+}
+```
+
+## Good
+
+```rust
+// Define trait for dependency
+#[async_trait]
+trait UserRepository: Send + Sync {
+    async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError>;
+    async fn save(&self, user: &User) -> Result<(), DbError>;
+}
+
+// Production implementation
+struct PostgresUserRepo {
+    pool: PgPool,
+}
+
+#[async_trait]
+impl UserRepository for PostgresUserRepo {
+    async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError> {
+        sqlx::query_as("SELECT * FROM users WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+    // ...
+}
+
+// Service depends on trait, not concrete type
+struct UserService<R: UserRepository> {
+    repo: R,
+}
+
+impl<R: UserRepository> UserService<R> {
+    async fn get_user(&self, id: u64) -> Result<User, Error> {
+        self.repo.find_by_id(id).await?
+            .ok_or(Error::NotFound)
+    }
+}
+
+// Test with mock
+#[cfg(test)]
+mod tests {
+    struct MockUserRepo {
+        users: HashMap<u64, User>,
+    }
+    
+    #[async_trait]
+    impl UserRepository for MockUserRepo {
+        async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError> {
+            Ok(self.users.get(&id).cloned())
+        }
+        // ...
+    }
+    
+    #[tokio::test]
+    async fn test_get_user_found() {
+        let mut mock = MockUserRepo { users: HashMap::new() };
+        mock.users.insert(1, User { id: 1, name: "Alice".into() });
+        
+        let service = UserService { repo: mock };
+        let user = service.get_user(1).await.unwrap();
+        
+        assert_eq!(user.name, "Alice");
+    }
+    
+    #[tokio::test]
+    async fn test_get_user_not_found() {
+        let mock = MockUserRepo { users: HashMap::new() };
+        let service = UserService { repo: mock };
+        
+        let result = service.get_user(999).await;
+        assert!(matches!(result, Err(Error::NotFound)));
+    }
+}
+```
+
+## mockall Crate
+
+```rust
+use mockall::*;
+use mockall::predicate::*;
+
+#[automock]
+#[async_trait]
+trait Database: Send + Sync {
+    async fn query(&self, sql: &str) -> Result<Vec<Row>, Error>;
+}
+
+#[tokio::test]
+async fn test_with_mockall() {
+    let mut mock = MockDatabase::new();
+    
+    mock.expect_query()
+        .with(eq("SELECT 1"))
+        .times(1)
+        .returning(|_| Ok(vec![Row::new()]));
+    
+    let result = mock.query("SELECT 1").await;
+    assert!(result.is_ok());
+}
+```
+
+## Testing Error Paths
+
+```rust
+#[async_trait]
+trait HttpClient: Send + Sync {
+    async fn get(&self, url: &str) -> Result<Response, HttpError>;
+}
+
+struct FailingClient;
+
+#[async_trait]
+impl HttpClient for FailingClient {
+    async fn get(&self, _url: &str) -> Result<Response, HttpError> {
+        Err(HttpError::Timeout)  // Always fails
+    }
+}
+
+#[tokio::test]
+async fn test_handles_timeout() {
+    let client = FailingClient;
+    let service = ApiService { client };
+    
+    let result = service.fetch_data().await;
+    assert!(matches!(result, Err(Error::NetworkError(_))));
+}
+```
+
+## Dynamic Dispatch Alternative
+
+```rust
+// When you don't want generics everywhere
+struct UserService {
+    repo: Box<dyn UserRepository>,
+}
+
+impl UserService {
+    fn new(repo: impl UserRepository + 'static) -> Self {
+        Self { repo: Box::new(repo) }
+    }
+}
+
+// Slight runtime cost but cleaner API
+```
+
+## Cargo.toml
+
+```toml
+[dev-dependencies]
+mockall = "0.11"
+async-trait = "0.1"  # For async trait mocking
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Trait design
+- [test-proptest-properties](./test-proptest-properties.md) - Property-based testing
+- [proj-lib-main-split](./proj-lib-main-split.md) - Testable architecture

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-mockall-mocking.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-mockall-mocking.md
@@ -1,0 +1,226 @@
+# test-mockall-mocking
+
+> Use mockall for trait mocking
+
+## Why It Matters
+
+Unit tests should isolate the code under test from external dependencies (databases, APIs, file systems). Mockall generates mock implementations of traits, allowing you to control and verify behavior without real dependencies.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+mockall = "0.12"
+```
+
+## Basic Usage
+
+```rust
+use mockall::automock;
+
+#[automock]
+trait Database {
+    fn get_user(&self, id: u64) -> Option<User>;
+    fn save_user(&self, user: &User) -> Result<(), Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    
+    #[test]
+    fn test_get_user() {
+        let mut mock = MockDatabase::new();
+        
+        mock.expect_get_user()
+            .with(eq(42))
+            .returning(|_| Some(User { id: 42, name: "Alice".into() }));
+        
+        let service = UserService::new(mock);
+        let user = service.find_user(42);
+        
+        assert_eq!(user.unwrap().name, "Alice");
+    }
+}
+```
+
+## Expectations
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_save_calls() {
+        let mut mock = MockDatabase::new();
+        
+        // Expect exactly one call
+        mock.expect_save_user()
+            .times(1)
+            .returning(|_| Ok(()));
+        
+        // Expect call with specific argument
+        mock.expect_get_user()
+            .with(eq(42))
+            .returning(|_| Some(User::default()));
+        
+        // Expect multiple calls
+        mock.expect_get_user()
+            .times(3..)  // At least 3 times
+            .returning(|_| None);
+        
+        // Expectations are verified on drop
+    }
+}
+```
+
+## Predicates
+
+```rust
+use mockall::predicate::*;
+
+mock.expect_process()
+    .with(eq(42))                    // Exact match
+    .returning(|_| Ok(()));
+
+mock.expect_validate()
+    .with(function(|s: &str| s.len() > 5))  // Custom predicate
+    .returning(|_| true);
+
+mock.expect_search()
+    .withf(|query, limit| {           // Multiple args
+        query.len() < 100 && *limit <= 1000
+    })
+    .returning(|_, _| vec![]);
+```
+
+## Sequences
+
+```rust
+use mockall::Sequence;
+
+#[test]
+fn test_ordered_calls() {
+    let mut seq = Sequence::new();
+    let mut mock = MockDatabase::new();
+    
+    mock.expect_connect()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|| Ok(()));
+    
+    mock.expect_query()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|_| Ok(vec![]));
+    
+    mock.expect_disconnect()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|| Ok(()));
+}
+```
+
+## Return Values
+
+```rust
+// Fixed value
+mock.expect_count().returning(|| 42);
+
+// Based on input
+mock.expect_double().returning(|x| x * 2);
+
+// Different values per call
+mock.expect_next()
+    .times(3)
+    .returning(|| 1)
+    .returning(|| 2)
+    .returning(|| 3);
+
+// Return owned values
+mock.expect_get_name()
+    .returning(|| "Alice".to_string());
+```
+
+## Mocking External Traits
+
+```rust
+// For traits you don't own
+#[cfg_attr(test, mockall::automock)]
+trait HttpClient {
+    fn get(&self, url: &str) -> Result<Response, Error>;
+}
+
+// In production
+struct RealHttpClient;
+impl HttpClient for RealHttpClient {
+    fn get(&self, url: &str) -> Result<Response, Error> { /* ... */ }
+}
+
+// In tests
+#[cfg(test)]
+fn mock_client() -> MockHttpClient {
+    let mut mock = MockHttpClient::new();
+    mock.expect_get()
+        .returning(|_| Ok(Response::new(200, "OK")));
+    mock
+}
+```
+
+## Async Mocking
+
+```rust
+#[automock]
+#[async_trait]
+trait AsyncDatabase {
+    async fn fetch(&self, id: u64) -> Option<Data>;
+}
+
+#[tokio::test]
+async fn test_async() {
+    let mut mock = MockAsyncDatabase::new();
+    
+    mock.expect_fetch()
+        .returning(|_| Some(Data::default()));
+    
+    let result = mock.fetch(1).await;
+    assert!(result.is_some());
+}
+```
+
+## Design for Testability
+
+```rust
+// Accept trait, not concrete type
+struct Service<D: Database> {
+    db: D,
+}
+
+impl<D: Database> Service<D> {
+    fn new(db: D) -> Self {
+        Self { db }
+    }
+}
+
+// Tests use mock
+#[test]
+fn test_service() {
+    let mock = MockDatabase::new();
+    let service = Service::new(mock);
+}
+
+// Production uses real implementation
+fn main() {
+    let db = PostgresDatabase::connect();
+    let service = Service::new(db);
+}
+```
+
+## See Also
+
+- [test-mock-traits](./test-mock-traits.md) - Mock trait design
+- [test-proptest-properties](./test-proptest-properties.md) - Property testing
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-proptest-properties.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-proptest-properties.md
@@ -1,0 +1,161 @@
+# test-proptest-properties
+
+> Use proptest for property-based testing
+
+## Why It Matters
+
+Property-based testing generates random inputs to verify that properties hold across all possible values, not just hand-picked examples. Proptest finds edge cases you wouldn't think to test manually—empty strings, integer overflows, unicode edge cases.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+proptest = "1.0"
+```
+
+## Basic Usage
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_reverse_reverse_is_identity(s in ".*") {
+        let reversed: String = s.chars().rev().collect();
+        let double_reversed: String = reversed.chars().rev().collect();
+        assert_eq!(s, double_reversed);
+    }
+    
+    #[test]
+    fn test_sort_is_idempotent(mut v in prop::collection::vec(any::<i32>(), 0..100)) {
+        v.sort();
+        let sorted = v.clone();
+        v.sort();
+        assert_eq!(v, sorted);
+    }
+}
+```
+
+## Common Strategies
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    // Any type implementing Arbitrary
+    #[test]
+    fn test_i32(x in any::<i32>()) { }
+    
+    // Regex-based string generation
+    #[test]
+    fn test_email(email in "[a-z]+@[a-z]+\\.[a-z]{2,3}") { }
+    
+    // Ranges
+    #[test]
+    fn test_range(x in 0..100i32) { }
+    
+    // Collections
+    #[test]
+    fn test_vec(v in prop::collection::vec(any::<i32>(), 0..10)) { }
+    
+    // Optionals
+    #[test]
+    fn test_option(opt in prop::option::of(any::<i32>())) { }
+}
+```
+
+## Custom Strategies
+
+```rust
+use proptest::prelude::*;
+
+#[derive(Debug, Clone)]
+struct User {
+    name: String,
+    age: u8,
+}
+
+fn user_strategy() -> impl Strategy<Value = User> {
+    ("[a-zA-Z]{1,20}", 0..120u8)
+        .prop_map(|(name, age)| User { name, age })
+}
+
+proptest! {
+    #[test]
+    fn test_user(user in user_strategy()) {
+        assert!(user.age < 150);
+        assert!(!user.name.is_empty());
+    }
+}
+
+// Or derive Arbitrary
+use proptest_derive::Arbitrary;
+
+#[derive(Debug, Arbitrary)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+```
+
+## Properties to Test
+
+| Property | Example |
+|----------|---------|
+| Roundtrip | `decode(encode(x)) == x` |
+| Idempotence | `f(f(x)) == f(x)` |
+| Commutativity | `f(a, b) == f(b, a)` |
+| Associativity | `f(f(a, b), c) == f(a, f(b, c))` |
+| Identity | `f(x, identity) == x` |
+| Invariants | `len(push(v, x)) == len(v) + 1` |
+
+## Example: Parser Roundtrip
+
+```rust
+proptest! {
+    #[test]
+    fn parse_roundtrip(config in valid_config_strategy()) {
+        let serialized = config.to_string();
+        let parsed = Config::parse(&serialized).unwrap();
+        assert_eq!(config, parsed);
+    }
+}
+```
+
+## Shrinking
+
+Proptest automatically shrinks failing inputs to minimal cases:
+
+```rust
+// If this fails with vec![100, 50, 75, 25, 0]
+// Proptest will shrink to vec![1, 0] (minimal failing case)
+proptest! {
+    #[test]
+    fn test_sorted(v in prop::collection::vec(0..1000i32, 1..100)) {
+        let sorted = is_sorted(&v);
+        // This will fail and shrink
+    }
+}
+```
+
+## Configuration
+
+```rust
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 1000,  // More test cases
+        max_shrink_iters: 10000,  // More shrinking
+        ..ProptestConfig::default()
+    })]
+    
+    #[test]
+    fn extensive_test(x in any::<i32>()) { }
+}
+```
+
+## See Also
+
+- [test-criterion-bench](./test-criterion-bench.md) - Benchmarking
+- [test-mockall-mocking](./test-mockall-mocking.md) - Mocking
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-should-panic.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-should-panic.md
@@ -1,0 +1,130 @@
+# test-should-panic
+
+> Use `#[should_panic]` to test that code panics as expected
+
+## Why It Matters
+
+Some code should panic on invalid inputs or invariant violations. `#[should_panic]` verifies the panic occurs, optionally checking the panic message. This ensures defensive panics work correctly and documents expected panic conditions.
+
+## Bad
+
+```rust
+#[test]
+fn test_panic() {
+    // Just calling panicking code makes test fail
+    divide(1, 0);  // Test fails with panic
+}
+
+// Using catch_unwind is verbose
+#[test]
+fn test_panic_manual() {
+    let result = std::panic::catch_unwind(|| divide(1, 0));
+    assert!(result.is_err());
+}
+```
+
+## Good
+
+```rust
+#[test]
+#[should_panic]
+fn divide_by_zero_panics() {
+    divide(1, 0);  // Test passes when this panics
+}
+
+// With expected message
+#[test]
+#[should_panic(expected = "division by zero")]
+fn divide_by_zero_panics_with_message() {
+    divide(1, 0);  // Panics with "division by zero"
+}
+
+// Partial message match
+#[test]
+#[should_panic(expected = "index out of bounds")]
+fn index_panic_contains_message() {
+    let v = vec![1, 2, 3];
+    let _ = v[100];  // Message contains "index out of bounds"
+}
+```
+
+## Testing Invariants
+
+```rust
+struct NonEmpty<T>(Vec<T>);
+
+impl<T> NonEmpty<T> {
+    fn new(items: Vec<T>) -> Self {
+        assert!(!items.is_empty(), "NonEmpty cannot be empty");
+        NonEmpty(items)
+    }
+}
+
+#[test]
+#[should_panic(expected = "NonEmpty cannot be empty")]
+fn non_empty_rejects_empty_vec() {
+    NonEmpty::new(Vec::<i32>::new());
+}
+
+#[test]
+fn non_empty_accepts_non_empty_vec() {
+    let ne = NonEmpty::new(vec![1, 2, 3]);
+    assert_eq!(ne.0.len(), 3);
+}
+```
+
+## With expect() Messages
+
+```rust
+fn get_config_value(key: &str) -> String {
+    CONFIG.get(key)
+        .expect(&format!("missing required config: {}", key))
+        .to_string()
+}
+
+#[test]
+#[should_panic(expected = "missing required config: DATABASE_URL")]
+fn missing_config_panics_with_key() {
+    get_config_value("DATABASE_URL");
+}
+```
+
+## When NOT to Use should_panic
+
+```rust
+// ❌ For recoverable errors - use Result
+#[test]
+#[should_panic]  // Wrong: this should return Err, not panic
+fn invalid_input_panics() {
+    parse_config("invalid");  // Should return Err, not panic
+}
+
+// ✅ Return Result and test the error
+#[test]
+fn invalid_input_returns_error() {
+    let result = parse_config("invalid");
+    assert!(result.is_err());
+}
+```
+
+## Combining with Result
+
+```rust
+#[test]
+#[should_panic]
+fn test_panics() -> Result<(), Error> {
+    // Can combine with Result for setup
+    let data = setup_test_data()?;
+    
+    // This should panic
+    process_invalid(&data);
+    
+    Ok(())  // Never reached
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Panic vs Result
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to use expect
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-tokio-async.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-tokio-async.md
@@ -1,0 +1,154 @@
+# test-tokio-async
+
+> Use `#[tokio::test]` for async tests
+
+## Why It Matters
+
+Async functions can't be called directly—they need a runtime to drive them. `#[tokio::test]` provides a Tokio runtime for your test, handling setup automatically. This is simpler than manually creating a runtime and essential for testing async code.
+
+## Bad
+
+```rust
+// Won't compile - async fn can't be called without runtime
+#[test]
+async fn test_async_function() {  // Error!
+    let result = fetch_data().await;
+    assert!(result.is_ok());
+}
+
+// Manual runtime - verbose and error-prone
+#[test]
+fn test_async_function() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let result = fetch_data().await;
+        assert!(result.is_ok());
+    });
+}
+```
+
+## Good
+
+```rust
+#[tokio::test]
+async fn test_async_function() {
+    let result = fetch_data().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_concurrent_operations() {
+    let (a, b) = tokio::join!(
+        fetch_user(1),
+        fetch_user(2),
+    );
+    assert!(a.is_ok());
+    assert!(b.is_ok());
+}
+```
+
+## Runtime Configuration
+
+```rust
+// Multi-threaded runtime (default)
+#[tokio::test]
+async fn test_default_runtime() {
+    // Uses multi-thread runtime
+}
+
+// Single-threaded (current_thread)
+#[tokio::test(flavor = "current_thread")]
+async fn test_single_threaded() {
+    // Simpler, deterministic
+}
+
+// With specific thread count
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_with_workers() {
+    // Exactly 2 worker threads
+}
+
+// With time control
+#[tokio::test(start_paused = true)]
+async fn test_with_time_control() {
+    // Time starts paused for deterministic testing
+    tokio::time::advance(Duration::from_secs(60)).await;
+}
+```
+
+## Testing Timeouts
+
+```rust
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn test_operation_completes_in_time() {
+    let result = timeout(
+        Duration::from_secs(5),
+        slow_operation()
+    ).await;
+    
+    assert!(result.is_ok(), "Operation timed out");
+}
+
+#[tokio::test]
+async fn test_timeout_triggers() {
+    let result = timeout(
+        Duration::from_millis(100),
+        never_completes()
+    ).await;
+    
+    assert!(result.is_err(), "Expected timeout");
+}
+```
+
+## Testing Channels
+
+```rust
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_channel_communication() {
+    let (tx, mut rx) = mpsc::channel(10);
+    
+    tokio::spawn(async move {
+        tx.send("hello").await.unwrap();
+        tx.send("world").await.unwrap();
+    });
+    
+    assert_eq!(rx.recv().await, Some("hello"));
+    assert_eq!(rx.recv().await, Some("world"));
+    assert_eq!(rx.recv().await, None);
+}
+```
+
+## Testing with Mocks
+
+```rust
+use mockall::*;
+
+#[automock]
+#[async_trait::async_trait]
+trait Database {
+    async fn get_user(&self, id: u64) -> Option<User>;
+}
+
+#[tokio::test]
+async fn test_with_mock_database() {
+    let mut mock = MockDatabase::new();
+    mock.expect_get_user()
+        .with(eq(42))
+        .returning(|_| Some(User { id: 42, name: "Alice".into() }));
+    
+    let service = UserService::new(mock);
+    let user = service.find_user(42).await;
+    
+    assert_eq!(user.unwrap().name, "Alice");
+}
+```
+
+## See Also
+
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime configuration
+- [test-mock-traits](./test-mock-traits.md) - Mocking async traits
+- [test-fixture-raii](./test-fixture-raii.md) - Async test cleanup

--- a/.cursor/skills/rust-skills-leonardomso/rules/test-use-super.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/test-use-super.md
@@ -1,0 +1,127 @@
+# test-use-super
+
+> Use `use super::*;` in test modules to access parent module items
+
+## Why It Matters
+
+The test module is a child of the module being tested. `use super::*` imports all items from the parent module, including private ones. This gives tests access to both public API and internal implementation details for thorough testing.
+
+## Bad
+
+```rust
+// Verbose imports
+#[cfg(test)]
+mod tests {
+    use crate::my_module::public_function;
+    use crate::my_module::MyStruct;
+    // Can't access private items this way!
+    
+    #[test]
+    fn test_function() {
+        let result = public_function();
+        // ...
+    }
+}
+```
+
+## Good
+
+```rust
+// src/my_module.rs
+pub struct PublicStruct { ... }
+struct PrivateStruct { ... }  // Private
+
+pub fn public_function() -> i32 { ... }
+fn private_helper() -> i32 { ... }  // Private
+
+#[cfg(test)]
+mod tests {
+    use super::*;  // Imports everything from parent
+    
+    #[test]
+    fn test_public_struct() {
+        let s = PublicStruct::new();
+        // ...
+    }
+    
+    #[test]
+    fn test_private_struct() {
+        let s = PrivateStruct::new();  // Can access private!
+        // ...
+    }
+    
+    #[test]
+    fn test_private_helper() {
+        assert_eq!(private_helper(), 42);  // Can test private!
+    }
+}
+```
+
+## Selective Imports
+
+```rust
+#[cfg(test)]
+mod tests {
+    // When you want to be explicit
+    use super::{parse, ParseError, Token};
+    
+    // Or import all plus test utilities
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn test_parse() { ... }
+}
+```
+
+## Nested Modules
+
+```rust
+mod outer {
+    pub fn outer_fn() -> i32 { 1 }
+    
+    mod inner {
+        pub fn inner_fn() -> i32 { 2 }
+        
+        #[cfg(test)]
+        mod tests {
+            use super::*;           // Gets inner's items
+            use super::super::*;    // Gets outer's items
+            
+            #[test]
+            fn test_inner() {
+                assert_eq!(inner_fn(), 2);
+                assert_eq!(outer_fn(), 1);
+            }
+        }
+    }
+}
+```
+
+## With External Dependencies
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test-only dependencies
+    use proptest::prelude::*;
+    use mockall::predicate::*;
+    
+    proptest! {
+        #[test]
+        fn test_property(s: String) {
+            let result = process(&s);
+            prop_assert!(result.is_ok());
+        }
+    }
+}
+```
+
+## See Also
+
+- [test-cfg-test-module](./test-cfg-test-module.md) - Test module structure
+- [test-integration-dir](./test-integration-dir.md) - Integration tests
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Visibility modifiers

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-enum-states.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-enum-states.md
@@ -1,0 +1,154 @@
+# type-enum-states
+
+> Use enums for mutually exclusive states
+
+## Why It Matters
+
+When a value can be in exactly one of several states, an enum makes invalid states unrepresentable. The compiler ensures all states are handled. Contrast with boolean flags or optional fields that can represent impossible combinations.
+
+## Bad
+
+```rust
+struct Connection {
+    is_connected: bool,
+    is_authenticated: bool,
+    is_disconnected: bool,  // Can all three be true? False?
+    socket: Option<TcpStream>,
+    credentials: Option<Credentials>,
+}
+
+// Possible invalid states:
+// - is_connected && is_disconnected (contradiction)
+// - is_authenticated && !is_connected (impossible)
+// - socket is None but is_connected is true (inconsistent)
+```
+
+## Good
+
+```rust
+enum ConnectionState {
+    Disconnected,
+    Connecting { address: SocketAddr },
+    Connected { socket: TcpStream },
+    Authenticated { socket: TcpStream, session: Session },
+    Failed { error: ConnectionError },
+}
+
+struct Connection {
+    state: ConnectionState,
+}
+
+// Impossible states are unrepresentable
+// Each state has exactly the data it needs
+```
+
+## Pattern Matching Ensures Completeness
+
+```rust
+fn handle_connection(conn: &Connection) {
+    match &conn.state {
+        ConnectionState::Disconnected => {
+            println!("Not connected");
+        }
+        ConnectionState::Connecting { address } => {
+            println!("Connecting to {}", address);
+        }
+        ConnectionState::Connected { socket } => {
+            println!("Connected, not authenticated");
+        }
+        ConnectionState::Authenticated { socket, session } => {
+            println!("Authenticated as {}", session.user);
+        }
+        ConnectionState::Failed { error } => {
+            println!("Failed: {}", error);
+        }
+    }
+    // Compiler error if any state is missing
+}
+```
+
+## State Transitions
+
+```rust
+impl Connection {
+    fn connect(&mut self, addr: SocketAddr) -> Result<(), Error> {
+        match &self.state {
+            ConnectionState::Disconnected => {
+                self.state = ConnectionState::Connecting { address: addr };
+                Ok(())
+            }
+            _ => Err(Error::AlreadyConnected),
+        }
+    }
+    
+    fn on_connected(&mut self, socket: TcpStream) {
+        if let ConnectionState::Connecting { .. } = &self.state {
+            self.state = ConnectionState::Connected { socket };
+        }
+    }
+    
+    fn authenticate(&mut self, creds: Credentials) -> Result<(), Error> {
+        match std::mem::replace(&mut self.state, ConnectionState::Disconnected) {
+            ConnectionState::Connected { socket } => {
+                let session = perform_auth(&socket, creds)?;
+                self.state = ConnectionState::Authenticated { socket, session };
+                Ok(())
+            }
+            other => {
+                self.state = other;
+                Err(Error::NotConnected)
+            }
+        }
+    }
+}
+```
+
+## Result and Option as State Enums
+
+```rust
+// Option<T> is an enum for "might not exist"
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+// Result<T, E> is an enum for "might have failed"
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+// Use these instead of nullable/sentinel values
+fn find_user(id: u64) -> Option<User> { ... }
+fn parse_config(s: &str) -> Result<Config, ParseError> { ... }
+```
+
+## Avoid Boolean Flags
+
+```rust
+// Bad: boolean flags
+struct Task {
+    is_running: bool,
+    is_completed: bool,
+    is_failed: bool,
+    error: Option<Error>,
+}
+
+// Good: enum state
+enum TaskState {
+    Pending,
+    Running { started_at: Instant },
+    Completed { result: Output },
+    Failed { error: Error },
+}
+
+struct Task {
+    state: TaskState,
+}
+```
+
+## See Also
+
+- [api-typestate](./api-typestate.md) - Type-level state machines
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums
+- [type-option-nullable](./type-option-nullable.md) - Option for optional values

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-generic-bounds.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-generic-bounds.md
@@ -1,0 +1,142 @@
+# type-generic-bounds
+
+> Add trait bounds only where needed, prefer where clauses for readability
+
+## Why It Matters
+
+Trait bounds constrain what types can be used with generic code. Adding unnecessary bounds limits flexibility. Adding bounds in the right place (impl vs function vs where clause) affects usability and readability. Well-placed bounds keep APIs flexible while ensuring type safety.
+
+## Bad
+
+```rust
+// Bounds on struct definition - limits all uses
+struct Container<T: Clone + Debug> {  // Even storage requires Clone?
+    items: Vec<T>,
+}
+
+// Inline bounds make signature hard to read
+fn process<T: Clone + Debug + Send + Sync + 'static, E: Error + Send + Clone>(
+    value: T
+) -> Result<T, E> { ... }
+
+// Redundant bounds
+fn print_twice<T: Clone + Debug>(value: T)
+where
+    T: Clone,  // Already specified above
+{ ... }
+```
+
+## Good
+
+```rust
+// No bounds on struct - store anything
+struct Container<T> {
+    items: Vec<T>,
+}
+
+// Bounds only on impls that need them
+impl<T: Clone> Container<T> {
+    fn duplicate(&self) -> Self {
+        Container { items: self.items.clone() }
+    }
+}
+
+impl<T: Debug> Container<T> {
+    fn debug_print(&self) {
+        println!("{:?}", self.items);
+    }
+}
+
+// Where clause for readability
+fn process<T, E>(value: T) -> Result<T, E>
+where
+    T: Clone + Debug + Send + Sync + 'static,
+    E: Error + Send + Clone,
+{ ... }
+```
+
+## Bound Placement
+
+```rust
+// On struct: affects all uses of the type
+struct MustBeClone<T: Clone> { data: T }  // Rarely needed
+
+// On impl: affects specific functionality
+impl<T: Clone> Container<T> { ... }  // Common pattern
+
+// On function: affects that function only
+fn requires_send<T: Send>(value: T) { ... }
+
+// Recommendation: start with no bounds, add as needed
+```
+
+## Where Clause Benefits
+
+```rust
+// Inline: hard to read
+fn complex<T: Clone + Debug + Send, U: AsRef<str> + Into<String>>(t: T, u: U) { }
+
+// Where clause: clear and scannable
+fn complex<T, U>(t: T, u: U)
+where
+    T: Clone + Debug + Send,
+    U: AsRef<str> + Into<String>,
+{ }
+
+// Essential for complex bounds
+fn foo<T, U>(t: T, u: U)
+where
+    T: Iterator<Item = U>,
+    U: Clone + Into<String>,
+    Vec<U>: Debug,  // Bounds on expressions
+{ }
+```
+
+## Implied Bounds
+
+```rust
+// Supertrait bounds are implied
+trait Foo: Clone + Debug {}
+
+fn process<T: Foo>(value: T) {
+    // T: Clone and T: Debug are implied by T: Foo
+    let cloned = value.clone();
+    println!("{:?}", cloned);
+}
+
+// Associated type bounds
+fn process<I>(iter: I)
+where
+    I: Iterator,
+    I::Item: Clone,  // Bound on associated type
+{ }
+```
+
+## Conditional Trait Implementation
+
+```rust
+struct Wrapper<T>(T);
+
+// Implement Clone only when T: Clone
+impl<T: Clone> Clone for Wrapper<T> {
+    fn clone(&self) -> Self {
+        Wrapper(self.0.clone())
+    }
+}
+
+// Implement Debug only when T: Debug  
+impl<T: Debug> Debug for Wrapper<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Wrapper").field(&self.0).finish()
+    }
+}
+
+// Wrapper<i32> is Clone + Debug
+// Wrapper<NonCloneable> is neither
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - Using Into bounds
+- [api-impl-asref](./api-impl-asref.md) - Using AsRef bounds
+- [name-type-param-single](./name-type-param-single.md) - Type parameter naming

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-never-diverge.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-never-diverge.md
@@ -1,0 +1,146 @@
+# type-never-diverge
+
+> Use `!` (never type) for functions that never return
+
+## Why It Matters
+
+The never type `!` indicates a function will never return normally—it either loops forever, panics, or exits the process. This helps the compiler understand control flow and enables `!` to coerce to any type, making it useful in match arms and expressions.
+
+## Bad
+
+```rust
+// Return type doesn't indicate non-returning
+fn infinite_loop() {
+    loop {
+        process_events();
+    }
+    // Implicit () return type, but never returns
+}
+
+// Using Option when it always panics
+fn unreachable_code() -> Option<()> {
+    panic!("This should never be called");
+}
+```
+
+## Good
+
+```rust
+// ! indicates function never returns
+fn infinite_loop() -> ! {
+    loop {
+        process_events();
+    }
+}
+
+fn abort_with_error(msg: &str) -> ! {
+    eprintln!("Fatal error: {}", msg);
+    std::process::exit(1);
+}
+
+fn panic_handler() -> ! {
+    panic!("Unexpected state");
+}
+```
+
+## Coercion to Any Type
+
+```rust
+// ! coerces to any type
+fn get_value(opt: Option<i32>) -> i32 {
+    match opt {
+        Some(v) => v,
+        None => panic!("No value"),  // panic! returns !, coerces to i32
+    }
+}
+
+// Useful in Result handling
+fn must_get_config() -> Config {
+    match load_config() {
+        Ok(c) => c,
+        Err(e) => {
+            log_error(&e);
+            std::process::exit(1)  // Returns !, coerces to Config
+        }
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// std::process::exit
+pub fn exit(code: i32) -> !
+
+// panic! macro
+// Expands to an expression of type !
+
+// std::hint::unreachable_unchecked
+pub unsafe fn unreachable_unchecked() -> !
+
+// loop {} with no break
+fn forever() -> ! {
+    loop {}
+}
+```
+
+## In Match Expressions
+
+```rust
+enum State {
+    Running,
+    Stopped,
+    Error,
+}
+
+fn get_status(state: &State) -> &str {
+    match state {
+        State::Running => "running",
+        State::Stopped => "stopped",
+        State::Error => unreachable!(),  // ! coerces to &str
+    }
+}
+
+// With Result
+fn process(r: Result<Data, Error>) -> Data {
+    match r {
+        Ok(d) => d,
+        Err(e) => panic!("Unexpected error: {}", e),  // ! coerces to Data
+    }
+}
+```
+
+## Diverging Closures
+
+```rust
+// Closures that never return
+let handler: fn() -> ! = || {
+    panic!("Handler called");
+};
+
+// In thread spawn
+std::thread::spawn(|| -> ! {
+    loop {
+        process_work();
+    }
+});
+```
+
+## Current Limitations (Nightly)
+
+```rust
+// Full ! type is nightly
+#![feature(never_type)]
+
+// Can use ! as type parameter
+type NeverResult = Result<(), !>;  // Can never be Err
+
+// On stable, use std::convert::Infallible
+type StableNeverResult = Result<(), std::convert::Infallible>;
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - When to panic vs return Result
+- [type-result-fallible](./type-result-fallible.md) - Result for errors
+- [opt-cold-unlikely](./opt-cold-unlikely.md) - Marking unlikely paths

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-newtype-ids.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-newtype-ids.md
@@ -1,0 +1,160 @@
+# type-newtype-ids
+
+> Wrap IDs in newtypes: `UserId(u64)`
+
+## Why It Matters
+
+Using raw integers for IDs is error-prone. It's easy to accidentally pass a `user_id` where a `post_id` is expected. Newtypes make these mix-ups compile-time errors instead of runtime bugs.
+
+## Bad
+
+```rust
+fn get_user_posts(user_id: u64, post_id: u64) -> Vec<Post> {
+    // Which is which? Easy to swap by accident
+}
+
+// Oops! Arguments swapped - compiles fine, wrong at runtime
+let posts = get_user_posts(post_id, user_id);
+
+// Even worse with multiple IDs
+fn transfer(from: u64, to: u64, amount: u64) {
+    // from/to can easily be swapped
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PostId(pub u64);
+
+fn get_user_posts(user_id: UserId, post_id: PostId) -> Vec<Post> {
+    // Types are distinct
+}
+
+// This won't compile - types don't match
+// let posts = get_user_posts(post_id, user_id);  // ERROR!
+
+// Correct usage
+let posts = get_user_posts(UserId(1), PostId(42));
+```
+
+## Derive Common Traits
+
+```rust
+#[derive(
+    Debug,      // For printing
+    Clone,      // For copying
+    Copy,       // For implicit copies (if small)
+    PartialEq,  // For == comparison
+    Eq,         // For HashMap keys
+    Hash,       // For HashMap keys
+    PartialOrd, // For sorting (optional)
+    Ord,        // For BTreeMap keys (optional)
+)]
+pub struct UserId(pub u64);
+```
+
+## Add Useful Methods
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserId(u64);
+
+impl UserId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+    
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+    
+    // For database queries
+    pub fn as_i64(self) -> i64 {
+        self.0 as i64
+    }
+}
+
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "user:{}", self.0)
+    }
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]  // Serializes as just the inner value
+pub struct UserId(pub u64);
+
+// JSON: {"user_id": 123} not {"user_id": {"0": 123}}
+```
+
+## String IDs (UUIDs, etc.)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+    
+    pub fn parse(s: &str) -> Result<Self, ParseError> {
+        // Validate format
+        uuid::Uuid::parse_str(s)?;
+        Ok(Self(s.to_string()))
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## Multiple Related IDs
+
+```rust
+// Macro for consistent ID types
+macro_rules! define_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct $name(pub u64);
+        
+        impl $name {
+            pub const fn new(id: u64) -> Self { Self(id) }
+            pub const fn get(self) -> u64 { self.0 }
+        }
+        
+        impl From<u64> for $name {
+            fn from(id: u64) -> Self { Self(id) }
+        }
+    };
+}
+
+define_id!(UserId);
+define_id!(PostId);
+define_id!(CommentId);
+define_id!(TeamId);
+```
+
+## See Also
+
+- [api-newtype-safety](api-newtype-safety.md) - Newtypes for type safety
+- [type-newtype-validated](type-newtype-validated.md) - Newtypes for validated data
+- [api-parse-dont-validate](api-parse-dont-validate.md) - Parse into validated types

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-newtype-validated.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-newtype-validated.md
@@ -1,0 +1,159 @@
+# type-newtype-validated
+
+> Use newtypes to enforce validation at construction time
+
+## Why It Matters
+
+A validated newtype guarantees its inner value is always valid. Once you have an `Email`, you know it passed validation—no re-checking needed. This "parse, don't validate" pattern catches errors at boundaries and makes invalid states unrepresentable.
+
+## Bad
+
+```rust
+// Validation scattered throughout code
+fn send_email(to: &str, body: &str) -> Result<(), Error> {
+    if !is_valid_email(to) {  // Must check every time
+        return Err(Error::InvalidEmail);
+    }
+    // ...
+}
+
+fn add_recipient(list: &mut Vec<String>, email: &str) -> Result<(), Error> {
+    if !is_valid_email(email) {  // Check again
+        return Err(Error::InvalidEmail);
+    }
+    list.push(email.to_string());
+    Ok(())
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Email(String);
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, EmailError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(EmailError::Invalid(s.to_string()))
+        }
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// No validation needed - Email is always valid
+fn send_email(to: &Email, body: &str) -> Result<(), Error> {
+    // to is guaranteed valid
+    send_to_address(to.as_str(), body)
+}
+
+fn add_recipient(list: &mut Vec<Email>, email: Email) {
+    // email is guaranteed valid
+    list.push(email);
+}
+```
+
+## Common Validated Types
+
+```rust
+// URLs
+pub struct Url(url::Url);
+
+impl Url {
+    pub fn parse(s: &str) -> Result<Self, UrlError> {
+        url::Url::parse(s)
+            .map(Url)
+            .map_err(UrlError::from)
+    }
+}
+
+// Non-empty strings
+pub struct NonEmptyString(String);
+
+impl NonEmptyString {
+    pub fn new(s: String) -> Option<Self> {
+        if s.is_empty() {
+            None
+        } else {
+            Some(NonEmptyString(s))
+        }
+    }
+}
+
+// Positive numbers
+pub struct PositiveI32(i32);
+
+impl PositiveI32 {
+    pub fn new(n: i32) -> Option<Self> {
+        if n > 0 {
+            Some(PositiveI32(n))
+        } else {
+            None
+        }
+    }
+    
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+// Bounded ranges
+pub struct Percentage(f64);
+
+impl Percentage {
+    pub fn new(value: f64) -> Result<Self, RangeError> {
+        if (0.0..=100.0).contains(&value) {
+            Ok(Percentage(value))
+        } else {
+            Err(RangeError::OutOfBounds)
+        }
+    }
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Email(String);
+
+impl<'de> Deserialize<'de> for Email {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Email::new(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// JSON deserialization automatically validates
+let email: Email = serde_json::from_str(r#""user@example.com""#)?;
+```
+
+## Compile-Time Validation
+
+```rust
+// For values known at compile time
+macro_rules! email {
+    ($s:literal) => {{
+        const _: () = assert!(is_valid_email_const($s));
+        Email::new_unchecked($s)
+    }};
+}
+
+let admin = email!("admin@example.com");  // Validated at compile time
+```
+
+## See Also
+
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Parse at boundaries
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe distinctions
+- [type-newtype-ids](./type-newtype-ids.md) - ID newtypes

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-no-stringly.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-no-stringly.md
@@ -1,0 +1,144 @@
+# type-no-stringly
+
+> Avoid stringly-typed APIs; use enums, newtypes, or validated types
+
+## Why It Matters
+
+Strings accept any value—typos, wrong formats, invalid data all compile fine. Enums, newtypes, and validated types catch errors at compile time or construction time, not runtime. They also provide better IDE support, documentation, and make invalid states unrepresentable.
+
+## Bad
+
+```rust
+// Status as string - easy to get wrong
+fn set_status(status: &str) {
+    match status {
+        "pending" => { ... }
+        "active" => { ... }
+        "completed" => { ... }
+        _ => panic!("Unknown status"),  // Runtime error
+    }
+}
+
+// Easy to misuse
+set_status("pending");   // OK
+set_status("Pending");   // Runtime error - wrong case
+set_status("aktive");    // Runtime error - typo
+set_status("done");      // Runtime error - wrong word
+
+// Configuration as strings
+fn configure(key: &str, value: &str) {
+    // No type safety, no validation
+}
+```
+
+## Good
+
+```rust
+// Status as enum - compile-time safety
+enum Status {
+    Pending,
+    Active,
+    Completed,
+}
+
+fn set_status(status: Status) {
+    match status {
+        Status::Pending => { ... }
+        Status::Active => { ... }
+        Status::Completed => { ... }
+    }  // Exhaustive - compiler checks all cases
+}
+
+// Can only pass valid values
+set_status(Status::Pending);  // OK
+set_status(Status::Aktivev);  // Compile error - typo caught!
+
+// Configuration with typed builder
+struct Config {
+    timeout: Duration,
+    retries: u32,
+    mode: Mode,
+}
+
+enum Mode { Fast, Safe, Balanced }
+```
+
+## Parsing at Boundaries
+
+```rust
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy)]
+enum Priority {
+    Low,
+    Medium,
+    High,
+}
+
+impl FromStr for Priority {
+    type Err = ParseError;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "low" => Ok(Priority::Low),
+            "medium" | "med" => Ok(Priority::Medium),
+            "high" => Ok(Priority::High),
+            _ => Err(ParseError::UnknownPriority(s.to_string())),
+        }
+    }
+}
+
+// Parse once at boundary
+fn handle_request(priority_str: &str) -> Result<(), Error> {
+    let priority: Priority = priority_str.parse()?;
+    // From here, priority is type-safe
+    process(priority);
+    Ok(())
+}
+```
+
+## Validated Newtypes
+
+```rust
+// Instead of string for email
+struct Email(String);
+
+impl Email {
+    fn new(s: &str) -> Result<Self, ValidationError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(ValidationError::InvalidEmail)
+        }
+    }
+}
+
+// Instead of string for UUID
+struct UserId(uuid::Uuid);
+
+// Instead of string for paths
+struct ConfigPath(PathBuf);
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EventType {
+    UserCreated,
+    UserDeleted,
+    UserUpdated,
+}
+
+// JSON: {"type": "user_created", ...}
+// Automatically validated during deserialization
+```
+
+## See Also
+
+- [anti-stringly-typed](./anti-stringly-typed.md) - Anti-pattern details
+- [type-newtype-validated](./type-newtype-validated.md) - Validated newtypes
+- [type-enum-states](./type-enum-states.md) - Enums for states

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-option-nullable.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-option-nullable.md
@@ -1,0 +1,137 @@
+# type-option-nullable
+
+> Use `Option<T>` for values that might not exist
+
+## Why It Matters
+
+`Option<T>` explicitly represents "value or nothing" in the type system. Unlike null pointers or sentinel values, you can't accidentally use a missing value—the compiler forces you to handle the `None` case. This eliminates null pointer exceptions at compile time.
+
+## Bad
+
+```rust
+// Sentinel values - easy to forget to check
+fn find_user(id: u64) -> User {
+    // Returns "empty" user if not found - caller might not check
+    users.get(&id).cloned().unwrap_or(User::empty())
+}
+
+// Nullable-style with raw pointers
+fn find_user(id: u64) -> *const User {
+    // Null if not found - unsafe, no compiler help
+}
+
+// Error-prone usage
+let user = find_user(42);
+println!("{}", user.name);  // Might be empty user - silent bug
+```
+
+## Good
+
+```rust
+// Option makes absence explicit
+fn find_user(id: u64) -> Option<User> {
+    users.get(&id).cloned()
+}
+
+// Must handle the None case
+let user = find_user(42);
+match user {
+    Some(u) => println!("{}", u.name),
+    None => println!("User not found"),
+}
+
+// Or use combinators
+let name = find_user(42)
+    .map(|u| u.name)
+    .unwrap_or_else(|| "Unknown".to_string());
+```
+
+## Common Option Patterns
+
+```rust
+// if let for single case
+if let Some(user) = find_user(id) {
+    process(user);
+}
+
+// Chaining with map
+let upper_name = find_user(id)
+    .map(|u| u.name)
+    .map(|n| n.to_uppercase());
+
+// Providing defaults
+let user = find_user(id).unwrap_or_default();
+let user = find_user(id).unwrap_or_else(|| User::guest());
+
+// ? operator for propagation
+fn get_user_email(id: u64) -> Option<String> {
+    let user = find_user(id)?;
+    Some(user.email)
+}
+
+// and_then for chained optionals
+fn get_user_country(id: u64) -> Option<String> {
+    find_user(id)
+        .and_then(|u| u.address)
+        .and_then(|a| a.country)
+}
+```
+
+## Struct Fields
+
+```rust
+struct User {
+    name: String,
+    email: String,
+    phone: Option<String>,        // Optional field
+    avatar_url: Option<Url>,      // Optional field
+}
+
+impl User {
+    fn display_phone(&self) -> &str {
+        self.phone.as_deref().unwrap_or("Not provided")
+    }
+}
+```
+
+## Option vs Result
+
+```rust
+// Option: value might not exist (no error context)
+fn find(key: &str) -> Option<Value> { ... }
+
+// Result: operation might fail (with error context)
+fn parse(input: &str) -> Result<Value, ParseError> { ... }
+
+// Convert Option to Result
+let value = find("key").ok_or(Error::NotFound)?;
+
+// Convert Result to Option
+let value = parse("input").ok();  // Discards error
+```
+
+## Option References
+
+```rust
+// Option<&T> for optional borrows
+fn get(&self, key: &str) -> Option<&Value> {
+    self.map.get(key)
+}
+
+// as_ref() to borrow Option contents
+let opt: Option<String> = Some("hello".to_string());
+let opt_ref: Option<&String> = opt.as_ref();
+let opt_str: Option<&str> = opt.as_deref();
+
+// as_mut() for mutable borrow
+let mut opt = Some(vec![1, 2, 3]);
+if let Some(v) = opt.as_mut() {
+    v.push(4);
+}
+```
+
+## See Also
+
+- [type-result-fallible](./type-result-fallible.md) - Result for errors
+- [type-enum-states](./type-enum-states.md) - Enums for states
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Handling Option safely

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-phantom-marker.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-phantom-marker.md
@@ -1,0 +1,188 @@
+# type-phantom-marker
+
+> Use `PhantomData` to express type relationships without runtime cost
+
+## Why It Matters
+
+Sometimes your type needs to be parameterized by a type that doesn't appear in any field—for variance, drop order, or semantic purposes. `PhantomData<T>` tells the compiler your type is "associated with" `T` without storing any `T` data. It has zero runtime cost.
+
+## Bad
+
+```rust
+// Type parameter unused - compiler error
+struct Handle<T> {
+    id: u64,
+    // Error: parameter `T` is never used
+}
+
+// Workaround with unnecessary storage
+struct Handle<T> {
+    id: u64,
+    _type: Option<T>,  // Wastes memory, requires T: Default
+}
+```
+
+## Good
+
+```rust
+use std::marker::PhantomData;
+
+struct Handle<T> {
+    id: u64,
+    _marker: PhantomData<T>,  // Zero-size, tells compiler about T
+}
+
+impl<T> Handle<T> {
+    fn new(id: u64) -> Self {
+        Handle {
+            id,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// Different Handle types are incompatible
+struct User;
+struct Order;
+
+fn process_user(h: Handle<User>) { ... }
+
+let user_handle = Handle::<User>::new(1);
+let order_handle = Handle::<Order>::new(2);
+
+process_user(user_handle);   // OK
+process_user(order_handle);  // Error: expected Handle<User>, found Handle<Order>
+```
+
+## Expressing Ownership
+
+```rust
+use std::marker::PhantomData;
+
+// Owns T conceptually (like Box<T>)
+struct Container<T> {
+    ptr: *mut T,
+    _marker: PhantomData<T>,  // Acts like we own a T
+}
+
+// Drop will be called on T when Container drops
+impl<T> Drop for Container<T> {
+    fn drop(&mut self) {
+        unsafe {
+            std::ptr::drop_in_place(self.ptr);
+        }
+    }
+}
+```
+
+## Expressing Borrowing
+
+```rust
+use std::marker::PhantomData;
+
+// Borrows T for lifetime 'a
+struct Ref<'a, T> {
+    ptr: *const T,
+    _marker: PhantomData<&'a T>,  // Acts like &'a T
+}
+
+// Compiler tracks lifetime correctly
+impl<'a, T> Ref<'a, T> {
+    fn get(&self) -> &'a T {
+        unsafe { &*self.ptr }
+    }
+}
+```
+
+## Type-Level State Machine
+
+```rust
+use std::marker::PhantomData;
+
+// States as zero-size types
+struct Unlocked;
+struct Locked;
+
+struct Door<State> {
+    _state: PhantomData<State>,
+}
+
+impl Door<Unlocked> {
+    fn lock(self) -> Door<Locked> {
+        println!("Locking...");
+        Door { _state: PhantomData }
+    }
+    
+    fn open(&self) {
+        println!("Opening...");
+    }
+}
+
+impl Door<Locked> {
+    fn unlock(self) -> Door<Unlocked> {
+        println!("Unlocking...");
+        Door { _state: PhantomData }
+    }
+    
+    // Can't call open() on Locked door - method doesn't exist
+}
+
+fn example() {
+    let door: Door<Unlocked> = Door { _state: PhantomData };
+    door.open();           // OK
+    let locked = door.lock();
+    // locked.open();      // Error: no method `open` for Door<Locked>
+    let unlocked = locked.unlock();
+    unlocked.open();       // OK
+}
+```
+
+## Variance Control
+
+```rust
+use std::marker::PhantomData;
+
+// Covariant in T (PhantomData<T>)
+struct Producer<T> {
+    _marker: PhantomData<T>,  // Covariant
+}
+
+// Contravariant in T (PhantomData<fn(T)>)
+struct Consumer<T> {
+    _marker: PhantomData<fn(T)>,  // Contravariant
+}
+
+// Invariant in T (PhantomData<fn(T) -> T>)
+struct Both<T> {
+    _marker: PhantomData<fn(T) -> T>,  // Invariant
+}
+```
+
+## Common Uses
+
+```rust
+// 1. FFI handles with type safety
+struct FileHandle<T: FileType> {
+    fd: i32,
+    _marker: PhantomData<T>,
+}
+
+// 2. Generic iterators
+struct Iter<'a, T> {
+    ptr: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,
+}
+
+// 3. Allocator-aware types
+struct Vec<T, A: Allocator = Global> {
+    buf: RawVec<T, A>,
+    len: usize,
+}
+```
+
+## See Also
+
+- [api-typestate](./api-typestate.md) - State machine pattern
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe wrappers
+- [type-newtype-ids](./type-newtype-ids.md) - ID types

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-repr-transparent.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-repr-transparent.md
@@ -1,0 +1,143 @@
+# type-repr-transparent
+
+> Use `#[repr(transparent)]` for newtypes in FFI contexts
+
+## Why It Matters
+
+`#[repr(transparent)]` guarantees a newtype has the same memory layout as its inner type. This is essential for FFI where you need type safety in Rust but must match C ABI layouts. Without it, the compiler may add padding or change layout.
+
+## Bad
+
+```rust
+// No layout guarantee - might not match inner type in FFI
+struct Handle(u64);
+
+// Passing to C code might fail
+extern "C" {
+    fn process_handle(h: Handle);  // May not work correctly
+}
+
+// Wrapping C type without layout guarantee
+struct SafePointer(*mut c_void);
+```
+
+## Good
+
+```rust
+// Guaranteed same layout as inner type
+#[repr(transparent)]
+struct Handle(u64);
+
+// Safe for FFI
+extern "C" {
+    fn process_handle(h: Handle);  // Works - same layout as u64
+}
+
+// FFI pointer wrapper
+#[repr(transparent)]
+struct SafePointer(*mut c_void);
+
+impl SafePointer {
+    // Safe Rust API around raw pointer
+    pub fn new(ptr: *mut c_void) -> Option<Self> {
+        if ptr.is_null() {
+            None
+        } else {
+            Some(SafePointer(ptr))
+        }
+    }
+}
+```
+
+## What repr(transparent) Guarantees
+
+```rust
+use std::mem::{size_of, align_of};
+
+#[repr(transparent)]
+struct Meters(f64);
+
+// Same size
+assert_eq!(size_of::<Meters>(), size_of::<f64>());
+
+// Same alignment
+assert_eq!(align_of::<Meters>(), align_of::<f64>());
+
+// Same ABI - can pass where f64 expected
+extern "C" fn measure(distance: Meters) { ... }
+```
+
+## With PhantomData
+
+```rust
+use std::marker::PhantomData;
+
+// PhantomData is zero-sized, doesn't affect layout
+#[repr(transparent)]
+struct TypedHandle<T> {
+    raw: u64,
+    _marker: PhantomData<T>,  // Zero-sized, ignored for layout
+}
+
+// Still same layout as u64
+assert_eq!(size_of::<TypedHandle<String>>(), size_of::<u64>());
+```
+
+## NonZero Wrappers
+
+```rust
+use std::num::NonZeroU64;
+
+#[repr(transparent)]
+struct NonZeroHandle(NonZeroU64);
+
+// Inherits null-pointer optimization
+assert_eq!(size_of::<Option<NonZeroHandle>>(), size_of::<u64>());
+```
+
+## FFI Pattern
+
+```rust
+mod ffi {
+    use std::os::raw::c_int;
+    
+    #[repr(transparent)]
+    pub struct FileDescriptor(c_int);
+    
+    extern "C" {
+        pub fn open(path: *const i8, flags: c_int) -> FileDescriptor;
+        pub fn close(fd: FileDescriptor) -> c_int;
+        pub fn read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isize;
+    }
+}
+
+// Safe wrapper
+pub struct File {
+    fd: ffi::FileDescriptor,
+}
+
+impl File {
+    pub fn open(path: &str) -> std::io::Result<Self> {
+        let c_path = std::ffi::CString::new(path)?;
+        let fd = unsafe { ffi::open(c_path.as_ptr(), 0) };
+        // ... error handling
+        Ok(File { fd })
+    }
+}
+```
+
+## When to Use
+
+| Scenario | Use `#[repr(transparent)]`? |
+|----------|----------------------------|
+| FFI newtype wrappers | Yes |
+| Type-safe handles | Yes |
+| NonZero optimization | Yes |
+| Pure Rust newtypes | Optional (doesn't hurt) |
+| Multi-field structs | N/A (only for single-field) |
+
+## See Also
+
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern
+- [type-phantom-marker](./type-phantom-marker.md) - PhantomData usage
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe newtypes

--- a/.cursor/skills/rust-skills-leonardomso/rules/type-result-fallible.md
+++ b/.cursor/skills/rust-skills-leonardomso/rules/type-result-fallible.md
@@ -1,0 +1,131 @@
+# type-result-fallible
+
+> Use `Result<T, E>` for operations that can fail
+
+## Why It Matters
+
+`Result<T, E>` makes failure explicit in the type system. Callers must acknowledge and handle potential errors—they can't accidentally ignore failures. The `?` operator makes error propagation ergonomic while maintaining explicit error handling.
+
+## Bad
+
+```rust
+// Returning Option loses error context
+fn read_config(path: &str) -> Option<Config> {
+    let content = std::fs::read_to_string(path).ok()?;  // Why did it fail?
+    toml::from_str(&content).ok()  // Parse error lost
+}
+
+// Panicking on errors
+fn read_config(path: &str) -> Config {
+    let content = std::fs::read_to_string(path).unwrap();  // Crashes
+    toml::from_str(&content).unwrap()  // Crashes
+}
+
+// Sentinel values
+fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 { return -1; }  // Magic value, easy to miss
+    a / b
+}
+```
+
+## Good
+
+```rust
+// Result with clear error type
+fn read_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(ConfigError::IoError)?;
+    toml::from_str(&content)
+        .map_err(ConfigError::ParseError)
+}
+
+fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {
+    if b == 0 {
+        return Err(DivisionError::DivideByZero);
+    }
+    Ok(a / b)
+}
+
+// Caller must handle
+match divide(10, 0) {
+    Ok(result) => println!("Result: {}", result),
+    Err(e) => println!("Error: {}", e),
+}
+```
+
+## The ? Operator
+
+```rust
+fn process_file(path: &str) -> Result<ProcessedData, Error> {
+    let content = std::fs::read_to_string(path)?;  // Propagates Err
+    let parsed: RawData = serde_json::from_str(&content)?;
+    let validated = validate(parsed)?;
+    let processed = transform(validated)?;
+    Ok(processed)
+}
+
+// Equivalent to:
+fn process_file(path: &str) -> Result<ProcessedData, Error> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => return Err(e.into()),
+    };
+    // ... etc
+}
+```
+
+## Result Combinators
+
+```rust
+let result: Result<i32, Error> = Ok(42);
+
+// map: transform success value
+let doubled = result.map(|n| n * 2);  // Ok(84)
+
+// map_err: transform error
+let with_context = result.map_err(|e| format!("Failed: {}", e));
+
+// and_then: chain fallible operations
+let processed = result.and_then(|n| {
+    if n > 0 { Ok(n * 2) } else { Err(Error::Negative) }
+});
+
+// unwrap_or: provide default on error
+let value = result.unwrap_or(0);
+
+// ok(): convert to Option, discarding error
+let maybe_value: Option<i32> = result.ok();
+```
+
+## Defining Error Types
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("failed to read file: {0}")]
+    Io(#[from] std::io::Error),
+    
+    #[error("failed to parse config: {0}")]
+    Parse(#[from] toml::de::Error),
+    
+    #[error("missing required field: {0}")]
+    MissingField(String),
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)?;  // Io error
+    let config: Config = toml::from_str(&content)?;  // Parse error
+    if config.name.is_empty() {
+        return Err(ConfigError::MissingField("name".into()));
+    }
+    Ok(config)
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Defining error types
+- [err-question-mark](./err-question-mark.md) - Using ? operator
+- [type-option-nullable](./type-option-nullable.md) - Option vs Result

--- a/.cursor/skills/rusthound-architecture/SKILL.md
+++ b/.cursor/skills/rusthound-architecture/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rusthound-architecture
+description: RustHound module layout, data flow, and stateful follow-mode rules. Use when changing src layout, log reading, or analyzer integration.
+---
+
+# RustHound Architecture
+
+## Module map
+
+```
+src/main.rs          CLI entry, orchestration
+src/config/rules.rs  TOML loading (Rules, RegexRule, FrequencyRules, CorrelatedRule)
+src/watcher/
+  log_reader.rs      Line/offset reading, detection pipeline
+  file_watcher.rs    notify-based file watch
+src/analyzer/
+  pattern_matcher.rs String + regex matching
+  frequency_tracker.rs Time-window event counts
+  correlation_engine.rs Multi-event correlation rules
+src/output/
+  mod.rs             Detection, Severity
+  console.rs         Colored console output
+  json_writer.rs     JSON file output
+```
+
+## Data flow
+
+1. Load `rules.toml` → `Rules`
+2. Build `PatternMatcher` (compile regex at startup)
+3. Create `ScanState` (frequency tracker + correlation engine) once per file/session
+4. `read_file_from_offset` reads new lines, pushes detections
+5. Filter by `--severity`, then `display_detections`
+
+## Stateful follow mode (critical)
+
+`FrequencyTracker` and `CorrelationEngine` **must persist** across incremental reads in `--follow` mode.
+
+- Create `ScanState` once in `main.rs` before the follow loop
+- Pass `&mut ScanState` into every `read_file_from_offset` call
+- Multi-file follow: store `ScanState` per file in `file_states` HashMap
+
+Do **not** recreate engines inside `read_file_from_offset` on each call.
+
+## Pattern matching priority
+
+In `pattern_matcher.rs`, first match wins:
+
+1. `rules.error_patterns` (substring)
+2. `rules.warning_patterns` (substring)
+3. `regex_rules` (compiled regex, in file order)
+
+## Binary naming
+
+- Cargo package: `rust_hound`
+- User-facing binary: `rusthound` (`[[bin]]` in Cargo.toml)
+- Config dir: `~/.config/rusthound/rules.toml`

--- a/.cursor/skills/rusthound-cargo-tail/SKILL.md
+++ b/.cursor/skills/rusthound-cargo-tail/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: rusthound-cargo-tail
+description: Monitor RustHound and Cargo command output in real time (build, test, clippy, rusthound --follow). Use when debugging compile errors, test failures, or live log analysis sessions.
+---
+
+# RustHound Cargo / Log Tail Workflow
+
+Adapted for this repo from community tailing/monitoring skills. Prefer this over generic Node/webpack tail skills when working in RustHound.
+
+## Commands to watch
+
+```bash
+cargo build
+cargo test
+cargo clippy -- -D warnings
+cargo run --bin rusthound -- -f sample.log
+cargo run --bin rusthound -- -f sample.log --follow
+cargo run --bin rusthound -- -f sample_freq.log -r correlated_rules.toml
+```
+
+Release smoke:
+
+```bash
+cargo build --release
+./target/release/rusthound -f sample.log -s high
+```
+
+## Workflow
+
+1. Run the command in a terminal (or tmux session).
+2. Read terminal output as it streams; do not assume success without seeing `Finished` or test `ok`.
+3. On compile error: fix the first error, rebuild — rustc errors are often cascading.
+4. On test failure: run `cargo test <module> -- --nocapture` for the failing test only.
+5. On `rusthound --follow`: append lines to the log file to verify `ScanState` (frequency/correlation) persists.
+
+## RustHound-specific checks
+
+- Follow mode must reuse `ScanState` in `main.rs`, not recreate engines per read.
+- `--severity` filters in `display_detections`, not at match time.
+- Rules must match [rusthound-rules-toml](../rusthound-rules-toml/SKILL.md) schema.
+
+## When done
+
+Invoke **prove-it**: all of `cargo test`, `cargo clippy -- -D warnings`, and a smoke `rusthound` run must pass.

--- a/.cursor/skills/rusthound-dev-workflow/SKILL.md
+++ b/.cursor/skills/rusthound-dev-workflow/SKILL.md
@@ -52,3 +52,19 @@ Verify correlation/frequency state persists across file appends (use `ScanState`
 ```
 
 Copies `target/release/rusthound` to `~/.local/bin/` and `rules.toml` to `~/.config/rusthound/`.
+
+## Community skills (installed in this repo)
+
+See `.cursor/skills/README.md` for the full index. Prefer these when relevant:
+
+| Task | Skill |
+|------|-------|
+| Verify work before PR | `prove-it` |
+| Debug failing tests/build | `debug-to-fix` |
+| Change shared modules | `trace-it` |
+| Pre-PR cleanup | `loose-ends` |
+| Rust errors / async / CLI | `rust-m06-error-handling`, `rust-m07-concurrency`, `rust-domain-cli` |
+| Stream cargo/rusthound output | `rusthound-cargo-tail` |
+| CI setup | `setting-up-ci` |
+
+Refresh vendored skills: `./scripts/install-cursor-skills.sh`

--- a/.cursor/skills/rusthound-dev-workflow/SKILL.md
+++ b/.cursor/skills/rusthound-dev-workflow/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rusthound-dev-workflow
+description: Build, test, and validation workflow for RustHound. Use before committing changes.
+---
+
+# RustHound Development Workflow
+
+## Requirements
+
+- Rust **1.83+** stable
+- Edition **2021** in Cargo.toml
+
+## Validation commands
+
+Run from repository root:
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+cargo build --release
+```
+
+## Smoke tests
+
+```bash
+./target/release/rusthound -f sample.log
+./target/release/rusthound -f sample_freq.log -r correlated_rules.toml
+./target/release/rusthound --init-config
+```
+
+## Severity filter example
+
+```bash
+./target/release/rusthound -f sample.log -s high
+```
+
+Only detections at or above the given severity are printed.
+
+## Follow mode
+
+```bash
+./target/release/rusthound -f sample.log --follow
+```
+
+Verify correlation/frequency state persists across file appends (use `ScanState` in main).
+
+## Install script
+
+```bash
+./setup.sh
+```
+
+Copies `target/release/rusthound` to `~/.local/bin/` and `rules.toml` to `~/.config/rusthound/`.

--- a/.cursor/skills/rusthound-rules-toml/SKILL.md
+++ b/.cursor/skills/rusthound-rules-toml/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: rusthound-rules-toml
+description: Valid rules.toml schema for RustHound. Use when editing or documenting configuration files.
+---
+
+# RustHound rules.toml Schema
+
+## Structure (authoritative)
+
+```toml
+[rules]
+error_patterns = ["ERROR", "FATAL"]
+warning_patterns = ["WARN", "WARNING"]
+
+[[regex_rules]]
+name = "rule_name"          # Used in correlation trigger_on_rule.name
+pattern = "regex here"
+severity = "critical"       # critical | high | warning | error | info
+
+[frequency_rules]
+max_same_errors_per_minute = 10
+time_window_seconds = 60
+
+[[correlated_rules]]
+name = "Alert Title"
+severity = "critical"
+description = "Human-readable description"
+time_window_seconds = 60
+followed_by = "Successful Login"   # Must match a regex_rules.name
+
+[correlated_rules.trigger_on_rule]
+name = "authentication_failure"    # Must match a regex_rules.name
+count = 10
+```
+
+## Reference files
+
+- Default rules: `rules.toml`
+- Correlation example: `correlated_rules.toml`
+
+## Common mistakes
+
+- Do **not** use README-style `[patterns]` or `[[regex_rules.rule]]` — they are invalid
+- `followed_by` and `trigger_on_rule.name` must match `[[regex_rules]].name` exactly
+- `[rules]` table holds `error_patterns` / `warning_patterns` (not `[patterns]`)
+
+## Severity values
+
+Maps to `Severity` enum in `src/output/mod.rs`:
+
+| TOML value | Enum |
+|------------|------|
+| critical | Critical |
+| high | High |
+| warn, warning | Warning |
+| error, fatal, exception | Error |
+| (other) | Info |

--- a/.cursor/skills/safe-refactor/SKILL.md
+++ b/.cursor/skills/safe-refactor/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: safe-refactor
+description: When refactoring, rewriting, or migrating critical code paths, orchestrate a safe cycle - assess risks, implement, verify, document. Chains pre-mortem and prove-it with built-in implementation phase. Use when the user says "refactor", "rewrite", "migrate", or "clean up" for non-trivial code.
+---
+
+# Safe Refactor
+
+## Purpose
+
+An elixir for risky code changes. Refactors feel safe ("I'm just cleaning up")
+but they're where bugs hide. This chains risk assessment, careful implementation,
+verification, and documentation. The ceremony slows you down just enough to
+catch problems before production does.
+
+## Prerequisites
+
+This skill works best with these skills installed:
+
+| Skill | Purpose | If Missing |
+|-------|---------|------------|
+| pre-mortem | Risk assessment before starting | Falls back to built-in checklist |
+| prove-it | Verification enforcement | Falls back to built-in verification |
+| retrospective | Document learnings | Skipped (optional phase) |
+
+## When To Activate
+
+- "Refactor this"
+- "Clean up this code"
+- "Rewrite this to be more..."
+- "Migrate from X to Y"
+- "Replace this implementation"
+- Large-scale find-and-replace
+- Changing shared utilities or core abstractions
+- Touching code you didn't write
+
+## Instructions
+
+### Phase 1: Assess Risk
+
+**If pre-mortem skill installed:** Invoke it now.
+
+**If not installed, evaluate:**
+
+```markdown
+## Refactor Risk Assessment
+
+**What's changing:**
+- [ ] Files affected: [list them]
+- [ ] Functions/classes modified: [list them]
+- [ ] Estimated lines changed: [number]
+
+**Risk factors:**
+- [ ] Touches shared/core code (used by multiple features)
+- [ ] Affects data persistence (database, files, cache)
+- [ ] Changes public API/interfaces
+- [ ] Lacks test coverage
+- [ ] Written by someone else / unfamiliar code
+- [ ] Production-critical path
+
+**Risk level:** [Low / Medium / High / Abort]
+```
+
+**GATE:** Do not proceed if:
+- Risk is "Abort"
+- More than 3 risk factors checked AND no tests exist
+- You can't list all affected files
+
+If high risk: Consider breaking into smaller refactors.
+
+### Phase 2: Prepare
+
+Before touching code:
+
+1. **Ensure tests exist** (or write them first)
+   ```
+   - [ ] Existing tests cover the behavior being preserved
+   - [ ] If no tests: write characterization tests NOW
+   ```
+
+2. **Create escape hatch**
+   ```bash
+   git stash  # or commit current state
+   git checkout -b refactor/[description]
+   ```
+
+3. **Document current behavior**
+   ```
+   Before: [How it works now]
+   After: [How it should work - must be identical externally]
+   ```
+
+**GATE:** Do not proceed without:
+- Tests that verify current behavior
+- Clean git state (can revert easily)
+- Clear before/after behavior description
+
+### Phase 3: Implement
+
+**Rules for safe refactoring:**
+
+1. **One thing at a time**
+   - Don't mix refactoring with feature changes
+   - Don't fix bugs you discover (note them, fix separately)
+   - Don't "while I'm here" other improvements
+
+2. **Small commits**
+   ```bash
+   # Good: multiple small commits
+   git commit -m "Extract helper function"
+   git commit -m "Rename variables for clarity"
+   git commit -m "Move file to new location"
+
+   # Bad: one giant commit
+   git commit -m "Refactor everything"
+   ```
+
+3. **Run tests frequently**
+   - After each logical change
+   - Before each commit
+   - If tests fail: revert and try smaller steps
+
+4. **Preserve behavior exactly**
+   - No "improvements" to logic
+   - No fixing edge cases (that's a separate change)
+   - External behavior must be identical
+
+### Phase 4: Verify
+
+**If prove-it skill installed:** Invoke it now.
+
+**If not installed:**
+
+```markdown
+## Refactor Verification
+
+**Automated checks:**
+- [ ] All existing tests pass
+- [ ] No new linter errors
+- [ ] Type checking passes (if applicable)
+
+**Manual verification:**
+- [ ] Tested the primary use case manually
+- [ ] Checked one edge case
+- [ ] Compared behavior before/after for critical paths
+
+**Regression check:**
+- [ ] git diff shows only intended changes
+- [ ] No accidental behavior changes
+- [ ] No debug code left in
+```
+
+**GATE:** Do not merge until all checks pass.
+
+If verification fails:
+```bash
+git revert HEAD  # or reset to before refactor
+# Start over with smaller scope
+```
+
+### Phase 5: Document (Optional)
+
+**If retrospective skill installed:** Invoke for significant refactors.
+
+For large refactors, capture:
+- What was refactored and why
+- Any tricky parts or gotchas discovered
+- Patterns that emerged (potential future skills)
+
+## Output Format
+
+```markdown
+## Safe Refactor: [Description]
+
+### Risk Assessment
+- Risk level: [Low/Medium/High]
+- Files affected: [count]
+- Risk factors: [list]
+
+### Preparation
+- [x] Tests verified/written
+- [x] Branch created: refactor/[name]
+- [x] Current behavior documented
+
+### Implementation
+- Commits: [count]
+- Approach: [brief description]
+
+### Verification
+- [x] Tests pass
+- [x] Manual verification complete
+- [x] No regressions detected
+
+### Learnings (if significant)
+[What you'd do differently]
+```
+
+## NEVER
+
+- Refactor and add features in the same change
+- Skip the risk assessment ("it's just a small cleanup")
+- Make large changes without test coverage
+- Commit all changes in one giant commit
+- "Fix" bugs discovered during refactoring (note them separately)
+- Proceed when tests are failing
+
+## ALWAYS
+
+- Assess risk before starting
+- Ensure tests exist (write them if needed)
+- Work on a branch with escape hatch ready
+- Make small, incremental commits
+- Run tests after each logical change
+- Verify behavior is preserved exactly
+
+## Example
+
+**User:** "Refactor the authentication module to use the new token format"
+
+**Phase 1 - Risk Assessment:**
+> Refactor Risk Assessment:
+> - Files affected: auth.ts, token.ts, middleware.ts, 12 test files
+> - Risk factors: Core code, Production-critical, Written by someone else
+> - Risk level: **High**
+>
+> Recommendation: Break into smaller refactors:
+> 1. First: Add new token format support alongside old
+> 2. Second: Migrate consumers one by one
+> 3. Third: Remove old format
+
+**Phase 2 - Prepare:**
+> - [x] Existing tests cover token generation and validation
+> - [x] Created branch: refactor/token-format-v2
+> - [x] Documented: Old format is JWT with RS256, new format adds `typ` header
+
+**Phase 3 - Implement:**
+> Making changes incrementally...
+> - Commit 1: "Add TokenV2 class with new format"
+> - Commit 2: "Add feature flag for token format"
+> - Commit 3: "Update token generation to use flag"
+> - Tests passing after each commit
+
+**Phase 4 - Verify:**
+> - [x] All 47 auth tests pass
+> - [x] Manual test: login flow works with both formats
+> - [x] Manual test: token refresh works
+> - [x] git diff shows only intended changes
+>
+> Ready to merge.

--- a/.cursor/skills/safe-refactor/UPSTREAM.md
+++ b/.cursor/skills/safe-refactor/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/bluriesophos/cursorskills
+- Path: `safe-refactor`
+- Commit: `0ebd86c11e02f32d7fc90a4b3b0f5609b0262069`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/setting-up-ci/SKILL.md
+++ b/.cursor/skills/setting-up-ci/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: setting-up-ci
+description: Set up a GitHub Actions CI/CD pipeline with linting, testing, type-checking, and deployment steps.
+---
+
+# Setup CI (GitHub Actions)
+
+Use this skill when the user asks to set up CI, continuous integration, a build pipeline, or GitHub Actions.
+
+## Steps
+
+1. **Detect the project structure** — check for `package.json` (Node.js), `requirements.txt` / `pyproject.toml` (Python), `go.mod` (Go), or monorepo tools like Turborepo.
+
+2. **Create `.github/workflows/ci.yml`**
+
+   For a Node.js project:
+
+   ```yaml
+   name: CI
+
+   on:
+     push:
+       branches: [main]
+     pull_request:
+       branches: [main]
+
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+             node-version: 20
+             cache: npm
+         - run: npm ci
+         - run: npm run lint
+         - run: npm run typecheck
+         - run: npm test
+         - run: npm run build
+   ```
+
+3. **Add type-checking** — if `typecheck` script doesn't exist in `package.json`, add `"typecheck": "tsc --noEmit"`.
+
+4. **Add caching** — the `actions/setup-node` `cache` option handles `node_modules`. For monorepos with Turborepo, add remote caching or `actions/cache` for `.turbo`.
+
+5. **Add matrix testing (optional)** — if the user needs to test across Node versions or OS:
+
+   ```yaml
+   strategy:
+     matrix:
+       node-version: [18, 20, 22]
+   ```
+
+6. **Add deployment step (optional)** — if requested, add a deploy job that runs only on `main` pushes, gated by the build job succeeding:
+
+   ```yaml
+   deploy:
+     needs: build
+     if: github.ref == 'refs/heads/main'
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v4
+       - run: npm ci && npm run build
+       - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+   ```
+
+7. **Add status badge** — add the workflow status badge to the project README:
+
+   ```markdown
+   ![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
+   ```
+
+## Notes
+
+- Keep CI fast — run lint and typecheck in parallel using separate jobs if the pipeline is slow.
+- Use `npm ci` (not `npm install`) for deterministic installs.
+- Store secrets (API keys, deploy tokens) in GitHub repository settings, never in the workflow file.

--- a/.cursor/skills/setting-up-ci/UPSTREAM.md
+++ b/.cursor/skills/setting-up-ci/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/spencerpauly/awesome-cursor-skills
+- Path: `resources/setting-up-ci`
+- Commit: `773b571db3693d2edc1cf656903c292d037e25b8`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/tailing-build-output/SKILL.md
+++ b/.cursor/skills/tailing-build-output/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: tailing-build-output
+description: Monitor a build process (webpack, turbo, docker) for warnings and errors as they stream. Summarize issues and fix them before the build finishes.
+user-invocable: true
+---
+
+# Tailing Build Output
+
+Watch a build process in real time via terminal files and fix issues as they appear.
+
+## Workflow
+
+### 1. Start or Find the Build
+
+Either start the build yourself or find the terminal running it:
+
+```bash
+head -n 10 <terminals_folder>/*.txt
+```
+
+Look for commands like `npm run build`, `pnpm build`, `turbo build`, `docker build`, `tsc`, `vite build`.
+
+### 2. Poll for Output
+
+Read the terminal file periodically. Look for:
+
+**Errors (fix immediately):**
+- `ERROR` / `Error:` / `error TS`
+- `Module not found` / `Cannot find module`
+- `SyntaxError` / `TypeError`
+- `Failed to compile`
+
+**Warnings (collect for summary):**
+- `WARNING` / `Warning:` / `warn`
+- `Deprecation` / `deprecated`
+- Unused imports/variables
+- Large bundle size warnings (`asset size limit`)
+
+**Progress indicators:**
+- Webpack: `[XX%]`, `modules`, `chunks`
+- Turbo: task completion logs
+- Docker: `Step X/Y`
+- TypeScript: file count
+
+### 3. Fix Errors in Flight
+
+When an error appears:
+1. Extract the file path and line number from the error
+2. Read and fix the source file
+3. If the build supports watch mode, it will re-trigger automatically
+4. If not, note the fix and let the build continue — it may reveal more errors
+
+### 4. Summary Report
+
+After the build completes (check for `exit_code` in terminal footer):
+
+```
+Build Summary:
+  Status: Failed (exit code 1) / Succeeded
+  Duration: ~45s
+  Errors fixed: 3
+  Remaining warnings: 2
+    - Large bundle: src/pages/Dashboard.tsx (450kb)
+    - Deprecated API: useRouter from 'next/router'
+```
+
+## Tips
+
+- Don't fix warnings during the build — collect them and address after
+- For `turbo build`, errors may appear in parallel task output — check all task logs
+- Docker builds cache layers — if you fix a file early in the Dockerfile, later layers rerun
+- TypeScript's `--noEmit` is useful for type-checking without a full build

--- a/.cursor/skills/tailing-build-output/UPSTREAM.md
+++ b/.cursor/skills/tailing-build-output/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/spencerpauly/awesome-cursor-skills
+- Path: `resources/tailing-build-output`
+- Commit: `773b571db3693d2edc1cf656903c292d037e25b8`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.cursor/skills/trace-it/SKILL.md
+++ b/.cursor/skills/trace-it/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: trace-it
+description: Before modifying shared code (utilities, types, configs, base classes), traces all callers and dependents first. Prevents "fixed one thing, broke three others." Use when editing files in shared/, utils/, lib/, or anything imported by 3+ files.
+---
+
+# Trace It
+
+## Purpose
+
+Shared code is high-leverage but high-risk. Change a utility function and you
+might break 10 callers. Change a type definition and you invalidate assumptions
+across the codebase. This skill forces you to trace impact before editing.
+
+## When To Activate
+
+- Editing files in: `utils/`, `lib/`, `shared/`, `common/`, `core/`
+- Modifying exported functions, classes, or types
+- Changing function signatures (parameters, return types)
+- Editing config files or constants
+- Renaming anything that might be imported elsewhere
+- Modifying base classes or interfaces
+- User says "change how X works" for foundational code
+
+## Instructions
+
+### Before Modifying Shared Code
+
+### Step 1: Find All Callers
+
+```bash
+# Find imports/requires of this file
+grep -r "from.*['\"].*filename" src/
+grep -r "import.*filename" src/
+grep -r "require.*filename" src/
+
+# Find usages of specific function/class
+grep -r "functionName" src/ --include="*.ts"
+```
+
+Document what you find:
+
+```markdown
+## Dependency Trace: [file or function name]
+
+**Direct callers:** [count]
+- `src/api/handler.ts:23` - uses for validation
+- `src/services/user.ts:45` - uses for formatting
+- `src/utils/helpers.ts:12` - re-exports it
+
+**Indirect dependents:** [count]
+- Files that import the direct callers
+```
+
+### Step 2: Assess Impact
+
+For each caller, determine:
+
+| Caller | How it uses this | Will change break it? |
+|--------|------------------|----------------------|
+| `handler.ts` | Calls `validate(input)` | Yes - signature changes |
+| `user.ts` | Uses return value | No - return type same |
+
+**Impact level:**
+- **Low:** 1-2 callers, simple usages
+- **Medium:** 3-5 callers, varied usages
+- **High:** 6+ callers OR complex/varied usages
+
+### Step 3: Plan the Change
+
+For **Low impact:** Proceed, update callers inline.
+
+For **Medium impact:**
+1. Make change backward-compatible if possible
+2. Update all callers in same commit
+3. Test each caller's behavior
+
+For **High impact:**
+1. Consider: Is this change necessary?
+2. Create migration plan
+3. Consider deprecation period
+4. Update incrementally with tests
+
+### Signature Changes
+
+When changing function signatures:
+
+```markdown
+## Signature Change
+
+**Before:** `function process(data: string): Result`
+**After:** `function process(data: string, options?: Options): Result`
+
+**Breaking:** No (new param is optional)
+**Callers to update:** 0 required, 5 could benefit
+
+## OR
+
+**Before:** `function process(data: string): Result`
+**After:** `function process(data: ProcessInput): Result`
+
+**Breaking:** Yes
+**Callers to update:** 8 files
+**Migration:** [list each file and required change]
+```
+
+## Output Format
+
+```markdown
+## Trace: [what you're changing]
+
+**Callers found:** [count]
+**Impact level:** [Low/Medium/High]
+
+**Changes required:**
+- [ ] `file1.ts:line` - [what needs updating]
+- [ ] `file2.ts:line` - [what needs updating]
+
+**Verified after change:**
+- [ ] All callers updated
+- [ ] No new type errors
+- [ ] Tests pass
+```
+
+## NEVER
+
+- Modify shared code without tracing callers first
+- Change function signatures assuming "it's probably fine"
+- Update shared code and only test one caller
+- Forget to check re-exports (file A exports from file B)
+- Assume grep found everything (check for dynamic imports)
+
+## ALWAYS
+
+- Trace before touching shared code
+- Document the caller count and impact level
+- Update ALL callers in the same change
+- Verify no type errors after the change
+- Check for string-based references (dynamic imports, configs)
+
+## Example
+
+**User:** "Rename the `formatDate` function to `formatDateTime`"
+
+**Trace:**
+```bash
+grep -r "formatDate" src/
+```
+
+**Found:**
+```
+src/utils/date.ts:15 - definition
+src/components/Header.tsx:8 - import
+src/components/EventCard.tsx:12 - import
+src/pages/Dashboard.tsx:45 - import
+src/api/events.ts:23 - import
+src/utils/index.ts:5 - re-export
+```
+
+**Impact:** 6 files reference this. High impact.
+
+**Plan:**
+1. Rename in `date.ts`
+2. Update re-export in `utils/index.ts`
+3. Update imports in all 4 consumer files
+4. Verify: `grep -r "formatDate" src/` returns nothing
+
+**After completion:**
+> Renamed `formatDate` to `formatDateTime` across 6 files.
+> Verified: no remaining references to old name.

--- a/.cursor/skills/trace-it/UPSTREAM.md
+++ b/.cursor/skills/trace-it/UPSTREAM.md
@@ -1,0 +1,7 @@
+# Upstream
+
+- Repository: https://github.com/bluriesophos/cursorskills
+- Path: `trace-it`
+- Commit: `0ebd86c11e02f32d7fc90a4b3b0f5609b0262069`
+
+Re-run `./scripts/install-cursor-skills.sh` to refresh.

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 Makefile
 makefile
 Makefile.*
-makefile.*
+makefile.*.cursor/skills-cache/
+.cursor/skills-cache/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "rust_hound"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
+
+[[bin]]
+name = "rusthound"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ severity = "high"
 #### Korelasyon dosyası
 `rusthound -f auth.log -r correlated_rules.toml`
 
+## Cursor Agent Skills
+
+RustHound includes Cursor skills under `.cursor/skills/`:
+
+- **Project skills** (`rusthound-*`) — architecture, TOML schema, dev workflow
+- **Community skills** — Rust ([ZhangHanDong/rust-skills](https://github.com/ZhangHanDong/rust-skills)), verification ([bluriesophos/cursorskills](https://github.com/bluriesophos/cursorskills)), DevOps ([awesome-cursor-skills](https://github.com/spencerpauly/awesome-cursor-skills))
+
+Install or refresh third-party skills:
+
+```bash
+./scripts/install-cursor-skills.sh
+```
+
+See `.cursor/skills/README.md` for the full catalog.
+
 ## 🤝 Katkıda Bulunma
 
 RustHound açık kaynak bir projedir ve katkılarınızı memnuniyetle karşılarız!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐕 RustHound: Gerçek Zamanlı Log Analiz ve İzleme Aracı
 
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.83+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)]()
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)]()
@@ -36,7 +36,7 @@
 
 ### Sistem Gereksinimleri
 
-- **Rust 1.70+** - [rustup.rs](https://rustup.rs/) üzerinden yükleyebilirsiniz
+- **Rust 1.83+** (edition 2021) - [rustup.rs](https://rustup.rs/) üzerinden yükleyebilirsiniz
 - **Git** (kaynak koddan kurulum için)
 - **Minimum 50MB disk alanı**
 
@@ -64,15 +64,15 @@ cargo install --path .
 #### Doğrudan İkili Dosya İndirme
 ```bash
 # GitHub Releases'den en son sürümü indirin
-wget https://github.com/rustfuture/RustHound/releases/latest/download/rust_hound-linux-x64.tar.gz
-tar -xzf rust_hound-linux-x64.tar.gz
-sudo mv rust_hound /usr/local/bin/
+wget https://github.com/rustfuture/RustHound/releases/latest/download/rusthound-linux-x64.tar.gz
+tar -xzf rusthound-linux-x64.tar.gz
+sudo mv rusthound /usr/local/bin/
 ```
 
 ### Kurulum Doğrulama
 ```bash
-rust_hound --version
-rust_hound --help
+rusthound --version
+rusthound --help
 ```
 
 ## 📖 Kullanım
@@ -81,13 +81,13 @@ rust_hound --help
 
 ```bash
 # Basit log dosyası analizi
-rust_hound --file /var/log/app.log
+rusthound --file /var/log/app.log
 
 # Dizin içindeki tüm log dosyalarını analiz et
-rust_hound --dir /var/log/
+rusthound --dir /var/log/
 
 # Gerçek zamanlı izleme (tail -f benzeri)
-rust_hound --file /var/log/app.log --follow
+rusthound --file /var/log/app.log --follow
 ```
 
 ### Komut Satırı Referansı
@@ -109,40 +109,40 @@ rust_hound --file /var/log/app.log --follow
 #### Temel Log Analizi
 ```bash
 # Tek dosya analizi
-rust_hound -f /var/log/nginx/access.log
+rusthound -f /var/log/nginx/access.log
 
 # Özel kurallar ile analiz
-rust_hound -f app.log -r custom_rules.toml
+rusthound -f app.log -r custom_rules.toml
 ```
 
 #### Gerçek Zamanlı İzleme
 ```bash
 # Canlı log takibi
-rust_hound -f /var/log/syslog --follow
+rusthound -f /var/log/syslog --follow
 
 # JSON çıktısı ile canlı takip
-rust_hound -d /var/log/ --follow -o json
+rusthound -d /var/log/ --follow -o json
 ```
 
 #### Filtreleme ve Çıktı
 ```bash
 # Sadece kritik seviye uyarılar
-rust_hound -f app.log -s critical
+rusthound -f app.log -s critical
 
 # Hem konsol hem JSON çıktısı
-rust_hound -f app.log -o both
+rusthound -f app.log -o both
 
 # Detaylı hata ayıklama
-rust_hound -f app.log --verbose
+rusthound -f app.log --verbose
 ```
 
 #### Toplu İşleme
 ```bash
 # Tüm log dizinini analiz et
-rust_hound -d /var/log/ -r production_rules.toml
+rusthound -d /var/log/ -r production_rules.toml
 
 # Belirli pattern'ler için tarama
-rust_hound -d /home/user/logs/ -s high -o json
+rusthound -d /home/user/logs/ -s high -o json
 ```
 
 ## ⚙️ Yapılandırma
@@ -152,93 +152,61 @@ RustHound, esnek TOML tabanlı yapılandırma sistemi kullanır. Varsayılan ola
 ### Temel Yapılandırma Dosyası (`rules.toml`)
 
 ```toml
-[general]
-# Genel ayarlar
-case_sensitive = false
-max_line_length = 1024
+[rules]
+error_patterns = ["ERROR", "FATAL", "Exception"]
+warning_patterns = ["WARN", "WARNING"]
 
-[patterns]
-# Basit string pattern'ler
-error_keywords = ["ERROR", "FATAL", "CRITICAL"]
-warning_keywords = ["WARN", "WARNING", "DEPRECATED"]
-
-[regex_rules]
-# Gelişmiş regex kuralları
-[[regex_rules.rule]]
-name = "SQL Injection Attempt"
-pattern = "(?i)(union|select|insert|delete|drop).*['\";]"
-severity = "critical"
-description = "Potansiyel SQL injection saldırısı tespit edildi"
-
-[[regex_rules.rule]]
-name = "Failed Login"
-pattern = "(?i)failed.*login|authentication.*failed"
+[[regex_rules]]
+name = "authentication_failure"
+pattern = "authentication failure|Failed password for"
 severity = "high"
-description = "Başarısız giriş denemesi"
+
+[[regex_rules]]
+name = "Successful Login"
+pattern = "(?i)successful login|session opened for user"
+severity = "info"
 
 [frequency_rules]
-# Frekans tabanlı kurallar
-[[frequency_rules.rule]]
-name = "Too Many Errors"
-pattern = "ERROR"
-threshold = 10
-window_seconds = 60
-severity = "critical"
-description = "1 dakika içinde çok fazla hata"
+max_same_errors_per_minute = 10
+time_window_seconds = 60
 
-[output]
-# Çıktı ayarları
-timestamp_format = "%Y-%m-%d %H:%M:%S"
-include_line_numbers = true
-color_output = true
+[[correlated_rules]]
+name = "Potential Brute-Force Attack"
+severity = "critical"
+description = "Çok sayıda başarısız giriş sonrası başarılı giriş"
+time_window_seconds = 60
+followed_by = "Successful Login"
+
+[correlated_rules.trigger_on_rule]
+name = "authentication_failure"
+count = 10
 ```
 
 ### Yapılandırma Seçenekleri
 
-#### Genel Ayarlar
-- `case_sensitive`: Büyük/küçük harf duyarlılığı
-- `max_line_length`: Maksimum satır uzunluğu
-- `ignore_empty_lines`: Boş satırları yoksay
+Detaylı şema: `.cursor/skills/rusthound-rules-toml/SKILL.md`
 
-#### Pattern Türleri
-- **Basit String Pattern'ler**: Hızlı anahtar kelime eşleştirme
-- **Regex Pattern'ler**: Karmaşık desen eşleştirme
-- **Frekans Kuralları**: Zaman tabanlı eşik kontrolü
+#### Pattern türleri
+- **Basit string** (`[rules]`): Anahtar kelime eşleştirme
+- **Regex** (`[[regex_rules]]`): Gelişmiş desenler
+- **Frekans** (`[frequency_rules]`): Zaman penceresinde tekrar sayımı
+- **Korelasyon** (`[[correlated_rules]]`): Ardışık olay zinciri
 
-#### Önem Seviyeleri
-- `critical`: Kritik durumlar
-- `high`: Yüksek öncelik
-- `medium`: Orta öncelik  
-- `low`: Düşük öncelik
-- `info`: Bilgilendirme
+#### Önem seviyeleri
+`critical`, `high`, `warning`, `error`, `info` — CLI: `rusthound -f app.log -s high`
 
 ### Örnek Yapılandırmalar
 
-#### Web Sunucu Logları
+#### Web sunucu
 ```toml
-[[regex_rules.rule]]
+[[regex_rules]]
 name = "HTTP 5xx Errors"
-pattern = "HTTP/1\.[01]\" [5][0-9][0-9]"
-severity = "high"
-
-[[regex_rules.rule]]
-name = "Slow Response"
-pattern = "response_time:[0-9]{4,}"
-severity = "medium"
-```
-
-#### Uygulama Logları
-```toml
-[[regex_rules.rule]]
-name = "Memory Leak Warning"
-pattern = "(?i)memory.*leak|out.*of.*memory"
-severity = "critical"
-
-[[regex_rules.rule]]
-name = "Database Connection Error"
-pattern = "(?i)database.*connection.*failed|db.*timeout"
+pattern = "HTTP/1\.\[01]" [5][0-9][0-9]"
 severity = "high"
 ```
+
+#### Korelasyon dosyası
+`rusthound -f auth.log -r correlated_rules.toml`
 
 ## 🤝 Katkıda Bulunma
 
@@ -296,13 +264,13 @@ chmod +r /var/log/app.log
 **Problem**: Yüksek bellek kullanımı
 ```bash
 # Çözüm: Streaming mode kullanın
-rust_hound -f large_file.log --follow
+rusthound -f large_file.log --follow
 ```
 
 **Problem**: Regex pattern çalışmıyor
 ```bash
 # Çözüm: Pattern'i test edin
-rust_hound -f test.log --verbose
+rusthound -f test.log --verbose
 ```
 
 ## 📜 Lisans

--- a/scripts/install-cursor-skills.sh
+++ b/scripts/install-cursor-skills.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_DIR="${ROOT}/.cursor/skills"
+CACHE_DIR="${ROOT}/.cursor/skills-cache"
+
+mkdir -p "$SKILLS_DIR" "$CACHE_DIR"
+
+clone_or_pull() {
+  local url="$1"
+  local name="$2"
+  local dir="${CACHE_DIR}/${name}"
+  if [[ -d "${dir}/.git" ]]; then
+    git -C "$dir" pull --ff-only >/dev/null
+  else
+    git clone --depth 1 "$url" "$dir" >/dev/null
+  fi
+  printf '%s' "$dir"
+}
+
+copy_skill() {
+  local src="$1"
+  local dest_name="$2"
+  local dest="${SKILLS_DIR}/${dest_name}"
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -r "${src}/." "$dest/"
+  [[ -f "${dest}/SKILL.md" ]] || { echo "missing SKILL.md: ${dest_name}" >&2; return 1; }
+  echo "  + ${dest_name}"
+}
+
+write_upstream() {
+  local dest_name="$1" cache_key="$2" repo_url="$3" path="$4"
+  local commit
+  commit="$(git -C "${CACHE_DIR}/${cache_key}" rev-parse HEAD)"
+  cat > "${SKILLS_DIR}/${dest_name}/UPSTREAM.md" <<EOF
+# Upstream
+
+- Repository: ${repo_url}
+- Path: \`${path}\`
+- Commit: \`${commit}\`
+
+Re-run \`./scripts/install-cursor-skills.sh\` to refresh.
+EOF
+}
+
+echo "==> Fetching sources..."
+ZH="$(clone_or_pull https://github.com/ZhangHanDong/rust-skills.git zhang-rust-skills)"
+LSO="$(clone_or_pull https://github.com/leonardomso/rust-skills.git leonardomso-rust-skills)"
+CS="$(clone_or_pull https://github.com/bluriesophos/cursorskills.git bluriesophos-cursorskills)"
+ACS="$(clone_or_pull https://github.com/spencerpauly/awesome-cursor-skills.git awesome-cursor-skills)"
+
+echo "==> Rust skills (ZhangHanDong)..."
+for skill in m06-error-handling m07-concurrency domain-cli m01-ownership; do
+  [[ -d "${ZH}/skills/${skill}" ]] || continue
+  copy_skill "${ZH}/skills/${skill}" "rust-${skill}"
+  write_upstream "rust-${skill}" "zhang-rust-skills" "https://github.com/ZhangHanDong/rust-skills" "skills/${skill}"
+done
+[[ -f "${ZH}/skills/rust-router/SKILL.md" ]] && copy_skill "${ZH}/skills/rust-router" "rust-router" && write_upstream "rust-router" "zhang-rust-skills" "https://github.com/ZhangHanDong/rust-skills" "skills/rust-router"
+
+echo "==> leonardomso/rust-skills..."
+copy_skill "${LSO}" "rust-skills-leonardomso"
+write_upstream "rust-skills-leonardomso" "leonardomso-rust-skills" "https://github.com/leonardomso/rust-skills" "."
+
+echo "==> Workflow skills (bluriesophos)..."
+for skill in prove-it debug-to-fix trace-it loose-ends safe-refactor; do
+  copy_skill "${CS}/${skill}" "${skill}"
+  write_upstream "${skill}" "bluriesophos-cursorskills" "https://github.com/bluriesophos/cursorskills" "${skill}"
+done
+
+echo "==> DevOps skills (awesome-cursor-skills)..."
+for skill in monitoring-terminal-errors tailing-build-output setting-up-ci parallel-ci-triage incident-response; do
+  src="${ACS}/resources/${skill}"
+  [[ -d "$src" ]] || continue
+  copy_skill "$src" "${skill}"
+  write_upstream "${skill}" "awesome-cursor-skills" "https://github.com/spencerpauly/awesome-cursor-skills" "resources/${skill}"
+done
+
+echo "==> Done:"
+ls -1 "$SKILLS_DIR"

--- a/src/analyzer/correlation_engine.rs
+++ b/src/analyzer/correlation_engine.rs
@@ -15,15 +15,18 @@ pub struct CorrelationEngine {
 
 impl CorrelationEngine {
     pub fn new(rules: Vec<CorrelatedRule>) -> Self {
-        Self { 
-            rules, 
+        Self {
+            rules,
             recent_events: VecDeque::new(),
         }
     }
 
     pub fn add_detection(&mut self, detection: Detection) -> Option<Detection> {
         let now = Instant::now();
-        self.recent_events.push_back(Event { timestamp: now, detection: detection.clone() });
+        self.recent_events.push_back(Event {
+            timestamp: now,
+            detection: detection.clone(),
+        });
 
         // Remove old events
         self.cleanup_old_events();
@@ -33,7 +36,12 @@ impl CorrelationEngine {
     }
 
     fn cleanup_old_events(&mut self) {
-        let oldest_rule_window = self.rules.iter().map(|r| r.time_window_seconds).max().unwrap_or(60);
+        let oldest_rule_window = self
+            .rules
+            .iter()
+            .map(|r| r.time_window_seconds)
+            .max()
+            .unwrap_or(60);
         let cutoff = Instant::now() - Duration::from_secs(oldest_rule_window);
 
         while let Some(event) = self.recent_events.front() {
@@ -50,13 +58,22 @@ impl CorrelationEngine {
             let window_start = Instant::now() - Duration::from_secs(rule.time_window_seconds);
 
             // Find the 'followed_by' event first
-            if let Some(followed_by_event_pos) = self.recent_events.iter().rposition(|e| e.detection.pattern_name == rule.followed_by) {
+            if let Some(followed_by_event_pos) = self
+                .recent_events
+                .iter()
+                .rposition(|e| e.detection.pattern_name == rule.followed_by)
+            {
                 let followed_by_event = &self.recent_events[followed_by_event_pos];
 
                 // Count trigger events that occurred *before* the 'followed_by' event
-                let trigger_count = self.recent_events.iter()
+                let trigger_count = self
+                    .recent_events
+                    .iter()
                     .take(followed_by_event_pos)
-                    .filter(|e| e.timestamp >= window_start && e.detection.pattern_name == rule.trigger_on_rule.name)
+                    .filter(|e| {
+                        e.timestamp >= window_start
+                            && e.detection.pattern_name == rule.trigger_on_rule.name
+                    })
                     .count();
 
                 if trigger_count >= rule.trigger_on_rule.count {

--- a/src/analyzer/correlation_engine.rs
+++ b/src/analyzer/correlation_engine.rs
@@ -73,3 +73,63 @@ impl CorrelationEngine {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::rules::{CorrelatedRule, TriggerRule};
+    use crate::output::{Detection, Severity};
+
+    fn sample_detection(pattern_name: &str, line: usize) -> Detection {
+        Detection {
+            severity: Severity::High,
+            file_path: "/var/log/auth.log".to_string(),
+            line_number: line,
+            pattern_name: pattern_name.to_string(),
+            matched_line: "sample line".to_string(),
+        }
+    }
+
+    fn brute_force_rules() -> Vec<CorrelatedRule> {
+        vec![CorrelatedRule {
+            name: "Potential Brute-Force Attack".to_string(),
+            severity: "critical".to_string(),
+            description: "test".to_string(),
+            time_window_seconds: 60,
+            trigger_on_rule: TriggerRule {
+                name: "authentication_failure".to_string(),
+                count: 3,
+            },
+            followed_by: "Successful Login".to_string(),
+        }]
+    }
+
+    #[test]
+    fn triggers_after_enough_failures_then_success() {
+        let mut engine = CorrelationEngine::new(brute_force_rules());
+        assert!(engine
+            .add_detection(sample_detection("authentication_failure", 1))
+            .is_none());
+        assert!(engine
+            .add_detection(sample_detection("authentication_failure", 2))
+            .is_none());
+        assert!(engine
+            .add_detection(sample_detection("authentication_failure", 3))
+            .is_none());
+        let correlated = engine
+            .add_detection(sample_detection("Successful Login", 4))
+            .expect("correlation should fire");
+        assert_eq!(correlated.pattern_name, "Potential Brute-Force Attack");
+        assert_eq!(correlated.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn no_trigger_without_followed_by_event() {
+        let mut engine = CorrelationEngine::new(brute_force_rules());
+        for i in 1..=5 {
+            assert!(engine
+                .add_detection(sample_detection("authentication_failure", i))
+                .is_none());
+        }
+    }
+}

--- a/src/analyzer/frequency_tracker.rs
+++ b/src/analyzer/frequency_tracker.rs
@@ -37,3 +37,32 @@ impl FrequencyTracker {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_alert_below_threshold() {
+        let mut tracker = FrequencyTracker::new(3, 60);
+        assert!(tracker.track_event("error").is_none());
+        assert!(tracker.track_event("error").is_none());
+        assert!(tracker.track_event("error").is_none());
+    }
+
+    #[test]
+    fn alerts_when_threshold_exceeded() {
+        let mut tracker = FrequencyTracker::new(2, 60);
+        assert!(tracker.track_event("error").is_none());
+        assert!(tracker.track_event("error").is_none());
+        assert_eq!(tracker.track_event("error"), Some(3));
+    }
+
+    #[test]
+    fn tracks_patterns_independently() {
+        let mut tracker = FrequencyTracker::new(1, 60);
+        assert!(tracker.track_event("a").is_none());
+        assert_eq!(tracker.track_event("a"), Some(2));
+        assert!(tracker.track_event("b").is_none());
+    }
+}

--- a/src/analyzer/frequency_tracker.rs
+++ b/src/analyzer/frequency_tracker.rs
@@ -18,10 +18,7 @@ impl FrequencyTracker {
 
     pub fn track_event(&mut self, pattern_name: &str) -> Option<u32> {
         let now = Local::now();
-        let entry = self
-            .trackers
-            .entry(pattern_name.to_string())
-            .or_default();
+        let entry = self.trackers.entry(pattern_name.to_string()).or_default();
 
         // Remove old timestamps outside the time window
         let time_window = Duration::seconds(self.time_window_seconds as i64);

--- a/src/analyzer/pattern_matcher.rs
+++ b/src/analyzer/pattern_matcher.rs
@@ -44,3 +44,53 @@ impl PatternMatcher {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::rules::{PatternConfig, RegexRule, Rules};
+
+    fn test_rules() -> Rules {
+        Rules {
+            patterns: PatternConfig {
+                error_patterns: vec!["ERROR".to_string()],
+                warning_patterns: vec!["WARN".to_string()],
+            },
+            regex_rules: vec![RegexRule {
+                name: "custom_rule".to_string(),
+                pattern: r"disk.*error".to_string(),
+                severity: "critical".to_string(),
+            }],
+            frequency_rules: None,
+            correlated_rules: vec![],
+        }
+    }
+
+    #[test]
+    fn matches_error_pattern_first() {
+        let matcher = PatternMatcher::new(&test_rules()).unwrap();
+        let result = matcher.check_for_patterns("something ERROR happened");
+        assert_eq!(result, Some(("ERROR", "ERROR")));
+    }
+
+    #[test]
+    fn matches_warning_when_no_error() {
+        let matcher = PatternMatcher::new(&test_rules()).unwrap();
+        let result = matcher.check_for_patterns("WARN: low memory");
+        assert_eq!(result, Some(("WARNING", "WARN")));
+    }
+
+    #[test]
+    fn matches_regex_when_no_string_patterns() {
+        let matcher = PatternMatcher::new(&test_rules()).unwrap();
+        let result = matcher.check_for_patterns("disk io error on /dev/sda");
+        assert_eq!(result, Some(("critical", "custom_rule")));
+    }
+
+    #[test]
+    fn error_takes_priority_over_regex() {
+        let matcher = PatternMatcher::new(&test_rules()).unwrap();
+        let result = matcher.check_for_patterns("ERROR disk error");
+        assert_eq!(result, Some(("ERROR", "ERROR")));
+    }
+}

--- a/src/config/rules.rs
+++ b/src/config/rules.rs
@@ -69,8 +69,7 @@ mod tests {
 
     #[test]
     fn deserializes_correlated_rules_toml() {
-        let rules =
-            load_rules_from_file(std::path::Path::new("correlated_rules.toml")).unwrap();
+        let rules = load_rules_from_file(std::path::Path::new("correlated_rules.toml")).unwrap();
         assert_eq!(rules.correlated_rules.len(), 1);
         assert_eq!(
             rules.correlated_rules[0].name,

--- a/src/config/rules.rs
+++ b/src/config/rules.rs
@@ -54,3 +54,27 @@ pub fn load_rules_from_file(path: &std::path::Path) -> anyhow::Result<Rules> {
     let rules: Rules = toml::from_str(&content)?;
     Ok(rules)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_rules_toml() {
+        let rules = load_rules_from_file(std::path::Path::new("rules.toml")).unwrap();
+        assert!(!rules.patterns.error_patterns.is_empty());
+        assert!(!rules.regex_rules.is_empty());
+        assert!(rules.frequency_rules.is_some());
+    }
+
+    #[test]
+    fn deserializes_correlated_rules_toml() {
+        let rules =
+            load_rules_from_file(std::path::Path::new("correlated_rules.toml")).unwrap();
+        assert_eq!(rules.correlated_rules.len(), 1);
+        assert_eq!(
+            rules.correlated_rules[0].name,
+            "Potential Brute-Force Attack"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
+use anyhow::Context;
 use clap::Parser;
 use std::path::PathBuf;
-use anyhow::Context;
 
 mod analyzer;
 mod config;
 mod output;
 mod watcher;
-
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -44,20 +43,24 @@ struct Args {
     severity: Option<String>,
 }
 
+fn min_severity_filter(args: &Args) -> Option<output::Severity> {
+    args.severity.as_ref().map(|s| output::Severity::from(s.as_str()))
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // Handle init-config command
     if args.init_config {
         return create_default_config();
     }
 
-    // Enable verbose logging if requested
     if args.verbose {
         println!("Debug mode enabled");
         println!("Arguments: {:#?}", args);
     }
+
+    let min_severity = min_severity_filter(&args);
 
     let rules_path = if let Some(path) = args.rules {
         path
@@ -82,42 +85,43 @@ async fn main() -> anyhow::Result<()> {
             let (tx, mut rx) = tokio::sync::mpsc::channel(100);
             watcher::file_watcher::watch_file(file_path.clone(), tx).await?;
 
+            let mut scan_state =
+                watcher::log_reader::ScanState::new(&rules.frequency_rules, &rules.correlated_rules);
             let mut current_offset = 0;
             let mut current_line_number = 0;
-            // Initial read of the file
-            let (offset, line_number, mut detections, _correlation_engine) = watcher::log_reader::read_file_from_offset(
+
+            let (offset, line_number, mut detections) = watcher::log_reader::read_file_from_offset(
                 &file_path,
                 &pattern_matcher,
                 &args.output,
                 &rules.frequency_rules,
-                &rules.correlated_rules,
+                &mut scan_state,
                 current_offset,
                 current_line_number,
             )
             .await?;
             current_offset = offset;
             current_line_number = line_number;
+            output::console::display_detections(&mut detections, min_severity);
 
-            output::console::display_detections(&mut detections);
-
-            while (rx.recv().await).is_some() {
-                // File modified, read new content
-                let (offset, line_number, mut new_detections, _updated_correlation_engine) = watcher::log_reader::read_file_from_offset(
-                    &file_path,
-                    &pattern_matcher,
-                    &args.output,
-                    &rules.frequency_rules,
-                    &rules.correlated_rules,
-                    current_offset,
-                    current_line_number,
-                )
-                .await?;
+            while rx.recv().await.is_some() {
+                let (offset, line_number, mut new_detections) =
+                    watcher::log_reader::read_file_from_offset(
+                        &file_path,
+                        &pattern_matcher,
+                        &args.output,
+                        &rules.frequency_rules,
+                        &mut scan_state,
+                        current_offset,
+                        current_line_number,
+                    )
+                    .await?;
                 current_offset = offset;
                 current_line_number = line_number;
-                output::console::display_detections(&mut new_detections);
+                output::console::display_detections(&mut new_detections, min_severity);
             }
         } else {
-            let (mut detections, _correlation_engine) = watcher::log_reader::read_file_line_by_line(
+            let (mut detections, _) = watcher::log_reader::read_file_line_by_line(
                 &file_path,
                 &pattern_matcher,
                 &args.output,
@@ -125,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
                 &rules.correlated_rules,
             )
             .await?;
-            output::console::display_detections(&mut detections);
+            output::console::display_detections(&mut detections, min_severity);
         }
     } else if let Some(dir_path) = args.dir {
         let log_files = watcher::log_reader::find_log_files(&dir_path)?;
@@ -133,84 +137,94 @@ async fn main() -> anyhow::Result<()> {
             println!("No .log files found in directory: {dir_path:?}");
             return Ok(());
         }
-        
+
         if args.verbose {
             println!("Found {} log files in directory: {dir_path:?}", log_files.len());
             for file_path in &log_files {
                 println!("  - {}", file_path.display());
             }
         }
-        
+
         if args.follow {
             println!("Monitoring {} log files in real-time...", log_files.len());
-            // Watch multiple files
             let (tx, mut rx) = tokio::sync::mpsc::channel(100);
-            
-            // Start watching all files
+
             for file_path in &log_files {
                 let tx_clone = tx.clone();
                 let file_path_clone = file_path.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = watcher::file_watcher::watch_file(file_path_clone, tx_clone).await {
+                    if let Err(e) = watcher::file_watcher::watch_file(file_path_clone, tx_clone).await
+                    {
                         eprintln!("Error watching file: {e}");
                     }
                 });
             }
-            
-            // Track offsets for each file and correlation engine state
-            let mut file_states: std::collections::HashMap<std::path::PathBuf, (u64, usize, analyzer::correlation_engine::CorrelationEngine)> = 
-                std::collections::HashMap::new();
 
-            // Initial read of all files
+            let mut file_states: std::collections::HashMap<
+                std::path::PathBuf,
+                (u64, usize, watcher::log_reader::ScanState),
+            > = std::collections::HashMap::new();
+
             for file_path in &log_files {
-                let (offset, line_number, mut detections, correlation_engine) = watcher::log_reader::read_file_from_offset(
-                    file_path,
-                    &pattern_matcher,
-                    &args.output,
+                let mut scan_state = watcher::log_reader::ScanState::new(
                     &rules.frequency_rules,
                     &rules.correlated_rules,
-                    0,
-                    0,
-                ).await?;
-                file_states.insert(file_path.clone(), (offset, line_number, correlation_engine));
-                output::console::display_detections(&mut detections);
-            }
-            
-            // Listen for file changes
-            while let Some(changed_file) = rx.recv().await {
-                if let Some((current_offset, current_line_number, _correlation_engine)) = file_states.remove(&changed_file) {
-                    let (new_offset, new_line_number, mut new_detections, updated_correlation_engine) = watcher::log_reader::read_file_from_offset(
-                        &changed_file,
+                );
+                let (offset, line_number, mut detections) =
+                    watcher::log_reader::read_file_from_offset(
+                        file_path,
                         &pattern_matcher,
                         &args.output,
                         &rules.frequency_rules,
-                        &rules.correlated_rules,
-                        current_offset,
-                        current_line_number,
-                    ).await?;
-                    file_states.insert(changed_file, (new_offset, new_line_number, updated_correlation_engine));
-                    output::console::display_detections(&mut new_detections);
+                        &mut scan_state,
+                        0,
+                        0,
+                    )
+                    .await?;
+                file_states.insert(file_path.clone(), (offset, line_number, scan_state));
+                output::console::display_detections(&mut detections, min_severity);
+            }
+
+            while let Some(changed_file) = rx.recv().await {
+                if let Some((current_offset, current_line_number, mut scan_state)) =
+                    file_states.remove(&changed_file)
+                {
+                    let (new_offset, new_line_number, mut new_detections) =
+                        watcher::log_reader::read_file_from_offset(
+                            &changed_file,
+                            &pattern_matcher,
+                            &args.output,
+                            &rules.frequency_rules,
+                            &mut scan_state,
+                            current_offset,
+                            current_line_number,
+                        )
+                        .await?;
+                    file_states.insert(
+                        changed_file,
+                        (new_offset, new_line_number, scan_state),
+                    );
+                    output::console::display_detections(&mut new_detections, min_severity);
                 }
             }
         } else {
-            // Read all files once
             let mut all_detections = Vec::new();
-            let _correlation_engine = analyzer::correlation_engine::CorrelationEngine::new(rules.correlated_rules.clone());
 
             for file_path in &log_files {
                 if args.verbose {
                     println!("Processing file: {}", file_path.display());
                 }
-                let (mut detections, _updated_correlation_engine) = watcher::log_reader::read_file_line_by_line(
+                let (mut detections, _) = watcher::log_reader::read_file_line_by_line(
                     file_path,
                     &pattern_matcher,
                     &args.output,
                     &rules.frequency_rules,
                     &rules.correlated_rules,
-                ).await?;
+                )
+                .await?;
                 all_detections.append(&mut detections);
             }
-            output::console::display_detections(&mut all_detections);
+            output::console::display_detections(&mut all_detections, min_severity);
         }
     } else if args.file.is_none() && args.dir.is_none() {
         let default_file_path = PathBuf::from("sample.log");
@@ -222,7 +236,7 @@ async fn main() -> anyhow::Result<()> {
             &rules.correlated_rules,
         )
         .await?;
-        output::console::display_detections(&mut detections);
+        output::console::display_detections(&mut detections, min_severity);
     }
 
     Ok(())
@@ -265,6 +279,11 @@ pattern = "authentication failure|Failed password for|Invalid user|Too many auth
 severity = "high"
 
 [[regex_rules]]
+name = "Successful Login"
+pattern = "(?i)successful login|session opened for user"
+severity = "info"
+
+[[regex_rules]]
 name = "network_issue"
 pattern = "Network is unreachable|Name or service not known|No route to host|Connection refused|Interface .* is down"
 severity = "high"
@@ -301,10 +320,10 @@ count = 10
         print!("Overwrite? (y/N): ");
         use std::io::{self, Write};
         io::stdout().flush()?;
-        
+
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
-        
+
         if !input.trim().to_lowercase().starts_with('y') {
             println!("Configuration file creation cancelled.");
             return Ok(());
@@ -314,6 +333,6 @@ count = 10
     std::fs::write(config_path, config_content)?;
     println!("Default configuration file created: {}", config_path);
     println!("You can now edit this file to customize your log analysis rules.");
-    
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,9 @@ struct Args {
 }
 
 fn min_severity_filter(args: &Args) -> Option<output::Severity> {
-    args.severity.as_ref().map(|s| output::Severity::from(s.as_str()))
+    args.severity
+        .as_ref()
+        .map(|s| output::Severity::from(s.as_str()))
 }
 
 #[tokio::main]
@@ -85,8 +87,10 @@ async fn main() -> anyhow::Result<()> {
             let (tx, mut rx) = tokio::sync::mpsc::channel(100);
             watcher::file_watcher::watch_file(file_path.clone(), tx).await?;
 
-            let mut scan_state =
-                watcher::log_reader::ScanState::new(&rules.frequency_rules, &rules.correlated_rules);
+            let mut scan_state = watcher::log_reader::ScanState::new(
+                &rules.frequency_rules,
+                &rules.correlated_rules,
+            );
             let mut current_offset = 0;
             let mut current_line_number = 0;
 
@@ -139,7 +143,10 @@ async fn main() -> anyhow::Result<()> {
         }
 
         if args.verbose {
-            println!("Found {} log files in directory: {dir_path:?}", log_files.len());
+            println!(
+                "Found {} log files in directory: {dir_path:?}",
+                log_files.len()
+            );
             for file_path in &log_files {
                 println!("  - {}", file_path.display());
             }
@@ -153,7 +160,8 @@ async fn main() -> anyhow::Result<()> {
                 let tx_clone = tx.clone();
                 let file_path_clone = file_path.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = watcher::file_watcher::watch_file(file_path_clone, tx_clone).await
+                    if let Err(e) =
+                        watcher::file_watcher::watch_file(file_path_clone, tx_clone).await
                     {
                         eprintln!("Error watching file: {e}");
                     }
@@ -200,10 +208,7 @@ async fn main() -> anyhow::Result<()> {
                             current_line_number,
                         )
                         .await?;
-                    file_states.insert(
-                        changed_file,
-                        (new_offset, new_line_number, scan_state),
-                    );
+                    file_states.insert(changed_file, (new_offset, new_line_number, scan_state));
                     output::console::display_detections(&mut new_detections, min_severity);
                 }
             }

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -2,7 +2,11 @@ use colored::Colorize;
 use std::path::Path;
 use super::{Detection, Severity};
 
-pub fn display_detections(detections: &mut Vec<Detection>) {
+pub fn display_detections(detections: &mut Vec<Detection>, min_severity: Option<Severity>) {
+    if let Some(minimum) = min_severity {
+        detections.retain(|d| d.severity.meets_minimum(&minimum));
+    }
+
     detections.sort_by(|a, b| a.line_number.cmp(&b.line_number));
 
     for detection in detections {

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -1,6 +1,6 @@
+use super::{Detection, Severity};
 use colored::Colorize;
 use std::path::Path;
-use super::{Detection, Severity};
 
 pub fn display_detections(detections: &mut Vec<Detection>, min_severity: Option<Severity>) {
     if let Some(minimum) = min_severity {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -11,7 +11,7 @@ pub struct Detection {
     pub matched_line: String,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum Severity {
     Critical,
     High,
@@ -29,5 +29,34 @@ impl From<&str> for Severity {
             "error" | "fatal" | "exception" => Severity::Error,
             _ => Severity::Info,
         }
+    }
+}
+
+impl Severity {
+    pub fn rank(&self) -> u8 {
+        match self {
+            Severity::Critical => 5,
+            Severity::High => 4,
+            Severity::Error => 3,
+            Severity::Warning => 2,
+            Severity::Info => 1,
+        }
+    }
+
+    pub fn meets_minimum(&self, minimum: &Severity) -> bool {
+        self.rank() >= minimum.rank()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_meets_minimum() {
+        assert!(Severity::Critical.meets_minimum(&Severity::High));
+        assert!(Severity::High.meets_minimum(&Severity::High));
+        assert!(!Severity::Warning.meets_minimum(&Severity::High));
+        assert!(!Severity::Info.meets_minimum(&Severity::Error));
     }
 }

--- a/src/watcher/log_reader.rs
+++ b/src/watcher/log_reader.rs
@@ -15,12 +15,12 @@ pub struct ScanState {
 }
 
 impl ScanState {
-    pub fn new(frequency_rules: &Option<FrequencyRules>, correlated_rules: &[CorrelatedRule]) -> Self {
+    pub fn new(
+        frequency_rules: &Option<FrequencyRules>,
+        correlated_rules: &[CorrelatedRule],
+    ) -> Self {
         let frequency_tracker = frequency_rules.as_ref().map(|rules| {
-            FrequencyTracker::new(
-                rules.max_same_errors_per_minute,
-                rules.time_window_seconds,
-            )
+            FrequencyTracker::new(rules.max_same_errors_per_minute, rules.time_window_seconds)
         });
         ScanState {
             frequency_tracker,

--- a/src/watcher/log_reader.rs
+++ b/src/watcher/log_reader.rs
@@ -8,24 +8,46 @@ use std::path::{Path, PathBuf};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, SeekFrom};
 
+/// Persistent analyzer state for follow mode and multi-chunk reads.
+pub struct ScanState {
+    pub frequency_tracker: Option<FrequencyTracker>,
+    pub correlation_engine: CorrelationEngine,
+}
+
+impl ScanState {
+    pub fn new(frequency_rules: &Option<FrequencyRules>, correlated_rules: &[CorrelatedRule]) -> Self {
+        let frequency_tracker = frequency_rules.as_ref().map(|rules| {
+            FrequencyTracker::new(
+                rules.max_same_errors_per_minute,
+                rules.time_window_seconds,
+            )
+        });
+        ScanState {
+            frequency_tracker,
+            correlation_engine: CorrelationEngine::new(correlated_rules.to_vec()),
+        }
+    }
+}
+
 pub async fn read_file_line_by_line(
     file_path: &Path,
     pattern_matcher: &PatternMatcher,
     output_format: &str,
     frequency_rules: &Option<FrequencyRules>,
     correlated_rules: &[CorrelatedRule],
-) -> anyhow::Result<(Vec<Detection>, CorrelationEngine)> {
-    let (_offset, _line_number, detections, correlation_engine) = read_file_from_offset(
+) -> anyhow::Result<(Vec<Detection>, ScanState)> {
+    let mut scan_state = ScanState::new(frequency_rules, correlated_rules);
+    let (_offset, _line_number, detections) = read_file_from_offset(
         file_path,
         pattern_matcher,
         output_format,
         frequency_rules,
-        correlated_rules,
+        &mut scan_state,
         0,
         0,
     )
     .await?;
-    Ok((detections, correlation_engine))
+    Ok((detections, scan_state))
 }
 
 pub async fn read_file_from_offset(
@@ -33,10 +55,10 @@ pub async fn read_file_from_offset(
     pattern_matcher: &PatternMatcher,
     output_format: &str,
     frequency_rules: &Option<FrequencyRules>,
-    correlated_rules: &[CorrelatedRule],
+    scan_state: &mut ScanState,
     mut offset: u64,
     mut current_line_number: usize,
-) -> anyhow::Result<(u64, usize, Vec<Detection>, CorrelationEngine)> {
+) -> anyhow::Result<(u64, usize, Vec<Detection>)> {
     let mut file = File::open(file_path).await?;
     file.seek(SeekFrom::Start(offset)).await?;
     let reader = BufReader::new(file);
@@ -53,7 +75,6 @@ pub async fn read_file_from_offset(
         );
     }
 
-    // Only print this message once when the file is first opened
     if offset == 0 && (output_format == "json" || output_format == "both") {
         println!(
             "Writing JSON output to: {}",
@@ -63,18 +84,11 @@ pub async fn read_file_from_offset(
 
     println!("Reading file: {}", file_path.display());
 
-    let mut frequency_tracker = frequency_rules.as_ref().map(|rules| FrequencyTracker::new(
-            rules.max_same_errors_per_minute,
-            rules.time_window_seconds,
-        ));
-
-    let mut correlation_engine = CorrelationEngine::new(correlated_rules.to_vec());
-
     let mut detections: Vec<Detection> = Vec::new();
 
     while let Some(line) = lines.next_line().await? {
         current_line_number += 1;
-        offset += (line.len() + 1) as u64; // +1 for newline character
+        offset += (line.len() + 1) as u64;
         if let Some((severity, pattern_name)) = pattern_matcher.check_for_patterns(&line) {
             let detection = create_detection(
                 severity,
@@ -104,8 +118,7 @@ pub async fn read_file_from_offset(
                 )?;
             }
 
-            // Frequency tracking
-            if let Some(tracker) = &mut frequency_tracker {
+            if let Some(tracker) = &mut scan_state.frequency_tracker {
                 if let Some(count) = tracker.track_event(pattern_name) {
                     if output_format == "console" || output_format == "both" {
                         detections.push(create_frequency_detection(
@@ -138,8 +151,9 @@ pub async fn read_file_from_offset(
                 }
             }
 
-            // Correlation tracking
-            if let Some(correlated_detection) = correlation_engine.add_detection(detection) {
+            if let Some(correlated_detection) =
+                scan_state.correlation_engine.add_detection(detection)
+            {
                 if output_format == "console" || output_format == "both" {
                     detections.push(correlated_detection);
                 }
@@ -147,25 +161,31 @@ pub async fn read_file_from_offset(
         }
     }
 
-    Ok((offset, current_line_number, detections, correlation_engine))
+    Ok((offset, current_line_number, detections))
 }
 
 /// Find all .log files in a directory
 pub fn find_log_files(dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
     let mut log_files = Vec::new();
-    
+
     if !dir_path.exists() {
-        return Err(anyhow::anyhow!("Directory does not exist: {}", dir_path.display()));
+        return Err(anyhow::anyhow!(
+            "Directory does not exist: {}",
+            dir_path.display()
+        ));
     }
-    
+
     if !dir_path.is_dir() {
-        return Err(anyhow::anyhow!("Path is not a directory: {}", dir_path.display()));
+        return Err(anyhow::anyhow!(
+            "Path is not a directory: {}",
+            dir_path.display()
+        ));
     }
-    
+
     for entry in std::fs::read_dir(dir_path)? {
         let entry = entry?;
         let path = entry.path();
-        
+
         if path.is_file() {
             if let Some(extension) = path.extension() {
                 if extension == "log" {
@@ -174,8 +194,7 @@ pub fn find_log_files(dir_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
             }
         }
     }
-    
-    // Sort files for consistent ordering
+
     log_files.sort();
     Ok(log_files)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the RustHound skill-based development plan: project Cursor skills plus critical fixes from the codebase analysis.

## Changes

### Cursor skills (`.cursor/skills/`)
- **rusthound-architecture** — module map, follow-mode state rules, pattern priority
- **rusthound-rules-toml** — authoritative TOML schema
- **rusthound-dev-workflow** — build, test, clippy, smoke commands

### Build and CLI
- `edition = "2021"` for stable Rust 1.83 compatibility
- `[[bin]] name = "rusthound"` aligned with README and `setup.sh`
- `--severity` filter: minimum severity via `Severity::rank()` / `meets_minimum()`

### Follow mode state
- New `ScanState` holds `FrequencyTracker` and `CorrelationEngine` across incremental reads
- Single-file and multi-file `--follow` reuse state instead of resetting each chunk

### Tests
- 12 unit tests: pattern matcher, frequency tracker, correlation engine, rules deserialize, severity filter

### Documentation
- README updated with real `rules.toml` schema, Rust 1.83+, and `rusthound` CLI examples
- `init-config` includes `Successful Login` regex for correlation example

## Verification

```bash
cargo test
cargo clippy -- -D warnings
cargo build --release
./target/release/rusthound -f sample.log -s high
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e795a81-d5db-431b-8095-220a1040f0c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e795a81-d5db-431b-8095-220a1040f0c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

